### PR TITLE
稳定弹幕预取并发测试

### DIFF
--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSessionTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSessionTests.swift
@@ -10,7 +10,7 @@ struct DanmakuSessionTests {
     @Test
     func sessionPrefetchesCurrentAndNextWithBoundedConcurrency() async throws {
         let identity = PlaybackItemIdentity(bvid: "BV1DanmakuFixture", cid: 1)
-        let repository = SessionRecordingRepository(delay: .milliseconds(20))
+        let repository = ControlledPrefetchRepository()
         let timeline = SessionTimeline()
         let session = DanmakuSession(
             useCase: DanmakuSegmentUseCase(repository: repository),
@@ -21,15 +21,22 @@ struct DanmakuSessionTests {
         timeline.publish(snapshot(identity: identity, position: 0, generation: 1))
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: .seconds(1))
-        while await repository.requestedIndices().count < 2,
-              clock.now < deadline
-        {
-            try await Task.sleep(for: .milliseconds(5))
+        do {
+            while await repository.requestedIndices().count < 2,
+                  clock.now < deadline
+            {
+                try await Task.sleep(for: .milliseconds(5))
+            }
+        } catch {
+            await repository.releaseRequests()
+            await session.waitForLoads()
+            throw error
         }
-        await session.waitForLoads()
 
         #expect(await repository.requestedIndices().sorted() == [1, 2])
         #expect(await repository.maximumActiveRequests() == 2)
+        await repository.releaseRequests()
+        await session.waitForLoads()
         #expect(session.state == .ready(identity))
     }
 
@@ -250,4 +257,43 @@ private actor SessionRecordingRepository: DanmakuSegmentRepository {
 
     func requestedIndices() -> [Int] { requested }
     func maximumActiveRequests() -> Int { maximumActive }
+}
+
+private actor ControlledPrefetchRepository: DanmakuSegmentRepository {
+    private var requested: [Int] = []
+    private var active = 0
+    private var maximumActive = 0
+    private var requestsReleased = false
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func segment(
+        index: Int,
+        for identity: PlaybackItemIdentity
+    ) async throws -> DanmakuSegment {
+        requested.append(index)
+        active += 1
+        maximumActive = max(maximumActive, active)
+
+        await withCheckedContinuation { continuation in
+            if requestsReleased {
+                continuation.resume()
+            } else {
+                releaseWaiters.append(continuation)
+            }
+        }
+
+        active -= 1
+        return DanmakuSegment(index: index, events: [])
+    }
+
+    func requestedIndices() -> [Int] { requested }
+
+    func maximumActiveRequests() -> Int { maximumActive }
+
+    func releaseRequests() {
+        requestsReleased = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll(keepingCapacity: false)
+        waiters.forEach { $0.resume() }
+    }
 }


### PR DESCRIPTION
## Goal

消除弹幕当前段与下一段预取并发测试对 20 ms 调度窗口的依赖，使同一源码在 PR 与合并后 CI 中得到确定一致的结果。

## Context / Constraints

- 合并 commit `5edd585` 的 macOS 15 CI 仅失败于 `sessionPrefetchesCurrentAndNextWithBoundedConcurrency()` 的 `maximumActiveRequests() == 2`。
- PR head 与 squash merge commit 的 Git tree 相同，且两次均使用 macOS 15.7.7、Xcode 16.4、Swift 6.1.2；merge run 的 macOS 26 job 通过。
- 原测试使用固定 20 ms repository delay 制造请求重叠，只保证两个请求最终发生，不能保证它们同时 active。
- 只修改私有测试代码；不改变 `DanmakuSession`、公开 API、生产并发上限或 App 行为。

## Done when

- 当前段与下一段请求在断言前均由测试仓库明确保持 active。
- 继续验证请求索引为 `[1, 2]`、最大并发为 2、释放后 session 进入 ready。
- 测试取消时释放所有 continuation 并等待加载 Task 收束。
- 本地定向重复与完整 App Gate 通过；远端 macOS 15/26 矩阵通过。

## 决策价值与复杂度预算

- 本变更支持的 1–2 个决策：确认 main 的失败是测试同步抖动；以确定性同步替代时间窗口。
- 会改变下一步的结果 / 不会改变决策的非目标：若确定性测试仍失败则检查生产预取；不修改生产调度、扩大并发矩阵或重跑到绿色。
- 候选理由 / 更便宜的淘汰方式：单个私有 latch helper 是保留既有断言的最小方案；增加 sleep 不能消除不确定性。
- 候选、指标、矩阵与实施组件预算：一份测试文件、一个私有 actor helper、50 次定向重复、本地 App Gate、远端 macOS 15/26。
- 是否超预算；若是，用户确认与受保护决策：未超预算。

## 风险与关键路径

- 风险等级：红区维护切片（并发测试契约；不改变生产语义）
- 风险理由：涉及并发观测与 continuation 清理，但改动仅位于测试 target。
- 人工追踪的关键路径：两个 segment 请求进入 actor → 同时保持 active → 断言 → 释放 → session ready。
- 回滚方式：回滚本提交即可；无数据、schema 或生产资源迁移。

## 验证

- [x] `static`（由 App Gate 包含）
- [x] `package`（由 App Gate 包含）
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer BILIKIT_COMPACT_LOGS=1 sh Scripts/run-quality-gates.sh app`
- [x] 修复并整改后定向测试连续 50/50 通过

未验证或跳过项：

- PR 的 GitHub Actions macOS 15/26 矩阵尚待本 PR 运行。
- 无真实播放探针：本 PR 不修改生产播放、弹幕调度或 renderer。

## 独立审查

- 价值与简化审查：保留单一测试目的，拒绝增加 sleep、通用 harness、额外矩阵或生产改动。
- 可理解性审查：用户确认以独立 hotfix worktree 完成测试同步修复；未扩张到 M4.6 文档或字幕工作。
- 技术正确性审查：独立 `red_reviewer` 首轮发现取消时 continuation 可能未释放；整改为异常路径先释放、等待加载任务收束、再重新抛出。复核结论为“未发现阻断”。
- 是否触发升级，原因：触发；原因是并发测试、continuation 所有权与重要 CI Gate。
- reviewer 建议是否导致预算超限；如何处理：未超限，仅增加最小异常清理。
- 已知剩余边界：本机为 Xcode 26.6；原故障环境 macOS 15 / Xcode 16.4 由远端矩阵验证。

红区附加记录：

- 决策摘要与最多三个授权问题：以测试专用可控同步替代 20 ms 时序窗口，不修改生产代码；用户确认后实施与交付。
- 用户实际入站回复位置及被确认的决策 revision：当前 Codex 任务中用户两次回复“可以”，确认 `CI-danmaku-prefetch-latch-r1` 的本地实现及随后提交、推送、开 PR。
- 重大误解及纠正；次要遗漏/技术细节不阻断：无。
- 技术计划变化是否触发重新确认：无。
- 技术审查后是否发生使确认失效的语义变更：无；仅补齐取消清理。
- 任务专用真实证据或明确未验证边界：定向测试 50/50、本地 App Gate、独立红区复核；远端矩阵待运行。
