### PR TITLE
精简 PR 的重复 CI 执行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       bvid:
@@ -20,7 +24,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## 变更内容

- PR 仅由 `pull_request` 事件运行 CI，避免同一提交同时触发 `push` 与 `pull_request` 两套矩阵。
- `push` 仅保留 `main`，继续验证最终合并提交和直接推送。
- concurrency 改为以 workflow 与 PR 编号或 ref 分组，使同一 PR 的旧执行可以取消。

## 原因

当前 workflow 对所有分支同时监听 `push` 和 `pull_request`。同仓库 PR 每次更新会对同一提交运行两套 macOS 15/26 App Gate，而且两种事件的 `github.ref` 不同，原有 concurrency 无法去重。

## 影响

PR 更新由四个主要构建 job 收敛为 macOS 15、macOS 26 各一个；最低系统与当前工具链覆盖不变。合并到 `main` 后仍会再验证准确的合并提交，手动真实播放验证也保持不变。

## 验证

- `sh Scripts/run-quality-gates.sh static`
- `git diff --check`