### PR TITLE
修复弹幕会话测试等待竞态

### DIFF
--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSessionTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSessionTests.swift
@@ -52,7 +52,13 @@ struct DanmakuSessionTests {
         try await Task.sleep(for: .milliseconds(5))
         session.start(for: second)
         timeline.publish(snapshot(identity: second, position: 0, generation: 2))
-        try await Task.sleep(for: .milliseconds(100))
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while session.state != .ready(second),
+              clock.now < deadline
+        {
+            try await Task.sleep(for: .milliseconds(5))
+        }
 
         #expect(session.state == .ready(second))
         session.stop()


### PR DESCRIPTION
## 变更内容

将 `DanmakuSessionTests.replacingIdentityRejectsLateOldSegmentsAndStopReturnsIdle` 的固定 100ms 睡眠改为有 1 秒上限的目标状态等待。

## 根因

PR #5 的 CI 配置本身已按预期去重。失败来自 macOS 26 上既有测试竞态：第二代弹幕请求仍处于 `.loading` 时，固定等待已经结束，测试随即错误断言必须为 `.ready`。macOS 15 同一 run 完整通过。

该测试仍严格要求最终进入第二代 `.ready`，随后 `stop()` 必须同步回到 `.idle`；没有修改生产代码，也没有放宽失败条件。

## 验证

- 目标测试连续运行 20 次通过
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer sh Scripts/run-quality-gates.sh package`
  - 177 项 Package 测试通过
  - static Gate 通过
- `git diff --check`