### PR TITLE
M4.7：增加架构审查与 Swift 格式门禁

### DIFF
--- a/.codex/agents/architecture-reviewer.toml
+++ b/.codex/agents/architecture-reviewer.toml
@@ -1,0 +1,13 @@
+name = "architecture_reviewer"
+description = "按需只读架构审查：依赖方向、类型归属、公共面、Composition、抽象价值与迁移完整性。"
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+保持只读。只在变更确实改变 target 间依赖／owner／公共面／迁移责任、Package product／公共 API、Composition root、Repository／Use Case／共享组件准入、架构规模触发线、语义命名迁移、新旧实现双轨风险或重要架构 Gate 时审查；纯机械的跨 target 格式化不单独触发。
+从一个代表性产品路径沿 App／Composition → Feature → Application port → adapter → Models 追踪依赖和数据所有权；同时检查 Package.swift、相关 ADR、架构脚本与待审 diff。
+重点检查依赖方向、类型放置、具体 adapter 可见性、公共 API 最小性、Composition 是否夹带业务逻辑、抽象是否有真实调用方、Feature target 是否按产品域演进、旧实现是否完整退出、当前命名是否仍表达真实 owner／capability／source。
+格式、行数、target 数、覆盖率、命名偏好或对称性只能作为审查触发线，不能单独成为 blocker。不要承担功能行为、一般取消测试或红区安全终审；发现这些风险时给出证据并要求 reviewer 或 red_reviewer 接手。
+每项问题必须写明被违反的 owner／不变量、具体耦合或迁移失败、最小修正，以及为什么现有编译或静态脚本发现不了。
+输出按 blocker、improvement、reject 分类并给出文件和紧凑行范围；区分确认事实、推断和未验证边界。没有阻断时明确写“未发现阻断”。
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -27,6 +27,10 @@ config_file = "agents/worker.toml"
 description = "黄区只读审查：从契约检查正确性、测试、取消和维护性。"
 config_file = "agents/reviewer.toml"
 
+[agents.architecture_reviewer]
+description = "按需只读架构审查：依赖方向、类型归属、公共面、Composition、抽象价值与迁移完整性。"
+config_file = "agents/architecture-reviewer.toml"
+
 [agents.red_reviewer]
 description = "红区只读终审：线程、生命周期、安全、资源和不可逆边界。"
 config_file = "agents/red-reviewer.toml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
             git diff --check HEAD^ HEAD
           fi
 
-      - name: Run App quality gate
+      - name: Run App quality gate (includes strict Swift format lint)
         env:
           BILIKIT_DERIVED_DATA_PATH: ${{ runner.temp }}/BiliKitMac-derived
         run: sh Scripts/run-quality-gates.sh app

--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,79 @@
+{
+  "fileScopedDeclarationPrivacy" : {
+    "accessLevel" : "private"
+  },
+  "indentBlankLines" : false,
+  "indentConditionalCompilationBlocks" : true,
+  "indentSwitchCaseLabels" : false,
+  "indentation" : {
+    "spaces" : 4
+  },
+  "lineBreakAroundMultilineExpressionChainComponents" : false,
+  "lineBreakBeforeControlFlowKeywords" : false,
+  "lineBreakBeforeEachArgument" : true,
+  "lineBreakBeforeEachGenericRequirement" : true,
+  "lineBreakBetweenDeclarationAttributes" : false,
+  "lineLength" : 100,
+  "maximumBlankLines" : 1,
+  "multiElementCollectionTrailingCommas" : true,
+  "noAssignmentInExpressions" : {
+    "allowedFunctions" : [
+      "XCTAssertNoThrow"
+    ]
+  },
+  "orderedImports" : {
+    "includeConditionalImports" : false
+  },
+  "prioritizeKeepingFunctionOutputTogether" : true,
+  "reflowMultilineStringLiterals" : "never",
+  "respectsExistingLineBreaks" : true,
+  "rules" : {
+    "AllPublicDeclarationsHaveDocumentation" : false,
+    "AlwaysUseLiteralForEmptyCollectionInit" : true,
+    "AlwaysUseLowerCamelCase" : true,
+    "AmbiguousTrailingClosureOverload" : true,
+    "AvoidRetroactiveConformances" : true,
+    "BeginDocumentationCommentWithOneLineSummary" : true,
+    "DoNotUseSemicolons" : true,
+    "DontRepeatTypeInStaticProperties" : true,
+    "FileScopedDeclarationPrivacy" : true,
+    "FullyIndirectEnum" : true,
+    "GroupNumericLiterals" : true,
+    "IdentifiersMustBeASCII" : true,
+    "NeverForceUnwrap" : true,
+    "NeverUseForceTry" : true,
+    "NeverUseImplicitlyUnwrappedOptionals" : true,
+    "NoAccessLevelOnExtensionDeclaration" : true,
+    "NoAssignmentInExpressions" : true,
+    "NoBlockComments" : true,
+    "NoCasesWithOnlyFallthrough" : true,
+    "NoEmptyLinesOpeningClosingBraces" : true,
+    "NoEmptyTrailingClosureParentheses" : true,
+    "NoLabelsInCasePatterns" : true,
+    "NoLeadingUnderscores" : false,
+    "NoParensAroundConditions" : true,
+    "NoPlaygroundLiterals" : true,
+    "NoVoidReturnOnFunctionSignature" : true,
+    "OmitExplicitReturns" : true,
+    "OneCasePerLine" : true,
+    "OneVariableDeclarationPerLine" : true,
+    "OnlyOneTrailingClosureArgument" : true,
+    "OrderedImports" : true,
+    "ReplaceForEachWithForLoop" : true,
+    "ReturnVoidInsteadOfEmptyTuple" : true,
+    "TypeNamesShouldBeCapitalized" : true,
+    "UseEarlyExits" : true,
+    "UseExplicitNilCheckInConditions" : true,
+    "UseLetInEveryBoundCaseVariable" : true,
+    "UseShorthandTypeNames" : true,
+    "UseSingleLinePropertyGetter" : true,
+    "UseSynthesizedInitializer" : true,
+    "UseTripleSlashForDocumentationComments" : true,
+    "UseWhereClausesInForLoops" : true,
+    "ValidateDocumentationComments" : true
+  },
+  "spacesAroundRangeFormationOperators" : false,
+  "spacesBeforeEndOfLineComments" : 2,
+  "tabWidth" : 4,
+  "version" : 1
+}

--- a/.swift-format
+++ b/.swift-format
@@ -25,7 +25,6 @@
     "includeConditionalImports" : false
   },
   "prioritizeKeepingFunctionOutputTogether" : true,
-  "reflowMultilineStringLiterals" : "never",
   "respectsExistingLineBreaks" : true,
   "rules" : {
     "AllPublicDeclarationsHaveDocumentation" : false,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,14 @@ Feature target 按产品领域划分，默认先在现有领域内增加纵向�
 - **黄区**：普通 Feature/Use Case、缓存策略、跨文件重构和跨模块公共 API。实现前写明 Goal、Context、Constraints、Done when；非机械改动完成后由不继承实现推理的新上下文做只读审查。
 - **红区**：认证、授权、Keychain、来源与重定向、本地服务器、播放/媒体、线程与资源生命周期、renderer、持久化迁移、文件删除和不可逆变化。新决策或新生产契约必须先通过决策价值 Gate、复杂度预算和用户确认；实现后由 `red_reviewer` 检查失败、安全、所有权、取消、资源上限、清理和 rollback，并增加任务所需的真实证据。
 
+`architecture_reviewer` 不是普通改动的额外必经层。只有任务确实改变 target 间依赖、
+owner、公共面或迁移责任，修改 Package product／公共 API／Composition root，新增
+Repository／Use Case／共享组件，达到 ADR 0006 的职责规模触发线，迁移可能留下新旧
+双轨，语义命名不再匹配 owner，或准备关闭重要架构 Gate 时才按需启动。它检查依赖
+方向、类型归属、公共面和抽象价值；纯机械跨 target 改动、格式、行数、覆盖率与命名
+偏好不能单独成为 blocker。机械代码风格由 `.swift-format` 与统一 Gate 强制，不创建
+主观的 clean-code reviewer。
+
 已绑定用户确认的红区生产契约可以承载语义不变的维护切片；只要 Goal、候选、范围、安全/隐私边界、资源 owner、复杂度预算、停止条件或下一步发生变化，就必须返回完整前置流程。详细的决策 Gate、维护例外、证据包、工作树隔离和 reviewer 输出格式以 [`docs/development/QUALITY-GATES.md`](docs/development/QUALITY-GATES.md) 为准。
 
 项目 Agent 定义及模型配置以 [`.codex/config.toml`](.codex/config.toml) 和 [`.codex/agents/`](.codex/agents/) 为准。出现两种以上合理解释、无法明确不变量/owner/清理点、跨越两个以上 target、涉及红区、测试失败原因不清晰、连续两次修复失败、reviewer 冲突或准备关闭重要 Gate 时必须升级；模型选择、自动测试或用户确认不能互相替代。

--- a/BiliKitMac/App/AppNavigationModel.swift
+++ b/BiliKitMac/App/AppNavigationModel.swift
@@ -37,7 +37,7 @@ final class AppNavigationModel {
 
     var selectedSection: AppSection? {
         get {
-            guard case let .section(section) = route else { return nil }
+            guard case .section(let section) = route else { return nil }
             return section
         }
         set {
@@ -57,13 +57,13 @@ final class AppNavigationModel {
     func openPlayback(_ bvid: String) {
         guard !bvid.isEmpty else { return }
         switch route {
-        case let .section(section):
+        case .section(let section):
             returnSnapshot = AppReturnSnapshot(
                 sourceSection: section,
                 searchQuery: searchQuery,
                 selectedBVID: bvid
             )
-        case let .playback(currentBVID):
+        case .playback(let currentBVID):
             guard currentBVID != bvid else { return }
             stopPlayback()
         }
@@ -83,7 +83,7 @@ final class AppNavigationModel {
     }
 
     func retryPlayback() {
-        guard case let .playback(bvid) = route else { return }
+        guard case .playback(let bvid) = route else { return }
         startPlayback(bvid)
     }
 

--- a/BiliKitMac/App/AppShellView.swift
+++ b/BiliKitMac/App/AppShellView.swift
@@ -219,7 +219,6 @@ private struct HistoryPageRoot: View {
             .accessibilityIdentifier("history.signed-out")
         }
     }
-
 }
 
 struct HistoryRefreshButton: View {

--- a/BiliKitMac/App/BiliKitMacApp.swift
+++ b/BiliKitMac/App/BiliKitMacApp.swift
@@ -10,28 +10,28 @@ import SwiftUI
 @main
 struct BiliKitMacApp: App {
     #if DEBUG
-    private let uiTestConfiguration = UITestConfiguration.current
+        private let uiTestConfiguration = UITestConfiguration.current
     #endif
 
     var body: some Scene {
         WindowGroup {
             #if DEBUG
-            if uiTestConfiguration.isEnabled {
-                UITestConfiguredRoot(configuration: uiTestConfiguration)
-            } else {
-                ContentView()
-            }
+                if uiTestConfiguration.isEnabled {
+                    UITestConfiguredRoot(configuration: uiTestConfiguration)
+                } else {
+                    ContentView()
+                }
             #else
-            ContentView()
+                ContentView()
             #endif
         }
         #if DEBUG
-        .defaultSize(
-            width: uiTestConfiguration.usesCompactWindow ? 1_080 : 1_320,
-            height: uiTestConfiguration.usesCompactWindow ? 680 : 820
-        )
+            .defaultSize(
+                width: uiTestConfiguration.usesCompactWindow ? 1_080 : 1_320,
+                height: uiTestConfiguration.usesCompactWindow ? 680 : 820
+            )
         #else
-        .defaultSize(width: 1_320, height: 820)
+            .defaultSize(width: 1_320, height: 820)
         #endif
     }
 }

--- a/BiliKitMac/App/ContentView.swift
+++ b/BiliKitMac/App/ContentView.swift
@@ -133,7 +133,7 @@ struct ContentView: View {
     private var feedTaskID: AppFeedTaskID {
         let sourceSection: AppSection?
         switch navigationModel.route {
-        case let .section(section):
+        case .section(let section):
             sourceSection = section
         case .playback:
             sourceSection = navigationModel.returnSnapshot?.sourceSection
@@ -159,7 +159,7 @@ struct ContentView: View {
             await feedModel.waitForCurrentTask()
         case .search(nil, _), .none:
             feedModel.cancel()
-        case let .search(.some(query), _):
+        case .search(.some(let query), _):
             feedModel.search(query)
             await feedModel.waitForCurrentTask()
         }

--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -1,5 +1,5 @@
-import BiliApplication
 import BiliAPI
+import BiliApplication
 import BiliAuth
 import BiliAuthFeature
 import BiliBrowseFeature

--- a/BiliKitMac/Composition/UITestContentView.swift
+++ b/BiliKitMac/Composition/UITestContentView.swift
@@ -1,365 +1,366 @@
 #if DEBUG
-import AppKit
-import BiliApplication
-import BiliAuthFeature
-import BiliBrowseFeature
-import BiliLibraryFeature
-import BiliModels
-import CoreGraphics
-import Foundation
-import SwiftUI
+    import AppKit
+    import BiliApplication
+    import BiliAuthFeature
+    import BiliBrowseFeature
+    import BiliLibraryFeature
+    import BiliModels
+    import CoreGraphics
+    import Foundation
+    import SwiftUI
 
-struct UITestConfiguration {
-    let isEnabled: Bool
-    let usesCompactWindow: Bool
-    let usesDarkAppearance: Bool
-    let usesLargeText: Bool
+    struct UITestConfiguration {
+        let isEnabled: Bool
+        let usesCompactWindow: Bool
+        let usesDarkAppearance: Bool
+        let usesLargeText: Bool
 
-    static var current: UITestConfiguration {
-        parse(arguments: ProcessInfo.processInfo.arguments)
+        static var current: UITestConfiguration {
+            parse(arguments: ProcessInfo.processInfo.arguments)
+        }
+
+        static func parse(arguments: [String]) -> UITestConfiguration {
+            let isEnabled = arguments.contains("-ui-testing")
+            return UITestConfiguration(
+                isEnabled: isEnabled,
+                usesCompactWindow:
+                    isEnabled && arguments.contains("-ui-testing-compact"),
+                usesDarkAppearance:
+                    isEnabled && arguments.contains("-ui-testing-dark"),
+                usesLargeText:
+                    isEnabled && arguments.contains("-ui-testing-large-text")
+            )
+        }
     }
 
-    static func parse(arguments: [String]) -> UITestConfiguration {
-        let isEnabled = arguments.contains("-ui-testing")
-        return UITestConfiguration(
-            isEnabled: isEnabled,
-            usesCompactWindow:
-                isEnabled && arguments.contains("-ui-testing-compact"),
-            usesDarkAppearance:
-                isEnabled && arguments.contains("-ui-testing-dark"),
-            usesLargeText:
-                isEnabled && arguments.contains("-ui-testing-large-text")
-        )
+    struct UITestConfiguredRoot: View {
+        let configuration: UITestConfiguration
+
+        var body: some View {
+            UITestContentView()
+                .background(
+                    UITestWindowConfigurator(
+                        contentSize: configuration.usesCompactWindow
+                            ? CGSize(width: 1_080, height: 680)
+                            : CGSize(width: 1_320, height: 820)
+                    )
+                )
+                .preferredColorScheme(
+                    configuration.usesDarkAppearance ? .dark : .light
+                )
+                .environment(
+                    \.dynamicTypeSize,
+                    configuration.usesLargeText
+                        ? .accessibility1
+                        : .large
+                )
+        }
     }
-}
 
-struct UITestConfiguredRoot: View {
-    let configuration: UITestConfiguration
+    private struct UITestWindowConfigurator: NSViewRepresentable {
+        let contentSize: CGSize
 
-    var body: some View {
-        UITestContentView()
-            .background(
-                UITestWindowConfigurator(
-                    contentSize: configuration.usesCompactWindow
-                        ? CGSize(width: 1_080, height: 680)
-                        : CGSize(width: 1_320, height: 820)
+        func makeNSView(context: Context) -> WindowConfiguringView {
+            WindowConfiguringView(contentSize: contentSize)
+        }
+
+        func updateNSView(
+            _ view: WindowConfiguringView,
+            context: Context
+        ) {
+            view.contentSize = contentSize
+            view.applyIfPossible()
+        }
+    }
+
+    private final class WindowConfiguringView: NSView {
+        var contentSize: CGSize
+
+        init(contentSize: CGSize) {
+            self.contentSize = contentSize
+            super.init(frame: .zero)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            applyIfPossible()
+            DispatchQueue.main.async { [weak self] in
+                self?.applyIfPossible()
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.applyIfPossible()
+            }
+        }
+
+        func applyIfPossible() {
+            guard let window else { return }
+            window.isRestorable = false
+            guard
+                abs(window.contentLayoutRect.width - contentSize.width) > 1
+                    || abs(window.contentLayoutRect.height - contentSize.height) > 1
+            else {
+                return
+            }
+            window.setContentSize(contentSize)
+        }
+    }
+
+    private struct UITestContentView: View {
+        private let content: ContentView
+
+        init() {
+            let repository = UITestGuestRepository()
+            let playback = UITestPlayback()
+            let feedModel = GuestFeedViewModel(
+                useCase: GuestFeedUseCase(repository: repository)
+            )
+            let videoModel = GuestVideoViewModel(
+                useCase: GuestVideoUseCase(repository: repository),
+                playback: playback
+            )
+            let timeline = UITestTimeline()
+            let subtitleModel = SubtitleViewModel(
+                useCase: SubtitleUseCase(
+                    repository: UITestSubtitleRepository()
+                ),
+                timeline: timeline
+            )
+            let danmakuModel = DanmakuControlsViewModel(
+                presentation: UITestDanmakuPresentation()
+            )
+            let authenticationModel = AuthenticationViewModel(
+                service: UITestAuthenticationService(),
+                qrCodeProvider: UITestQRCodeProvider()
+            )
+            let historyModel = WatchHistoryViewModel(
+                useCase: WatchHistoryUseCase(
+                    repository: UITestHistoryRepository()
                 )
             )
-            .preferredColorScheme(
-                configuration.usesDarkAppearance ? .dark : .light
-            )
-            .environment(
-                \.dynamicTypeSize,
-                configuration.usesLargeText
-                    ? .accessibility1
-                    : .large
-            )
-    }
-}
-
-private struct UITestWindowConfigurator: NSViewRepresentable {
-    let contentSize: CGSize
-
-    func makeNSView(context: Context) -> WindowConfiguringView {
-        WindowConfiguringView(contentSize: contentSize)
-    }
-
-    func updateNSView(
-        _ view: WindowConfiguringView,
-        context: Context
-    ) {
-        view.contentSize = contentSize
-        view.applyIfPossible()
-    }
-}
-
-private final class WindowConfiguringView: NSView {
-    var contentSize: CGSize
-
-    init(contentSize: CGSize) {
-        self.contentSize = contentSize
-        super.init(frame: .zero)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidMoveToWindow() {
-        super.viewDidMoveToWindow()
-        applyIfPossible()
-        DispatchQueue.main.async { [weak self] in
-            self?.applyIfPossible()
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            self?.applyIfPossible()
-        }
-    }
-
-    func applyIfPossible() {
-        guard let window else { return }
-        window.isRestorable = false
-        guard abs(window.contentLayoutRect.width - contentSize.width) > 1
-                || abs(window.contentLayoutRect.height - contentSize.height) > 1
-        else {
-            return
-        }
-        window.setContentSize(contentSize)
-    }
-}
-
-private struct UITestContentView: View {
-    private let content: ContentView
-
-    init() {
-        let repository = UITestGuestRepository()
-        let playback = UITestPlayback()
-        let feedModel = GuestFeedViewModel(
-            useCase: GuestFeedUseCase(repository: repository)
-        )
-        let videoModel = GuestVideoViewModel(
-            useCase: GuestVideoUseCase(repository: repository),
-            playback: playback
-        )
-        let timeline = UITestTimeline()
-        let subtitleModel = SubtitleViewModel(
-            useCase: SubtitleUseCase(
-                repository: UITestSubtitleRepository()
-            ),
-            timeline: timeline
-        )
-        let danmakuModel = DanmakuControlsViewModel(
-            presentation: UITestDanmakuPresentation()
-        )
-        let authenticationModel = AuthenticationViewModel(
-            service: UITestAuthenticationService(),
-            qrCodeProvider: UITestQRCodeProvider()
-        )
-        let historyModel = WatchHistoryViewModel(
-            useCase: WatchHistoryUseCase(
-                repository: UITestHistoryRepository()
-            )
-        )
-        let navigationModel = AppNavigationModel(
-            startPlayback: { bvid in
-                videoModel.selectVideo(bvid)
-            },
-            stopPlayback: {
-                videoModel.reset()
-                subtitleModel.reset()
-                danmakuModel.reset()
-            }
-        )
-
-        content = ContentView(
-            navigationModel: navigationModel,
-            feedModel: feedModel,
-            videoModel: videoModel,
-            subtitleModel: subtitleModel,
-            danmakuModel: danmakuModel,
-            authenticationModel: authenticationModel,
-            historyModel: historyModel,
-            playerContent: AnyView(
-                ZStack {
-                    Color.black
-                    Image(systemName: "play.rectangle")
-                        .font(.largeTitle)
-                        .foregroundStyle(.white.opacity(0.75))
-                        .accessibilityHidden(true)
+            let navigationModel = AppNavigationModel(
+                startPlayback: { bvid in
+                    videoModel.selectVideo(bvid)
+                },
+                stopPlayback: {
+                    videoModel.reset()
+                    subtitleModel.reset()
+                    danmakuModel.reset()
                 }
             )
-        )
-    }
 
-    var body: some View {
-        content
-    }
-}
+            content = ContentView(
+                navigationModel: navigationModel,
+                feedModel: feedModel,
+                videoModel: videoModel,
+                subtitleModel: subtitleModel,
+                danmakuModel: danmakuModel,
+                authenticationModel: authenticationModel,
+                historyModel: historyModel,
+                playerContent: AnyView(
+                    ZStack {
+                        Color.black
+                        Image(systemName: "play.rectangle")
+                            .font(.largeTitle)
+                            .foregroundStyle(.white.opacity(0.75))
+                            .accessibilityHidden(true)
+                    }
+                )
+            )
+        }
 
-private struct UITestGuestRepository: GuestContentRepository {
-    func popular(page: Int, pageSize: Int) async throws -> PopularPage {
-        PopularPage(
-            videos: Self.popularVideos,
-            pageNumber: page,
-            pageSize: pageSize
-        )
-    }
-
-    func searchVideos(keyword: String, page: Int) async throws -> SearchPage {
-        SearchPage(
-            videos: Self.searchVideos,
-            pageNumber: page,
-            pageSize: Self.searchVideos.count,
-            totalResults: Self.searchVideos.count,
-            totalPages: 1
-        )
-    }
-
-    func videoDetail(for bvid: String) async throws -> VideoDetail {
-        VideoDetail(
-            bvid: bvid,
-            title: "自制播放页示例",
-            summary: "用于验证布局、键盘和辅助显示的本机假值。",
-            coverURL: nil,
-            owner: Self.owner,
-            statistics: Self.statistics,
-            durationSeconds: 4_205,
-            publishedAt: Self.publishedAt,
-            dimension: VideoDimension(width: 1_920, height: 1_080, rotation: 0)
-        )
-    }
-
-    func pages(for bvid: String) async throws -> [VideoPage] {
-        [
-            VideoPage(
-                cid: 101,
-                index: 1,
-                title: "示例章节一",
-                durationSeconds: 1_205
-            ),
-            VideoPage(
-                cid: 102,
-                index: 2,
-                title: "示例章节二",
-                durationSeconds: 1_400
-            ),
-            VideoPage(
-                cid: 103,
-                index: 3,
-                title: "示例章节三",
-                durationSeconds: 1_600
-            ),
-        ]
-    }
-
-    func playback(
-        for bvid: String,
-        cid: Int64,
-        quality: Int
-    ) async throws -> VideoPlayback {
-        VideoPlayback(
-            manifest: PlaybackManifest(
-                videoRepresentations: [],
-                audioRepresentations: []
-            ),
-            mediaHeaders: [:]
-        )
-    }
-
-    private static let owner = VideoOwner(
-        id: 1,
-        name: "示例创作者"
-    )
-    private static let statistics = VideoStatistics(
-        viewCount: 123_456,
-        danmakuCount: 7_890,
-        likeCount: 4_321
-    )
-    private static let publishedAt = Date(timeIntervalSince1970: 1_785_000_000)
-
-    private static let popularVideos = (1...8).map { index in
-        PopularVideo(
-            bvid: "fixture-video-\(index)",
-            title: "自制热门示例 \(index)：用于检查两行标题与文字放大",
-            coverURL: nil,
-            owner: owner,
-            statistics: statistics,
-            durationSeconds: 600 + index * 37,
-            publishedAt: publishedAt
-        )
-    }
-
-    private static let searchVideos = (1...4).map { index in
-        SearchVideo(
-            bvid: "fixture-search-\(index)",
-            title: "自制搜索结果 \(index)",
-            coverURL: nil,
-            owner: owner,
-            statistics: statistics,
-            durationSeconds: 900 + index * 15,
-            publishedAt: publishedAt
-        )
-    }
-}
-
-@MainActor
-private final class UITestPlayback: PlaybackControlling {
-    func load(
-        _ playback: VideoPlayback,
-        identity: PlaybackItemIdentity
-    ) async throws {}
-
-    func pause() {}
-
-    func stop() {}
-}
-
-@MainActor
-private final class UITestTimeline: PlaybackTimelineProviding {
-    let currentTimelineSnapshot = PlaybackTimelineSnapshot.idle
-
-    func timelineUpdates() -> AsyncStream<PlaybackTimelineSnapshot> {
-        AsyncStream { continuation in
-            continuation.yield(.idle)
-            continuation.finish()
+        var body: some View {
+            content
         }
     }
-}
 
-private struct UITestSubtitleRepository: SubtitleRepository {
-    func tracks(
-        for identity: PlaybackItemIdentity
-    ) async throws -> [SubtitleTrack] {
-        []
+    private struct UITestGuestRepository: GuestContentRepository {
+        func popular(page: Int, pageSize: Int) async throws -> PopularPage {
+            PopularPage(
+                videos: Self.popularVideos,
+                pageNumber: page,
+                pageSize: pageSize
+            )
+        }
+
+        func searchVideos(keyword: String, page: Int) async throws -> SearchPage {
+            SearchPage(
+                videos: Self.searchVideos,
+                pageNumber: page,
+                pageSize: Self.searchVideos.count,
+                totalResults: Self.searchVideos.count,
+                totalPages: 1
+            )
+        }
+
+        func videoDetail(for bvid: String) async throws -> VideoDetail {
+            VideoDetail(
+                bvid: bvid,
+                title: "自制播放页示例",
+                summary: "用于验证布局、键盘和辅助显示的本机假值。",
+                coverURL: nil,
+                owner: Self.owner,
+                statistics: Self.statistics,
+                durationSeconds: 4_205,
+                publishedAt: Self.publishedAt,
+                dimension: VideoDimension(width: 1_920, height: 1_080, rotation: 0)
+            )
+        }
+
+        func pages(for bvid: String) async throws -> [VideoPage] {
+            [
+                VideoPage(
+                    cid: 101,
+                    index: 1,
+                    title: "示例章节一",
+                    durationSeconds: 1_205
+                ),
+                VideoPage(
+                    cid: 102,
+                    index: 2,
+                    title: "示例章节二",
+                    durationSeconds: 1_400
+                ),
+                VideoPage(
+                    cid: 103,
+                    index: 3,
+                    title: "示例章节三",
+                    durationSeconds: 1_600
+                ),
+            ]
+        }
+
+        func playback(
+            for bvid: String,
+            cid: Int64,
+            quality: Int
+        ) async throws -> VideoPlayback {
+            VideoPlayback(
+                manifest: PlaybackManifest(
+                    videoRepresentations: [],
+                    audioRepresentations: []
+                ),
+                mediaHeaders: [:]
+            )
+        }
+
+        private static let owner = VideoOwner(
+            id: 1,
+            name: "示例创作者"
+        )
+        private static let statistics = VideoStatistics(
+            viewCount: 123_456,
+            danmakuCount: 7_890,
+            likeCount: 4_321
+        )
+        private static let publishedAt = Date(timeIntervalSince1970: 1_785_000_000)
+
+        private static let popularVideos = (1...8).map { index in
+            PopularVideo(
+                bvid: "fixture-video-\(index)",
+                title: "自制热门示例 \(index)：用于检查两行标题与文字放大",
+                coverURL: nil,
+                owner: owner,
+                statistics: statistics,
+                durationSeconds: 600 + index * 37,
+                publishedAt: publishedAt
+            )
+        }
+
+        private static let searchVideos = (1...4).map { index in
+            SearchVideo(
+                bvid: "fixture-search-\(index)",
+                title: "自制搜索结果 \(index)",
+                coverURL: nil,
+                owner: owner,
+                statistics: statistics,
+                durationSeconds: 900 + index * 15,
+                publishedAt: publishedAt
+            )
+        }
     }
 
-    func cues(
-        for trackID: String,
-        identity: PlaybackItemIdentity
-    ) async throws -> [SubtitleCue] {
-        []
+    @MainActor
+    private final class UITestPlayback: PlaybackControlling {
+        func load(
+            _ playback: VideoPlayback,
+            identity: PlaybackItemIdentity
+        ) async throws {}
+
+        func pause() {}
+
+        func stop() {}
     }
 
-    func reset(for identity: PlaybackItemIdentity) async {}
-}
+    @MainActor
+    private final class UITestTimeline: PlaybackTimelineProviding {
+        let currentTimelineSnapshot = PlaybackTimelineSnapshot.idle
 
-@MainActor
-private final class UITestDanmakuPresentation:
-    DanmakuPresentationControlling
-{
-    func start(for identity: PlaybackItemIdentity) {}
-
-    func setEnabled(_ enabled: Bool) {}
-
-    func setModeVisibility(
-        scrolling: Bool,
-        top: Bool,
-        bottom: Bool
-    ) {}
-
-    func stop() {}
-}
-
-private struct UITestAuthenticationService: AuthenticationServicing {
-    func restore() async -> AuthenticationState { .signedOut }
-    func requestQRCode() async -> AuthenticationState { .signedOut }
-    func pollOnce() async -> AuthenticationState { .signedOut }
-    func finalizeLogin() async -> AuthenticationState { .signedOut }
-    func cancelLogin() async -> AuthenticationState { .signedOut }
-    func logout() async -> AuthenticationState { .signedOut }
-}
-
-private struct UITestQRCodeProvider: AuthenticationQRCodeProviding {
-    func makeQRCodeImage(scale: Int) async throws -> CGImage? { nil }
-}
-
-private struct UITestHistoryRepository: WatchHistoryRepository {
-    func watchHistory(
-        after continuation: WatchHistoryContinuation?,
-        pageSize: Int
-    ) async throws -> WatchHistoryPage {
-        WatchHistoryPage(items: [], continuation: nil)
+        func timelineUpdates() -> AsyncStream<PlaybackTimelineSnapshot> {
+            AsyncStream { continuation in
+                continuation.yield(.idle)
+                continuation.finish()
+            }
+        }
     }
-}
+
+    private struct UITestSubtitleRepository: SubtitleRepository {
+        func tracks(
+            for identity: PlaybackItemIdentity
+        ) async throws -> [SubtitleTrack] {
+            []
+        }
+
+        func cues(
+            for trackID: String,
+            identity: PlaybackItemIdentity
+        ) async throws -> [SubtitleCue] {
+            []
+        }
+
+        func reset(for identity: PlaybackItemIdentity) async {}
+    }
+
+    @MainActor
+    private final class UITestDanmakuPresentation:
+        DanmakuPresentationControlling
+    {
+        func start(for identity: PlaybackItemIdentity) {}
+
+        func setEnabled(_ enabled: Bool) {}
+
+        func setModeVisibility(
+            scrolling: Bool,
+            top: Bool,
+            bottom: Bool
+        ) {}
+
+        func stop() {}
+    }
+
+    private struct UITestAuthenticationService: AuthenticationServicing {
+        func restore() async -> AuthenticationState { .signedOut }
+        func requestQRCode() async -> AuthenticationState { .signedOut }
+        func pollOnce() async -> AuthenticationState { .signedOut }
+        func finalizeLogin() async -> AuthenticationState { .signedOut }
+        func cancelLogin() async -> AuthenticationState { .signedOut }
+        func logout() async -> AuthenticationState { .signedOut }
+    }
+
+    private struct UITestQRCodeProvider: AuthenticationQRCodeProviding {
+        func makeQRCodeImage(scale: Int) async throws -> CGImage? { nil }
+    }
+
+    private struct UITestHistoryRepository: WatchHistoryRepository {
+        func watchHistory(
+            after continuation: WatchHistoryContinuation?,
+            pageSize: Int
+        ) async throws -> WatchHistoryPage {
+            WatchHistoryPage(items: [], continuation: nil)
+        }
+    }
 #endif

--- a/BiliKitMac/Platform/PlayerHostView.swift
+++ b/BiliKitMac/Platform/PlayerHostView.swift
@@ -132,7 +132,7 @@ private final class DanmakuPlayerView: AVPlayerView {
 
     private func installDanmakuOverlayIfNeeded() {
         guard !installedDanmakuOverlay,
-              let contentOverlayView
+            let contentOverlayView
         else {
             return
         }

--- a/BiliKitMacTests/AppNavigationModelTests.swift
+++ b/BiliKitMacTests/AppNavigationModelTests.swift
@@ -1,4 +1,5 @@
 import Testing
+
 @testable import BiliKit
 
 struct AppNavigationModelTests {

--- a/BiliKitMacTests/BiliKitMacTests.swift
+++ b/BiliKitMacTests/BiliKitMacTests.swift
@@ -3,6 +3,7 @@ import BiliAuthFeature
 import BiliBrowseFeature
 import BiliLibraryFeature
 import Testing
+
 @testable import BiliKit
 
 struct BiliKitMacTests {

--- a/BiliKitMacTests/M46AuthenticatedSubtitleLifecycleProbeTests.swift
+++ b/BiliKitMacTests/M46AuthenticatedSubtitleLifecycleProbeTests.swift
@@ -11,13 +11,14 @@ import XCTest
 final class M46AuthenticatedSubtitleLifecycleProbeTests: XCTestCase {
     @MainActor
     func testAuthenticatedABASubtitleLifecycleWhenExplicitlyConfigured()
-        async throws {
+        async throws
+    {
         let environment = ProcessInfo.processInfo.environment
         guard let firstBVID = environment["BILIKIT_M46_PROBE_BVID_A"],
-              let secondBVID = environment["BILIKIT_M46_PROBE_BVID_B"],
-              Self.isValidBVID(firstBVID),
-              Self.isValidBVID(secondBVID),
-              firstBVID != secondBVID
+            let secondBVID = environment["BILIKIT_M46_PROBE_BVID_B"],
+            Self.isValidBVID(firstBVID),
+            Self.isValidBVID(secondBVID),
+            firstBVID != secondBVID
         else {
             throw XCTSkip(
                 "仅在显式提供两个不同的 M4.6 probe BVID 时运行签名 A/B 生命周期探针"
@@ -67,7 +68,7 @@ final class M46AuthenticatedSubtitleLifecycleProbeTests: XCTestCase {
         for (index, bvid) in [firstBVID, secondBVID, firstBVID].enumerated() {
             videoModel.selectVideo(bvid)
             await videoModel.waitForCurrentTask()
-            guard case let .ready(context) = videoModel.state else {
+            guard case .ready(let context) = videoModel.state else {
                 recordFailure("video-session-\(index + 1)")
                 throw ProbeFailure.videoPreparationFailed(session: index + 1)
             }
@@ -84,8 +85,8 @@ final class M46AuthenticatedSubtitleLifecycleProbeTests: XCTestCase {
             subtitleModel.selectVideo(contextIdentity)
             await subtitleModel.waitForCurrentTask()
             guard subtitleModel.state == .ready(contextIdentity),
-                  !subtitleModel.tracks.isEmpty,
-                  subtitleModel.selectedTrackID != nil
+                !subtitleModel.tracks.isEmpty,
+                subtitleModel.selectedTrackID != nil
             else {
                 recordFailure(
                     subtitleFailureCategory(
@@ -113,8 +114,8 @@ final class M46AuthenticatedSubtitleLifecycleProbeTests: XCTestCase {
         }
 
         guard completedSessions == 3,
-              identitiesMatched,
-              generationsAdvanced
+            identitiesMatched,
+            generationsAdvanced
         else {
             recordFailure("identity-or-generation")
             throw ProbeFailure.identityMismatch
@@ -124,7 +125,7 @@ final class M46AuthenticatedSubtitleLifecycleProbeTests: XCTestCase {
         await subtitleModel.waitForCurrentTask()
         videoModel.reset()
         guard player.currentTimelineSnapshot.identity == nil,
-              subtitleModel.state == .idle
+            subtitleModel.state == .idle
         else {
             recordFailure("cleanup")
             throw ProbeFailure.cleanupFailed
@@ -156,29 +157,30 @@ final class M46AuthenticatedSubtitleLifecycleProbeTests: XCTestCase {
         state: SubtitleViewState,
         session: Int
     ) -> String {
-        let reason = switch state {
-        case .idle:
-            "idle"
-        case .loadingCatalog:
-            "loading-catalog"
-        case .loadingTrack:
-            "loading-track"
-        case .ready:
-            "incomplete-ready"
-        case .unavailable:
-            "unavailable"
-        case let .failed(_, failure):
-            switch failure {
-            case .authenticationRequired:
-                "authentication-required"
-            case .requestRestricted:
-                "request-restricted"
-            case .invalidResponse:
-                "invalid-response"
+        let reason =
+            switch state {
+            case .idle:
+                "idle"
+            case .loadingCatalog:
+                "loading-catalog"
+            case .loadingTrack:
+                "loading-track"
+            case .ready:
+                "incomplete-ready"
             case .unavailable:
-                "failed-unavailable"
+                "unavailable"
+            case .failed(_, let failure):
+                switch failure {
+                case .authenticationRequired:
+                    "authentication-required"
+                case .requestRestricted:
+                    "request-restricted"
+                case .invalidResponse:
+                    "invalid-response"
+                case .unavailable:
+                    "failed-unavailable"
+                }
             }
-        }
         return "subtitle-\(reason)-session-\(session)"
     }
 }

--- a/BiliKitMacTests/M4AuthenticatedContractProbeTests.swift
+++ b/BiliKitMacTests/M4AuthenticatedContractProbeTests.swift
@@ -4,6 +4,7 @@ import BiliBrowseFeature
 import BiliNetworking
 import Foundation
 import XCTest
+
 @testable import BiliKit
 
 final class M4AuthenticatedContractProbeTests: XCTestCase {
@@ -11,14 +12,14 @@ final class M4AuthenticatedContractProbeTests: XCTestCase {
     private static let maximumPageListSize = 512 * 1_024
     private static let maximumSubtitleBodySize = 2 * 1_024 * 1_024
     private static let allowedSubtitleHosts: Set<String> = [
-        "aisubtitle.hdslb.com",
+        "aisubtitle.hdslb.com"
     ]
 
     @MainActor
     func testAuthenticatedSubtitleContractWhenExplicitlyConfigured() async throws {
         let environment = ProcessInfo.processInfo.environment
         guard let bvid = environment["BILIKIT_M4_PROBE_BVID"],
-              Self.isValidBVID(bvid)
+            Self.isValidBVID(bvid)
         else {
             throw XCTSkip(
                 "仅在显式提供 BILIKIT_M4_PROBE_BVID 时运行已登录 M4 探针"
@@ -62,7 +63,8 @@ final class M4AuthenticatedContractProbeTests: XCTestCase {
         let catalogResponse = try await transport.send(authorizedRequest)
         let catalog = try Self.catalogObservation(from: catalogResponse)
 
-        let catalogSummary = "m4-subtitle-catalog status=200 content-type=json "
+        let catalogSummary =
+            "m4-subtitle-catalog status=200 content-type=json "
             + "bytes=\(catalogResponse.body.count) tracks=\(catalog.trackCount) "
             + "usable-tracks=\(catalog.usableTrackCount) "
             + "needs-login=\(catalog.needsLogin) "
@@ -72,7 +74,7 @@ final class M4AuthenticatedContractProbeTests: XCTestCase {
             + "track-fields=\(catalog.trackFieldTypes.joined(separator: ","))"
         XCTContext.runActivity(named: catalogSummary) { _ in }
         guard catalog.hasSuccessfulEnvelope,
-              catalog.hasSubtitleCatalog
+            catalog.hasSubtitleCatalog
         else {
             throw ProbeFailure.invalidJSONShape
         }
@@ -98,7 +100,8 @@ final class M4AuthenticatedContractProbeTests: XCTestCase {
             )
         )
         let body = try Self.subtitleBodyObservation(from: subtitleResponse)
-        let bodySummary = "m4-subtitle-body status=200 host=\(host) "
+        let bodySummary =
+            "m4-subtitle-body status=200 host=\(host) "
             + "content-type=json bytes=\(subtitleResponse.body.count) "
             + "cues=\(body.cueCount) "
             + "cue-fields=\(body.cueFieldTypes.joined(separator: ","))"
@@ -112,8 +115,8 @@ final class M4AuthenticatedContractProbeTests: XCTestCase {
         productionModel.selectVideo(identity)
         await productionModel.waitForCurrentTask()
         guard productionModel.state == .ready(identity),
-              !productionModel.tracks.isEmpty,
-              productionModel.selectedTrackID != nil
+            !productionModel.tracks.isEmpty,
+            productionModel.selectedTrackID != nil
         else {
             throw ProbeFailure.productionDecoderFailed
         }
@@ -153,13 +156,14 @@ final class M4AuthenticatedContractProbeTests: XCTestCase {
         guard contentType(response).contains("json") else {
             throw ProbeFailure.unexpectedContentType
         }
-        guard let envelope = try JSONSerialization.jsonObject(
-            with: response.body
-        ) as? [String: Any],
-              envelope["code"] as? Int == 0,
-              let pages = envelope["data"] as? [[String: Any]],
-              let firstCID = pages.first?["cid"] as? NSNumber,
-              firstCID.int64Value > 0
+        guard
+            let envelope = try JSONSerialization.jsonObject(
+                with: response.body
+            ) as? [String: Any],
+            envelope["code"] as? Int == 0,
+            let pages = envelope["data"] as? [[String: Any]],
+            let firstCID = pages.first?["cid"] as? NSNumber,
+            firstCID.int64Value > 0
         else {
             throw ProbeFailure.invalidJSONShape
         }
@@ -202,9 +206,11 @@ final class M4AuthenticatedContractProbeTests: XCTestCase {
         guard contentType(response).contains("json") else {
             throw ProbeFailure.unexpectedContentType
         }
-        guard let envelope = try JSONSerialization.jsonObject(
-            with: response.body
-        ) as? [String: Any] else {
+        guard
+            let envelope = try JSONSerialization.jsonObject(
+                with: response.body
+            ) as? [String: Any]
+        else {
             throw ProbeFailure.invalidJSONShape
         }
         let data = envelope["data"] as? [String: Any]
@@ -233,14 +239,13 @@ final class M4AuthenticatedContractProbeTests: XCTestCase {
             dataFieldTypes: data.map(fieldTypes) ?? [],
             subtitleFieldTypes: subtitle.map(fieldTypes) ?? [],
             trackFieldTypes: firstTrack.map(fieldTypes) ?? [],
-            hasSuccessfulEnvelope:
-                (envelope["code"] as? NSNumber)?.intValue == 0
+            hasSuccessfulEnvelope: (envelope["code"] as? NSNumber)?.intValue == 0
                 && data != nil,
             hasSubtitleCatalog:
                 subtitle != nil
                 && subtitle?["subtitles"] is [[String: Any]],
-            hasMinimumTrackFields:
-                (firstTrack?["id"] is NSNumber || firstTrack?["id_str"] is String)
+            hasMinimumTrackFields: (firstTrack?["id"] is NSNumber
+                || firstTrack?["id_str"] is String)
                 && firstTrack?["lan"] is String
                 && firstTrack?["subtitle_url"] is String,
             firstSubtitleURL: firstURL
@@ -248,17 +253,18 @@ final class M4AuthenticatedContractProbeTests: XCTestCase {
     }
 
     private static func validatedSubtitleHost(for url: URL) throws -> String {
-        guard let components = URLComponents(
-            url: url,
-            resolvingAgainstBaseURL: false
-        ),
-              components.scheme?.lowercased() == "https",
-              let host = components.host?.lowercased(),
-              allowedSubtitleHosts.contains(host),
-              (components.port == nil || components.port == 443),
-              components.user == nil,
-              components.password == nil,
-              components.fragment == nil
+        guard
+            let components = URLComponents(
+                url: url,
+                resolvingAgainstBaseURL: false
+            ),
+            components.scheme?.lowercased() == "https",
+            let host = components.host?.lowercased(),
+            allowedSubtitleHosts.contains(host),
+            components.port == nil || components.port == 443,
+            components.user == nil,
+            components.password == nil,
+            components.fragment == nil
         else {
             throw ProbeFailure.untrustedSubtitleOrigin
         }
@@ -277,11 +283,12 @@ final class M4AuthenticatedContractProbeTests: XCTestCase {
         guard contentType(response).contains("json") else {
             throw ProbeFailure.unexpectedContentType
         }
-        guard let payload = try JSONSerialization.jsonObject(
-            with: response.body
-        ) as? [String: Any],
-              let cues = payload["body"] as? [[String: Any]],
-              let firstCue = cues.first
+        guard
+            let payload = try JSONSerialization.jsonObject(
+                with: response.body
+            ) as? [String: Any],
+            let cues = payload["body"] as? [[String: Any]],
+            let firstCue = cues.first
         else {
             throw ProbeFailure.invalidJSONShape
         }
@@ -346,7 +353,8 @@ final class M4AuthenticatedContractProbeTests: XCTestCase {
             case is String:
                 self = .string
             case let number as NSNumber:
-                self = CFGetTypeID(number) == CFBooleanGetTypeID()
+                self =
+                    CFGetTypeID(number) == CFBooleanGetTypeID()
                     ? .boolean : .number
             case is [Any]:
                 self = .array

--- a/BiliKitMacTests/PlayerHostLifecycleProbeTests.swift
+++ b/BiliKitMacTests/PlayerHostLifecycleProbeTests.swift
@@ -1,5 +1,5 @@
-import AppKit
 import AVKit
+import AppKit
 import BiliApplication
 import BiliAuthFeature
 import BiliBrowseFeature
@@ -9,6 +9,7 @@ import BiliModels
 import Observation
 import SwiftUI
 import Testing
+
 @testable import BiliKit
 
 @Suite(.serialized)
@@ -102,14 +103,14 @@ struct PlayerHostLifecycleProbeTests {
             rootView: DisappearingContentRoot(
                 visibility: visibility,
                 content: ContentView(
-                navigationModel: navigationModel,
-                feedModel: feedModel,
-                videoModel: videoModel,
-                subtitleModel: subtitleModel,
-                danmakuModel: danmakuModel,
-                authenticationModel: authenticationModel,
-                historyModel: historyModel,
-                playerContent: playerContent
+                    navigationModel: navigationModel,
+                    feedModel: feedModel,
+                    videoModel: videoModel,
+                    subtitleModel: subtitleModel,
+                    danmakuModel: danmakuModel,
+                    authenticationModel: authenticationModel,
+                    historyModel: historyModel,
+                    playerContent: playerContent
                 )
             )
         )
@@ -123,16 +124,20 @@ struct PlayerHostLifecycleProbeTests {
         hostingView.layoutSubtreeIfNeeded()
 
         navigationModel.openPlayback("BV1RouteHostA")
-        #expect(await waitUntil {
-            probe.events.count == 1
-                && probe.activeCount == 1
-                && playback.loadedIdentities.count == 1
-                && presentation.startedIdentities.count == 1
-        })
+        #expect(
+            await waitUntil {
+                probe.events.count == 1
+                    && probe.activeCount == 1
+                    && playback.loadedIdentities.count == 1
+                    && presentation.startedIdentities.count == 1
+            }
+        )
         await subtitleModel.waitForCurrentTask()
-        guard let compactPlayerSize = await waitForPlayerSize(
-            in: hostingView
-        ) else {
+        guard
+            let compactPlayerSize = await waitForPlayerSize(
+                in: hostingView
+            )
+        else {
             Issue.record("compact player layout did not settle")
             return
         }
@@ -147,23 +152,27 @@ struct PlayerHostLifecycleProbeTests {
 
         window.setContentSize(NSSize(width: 1_320, height: 820))
         hostingView.layoutSubtreeIfNeeded()
-        #expect(await waitUntil {
-            guard let playerSize = self.playerSize(in: hostingView) else {
-                return false
+        #expect(
+            await waitUntil {
+                guard let playerSize = self.playerSize(in: hostingView) else {
+                    return false
+                }
+                return self.isSixteenByNine(playerSize)
+                    && playerSize.width < compactPlayerSize.width
             }
-            return self.isSixteenByNine(playerSize)
-                && playerSize.width < compactPlayerSize.width
-        })
+        )
 
         window.setContentSize(NSSize(width: 1_080, height: 680))
         hostingView.layoutSubtreeIfNeeded()
-        #expect(await waitUntil {
-            guard let playerSize = self.playerSize(in: hostingView) else {
-                return false
+        #expect(
+            await waitUntil {
+                guard let playerSize = self.playerSize(in: hostingView) else {
+                    return false
+                }
+                return self.isSixteenByNine(playerSize)
+                    && abs(playerSize.width - compactPlayerSize.width) < 1
             }
-            return self.isSixteenByNine(playerSize)
-                && abs(playerSize.width - compactPlayerSize.width) < 1
-        })
+        )
         #expect(probe.events.count == baselineEventCount)
         #expect(probe.events[0] == firstHostEvent)
         #expect(probe.activeCount == 1)
@@ -176,29 +185,35 @@ struct PlayerHostLifecycleProbeTests {
         #expect(presentation.startedIdentities == baselineDanmakuIdentities)
 
         navigationModel.returnFromPlayback()
-        #expect(await waitUntil {
-            probe.events.count == 2 && probe.activeCount == 0
-        })
+        #expect(
+            await waitUntil {
+                probe.events.count == 2 && probe.activeCount == 0
+            }
+        )
         #expect(playback.stopCount == 1)
 
         navigationModel.openPlayback("BV1RouteHostB")
-        #expect(await waitUntil {
-            probe.events.count == 3 && probe.activeCount == 1
-        })
+        #expect(
+            await waitUntil {
+                probe.events.count == 3 && probe.activeCount == 1
+            }
+        )
 
         visibility.isPresented = false
         hostingView.layoutSubtreeIfNeeded()
-        #expect(await waitUntil {
-            probe.events.count == 4
-                && probe.activeCount == 0
-                && navigationModel.route == .section(.popular)
-                && playback.stopCount == 2
-        })
+        #expect(
+            await waitUntil {
+                probe.events.count == 4
+                    && probe.activeCount == 0
+                    && navigationModel.route == .section(.popular)
+                    && playback.stopCount == 2
+            }
+        )
 
-        guard case let .created(firstHost) = probe.events[0],
-              case let .dismantled(firstDismantled) = probe.events[1],
-              case let .created(secondHost) = probe.events[2],
-              case let .dismantled(secondDismantled) = probe.events[3]
+        guard case .created(let firstHost) = probe.events[0],
+            case .dismantled(let firstDismantled) = probe.events[1],
+            case .created(let secondHost) = probe.events[2],
+            case .dismantled(let secondDismantled) = probe.events[3]
         else {
             Issue.record("unexpected lifecycle event order")
             return
@@ -262,7 +277,6 @@ struct PlayerHostLifecycleProbeTests {
         }
         return nil
     }
-
 }
 
 @MainActor
@@ -381,7 +395,7 @@ private actor AppShellRecordingSubtitleRepository: SubtitleRepository {
         for trackID: String,
         identity: PlaybackItemIdentity
     ) async throws -> [SubtitleCue] {
-        return []
+        []
     }
 
     func reset(for identity: PlaybackItemIdentity) async {}

--- a/BiliKitMacTests/SignedKeychainSmokeTests.swift
+++ b/BiliKitMacTests/SignedKeychainSmokeTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Security
 import XCTest
+
 @testable import BiliAuth
 
 final class SignedKeychainSmokeTests: XCTestCase {
@@ -110,9 +111,9 @@ final class SignedKeychainSmokeTests: XCTestCase {
             throw SmokeFailure.attributeReadFailed(status)
         }
         guard let attributes = result as? [String: Any],
-              attributes[kSecAttrAccessible as String] as? String
+            attributes[kSecAttrAccessible as String] as? String
                 == kSecAttrAccessibleWhenUnlockedThisDeviceOnly as String,
-              !isSynchronizable(attributes[kSecAttrSynchronizable as String])
+            !isSynchronizable(attributes[kSecAttrSynchronizable as String])
         else {
             throw SmokeFailure.invalidStoredAttributes
         }
@@ -127,14 +128,14 @@ final class SignedKeychainSmokeTests: XCTestCase {
     private static func signingTeamIdentifier() -> String? {
         var code: SecCode?
         guard SecCodeCopySelf([], &code) == errSecSuccess,
-              let code
+            let code
         else {
             return nil
         }
 
         var staticCode: SecStaticCode?
         guard SecCodeCopyStaticCode(code, [], &staticCode) == errSecSuccess,
-              let staticCode
+            let staticCode
         else {
             return nil
         }
@@ -142,7 +143,7 @@ final class SignedKeychainSmokeTests: XCTestCase {
         var information: CFDictionary?
         let flags = SecCSFlags(rawValue: kSecCSSigningInformation)
         guard SecCodeCopySigningInformation(staticCode, flags, &information) == errSecSuccess,
-              let values = information as? [String: Any]
+            let values = information as? [String: Any]
         else {
             return nil
         }

--- a/BiliKitMacTests/SliceCAccessibilityTests.swift
+++ b/BiliKitMacTests/SliceCAccessibilityTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import Testing
+
 @testable import BiliKit
 
 struct SliceCAccessibilityTests {
@@ -51,10 +52,12 @@ struct SliceCAccessibilityTests {
         hostingView.frame = NSRect(x: 0, y: 0, width: 340, height: 40)
         hostingView.layoutSubtreeIfNeeded()
 
-        guard let searchField = firstSubview(
-            of: NSSearchField.self,
-            in: hostingView
-        ) else {
+        guard
+            let searchField = firstSubview(
+                of: NSSearchField.self,
+                in: hostingView
+            )
+        else {
             Issue.record("missing NSSearchField")
             return
         }

--- a/BiliKitMacTests/VideoDetailLifecycleTests.swift
+++ b/BiliKitMacTests/VideoDetailLifecycleTests.swift
@@ -47,41 +47,51 @@ struct VideoDetailLifecycleTests {
         )
         window.contentView = hostingView
         window.layoutIfNeeded()
-        #expect(await waitUntil {
-            presentation.stopCount > 0
-        })
+        #expect(
+            await waitUntil {
+                presentation.stopCount > 0
+            }
+        )
         let baselineStopCount = presentation.stopCount
 
         videoModel.selectVideo(fixture.bvid)
-        #expect(await waitUntil {
-            player.loadCallCount == 1
-                && presentation.startedIdentities.count == 1
-                && subtitleModel.state != .idle
-        })
+        #expect(
+            await waitUntil {
+                player.loadCallCount == 1
+                    && presentation.startedIdentities.count == 1
+                    && subtitleModel.state != .idle
+            }
+        )
 
         player.failPendingLoad()
         await videoModel.waitForCurrentTask()
-        #expect(await waitUntil {
-            if case .failed = videoModel.state {
-                return subtitleModel.state == .idle
-                    && presentation.stopCount == baselineStopCount + 1
+        #expect(
+            await waitUntil {
+                if case .failed = videoModel.state {
+                    return subtitleModel.state == .idle
+                        && presentation.stopCount == baselineStopCount + 1
+                }
+                return false
             }
-            return false
-        })
+        )
 
         videoModel.selectVideo(fixture.bvid)
-        #expect(await waitUntil {
-            player.loadCallCount == 2
-                && presentation.startedIdentities.count == 2
-                && subtitleModel.state != .idle
-        })
+        #expect(
+            await waitUntil {
+                player.loadCallCount == 2
+                    && presentation.startedIdentities.count == 2
+                    && subtitleModel.state != .idle
+            }
+        )
 
         player.failPendingLoad()
         await videoModel.waitForCurrentTask()
-        #expect(await waitUntil {
-            subtitleModel.state == .idle
-                && presentation.stopCount == baselineStopCount + 2
-        })
+        #expect(
+            await waitUntil {
+                subtitleModel.state == .idle
+                    && presentation.stopCount == baselineStopCount + 2
+            }
+        )
 
         window.contentView = NSView()
     }

--- a/BiliKitMacUITests/BiliKitMacUITests.swift
+++ b/BiliKitMacUITests/BiliKitMacUITests.swift
@@ -8,7 +8,6 @@
 import XCTest
 
 final class BiliKitMacUITests: XCTestCase {
-
     override func setUpWithError() throws {
         continueAfterFailure = false
     }

--- a/Packages/BiliKitCore/Package.swift
+++ b/Packages/BiliKitCore/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "BiliKitCore",
     platforms: [
-        .macOS(.v15),
+        .macOS(.v15)
     ],
     products: [
         .library(name: "BiliModels", targets: ["BiliModels"]),
@@ -27,7 +27,7 @@ let package = Package(
         .package(
             url: "https://github.com/apple/swift-protobuf.git",
             exact: "1.38.1"
-        ),
+        )
     ],
     targets: [
         .target(name: "BiliModels"),
@@ -114,14 +114,14 @@ let package = Package(
             name: "BiliAuthTests",
             dependencies: ["BiliAuth", "BiliNetworking"],
             resources: [
-                .copy("Fixtures"),
+                .copy("Fixtures")
             ]
         ),
         .testTarget(
             name: "BiliAPITests",
             dependencies: ["BiliAPI", "BiliModels", "BiliNetworking"],
             resources: [
-                .copy("Fixtures"),
+                .copy("Fixtures")
             ]
         ),
         .testTarget(
@@ -133,7 +133,7 @@ let package = Package(
                 "BiliPlayback",
             ],
             resources: [
-                .copy("Fixtures"),
+                .copy("Fixtures")
             ]
         ),
         .testTarget(

--- a/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliDanmakuRepository.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliDanmakuRepository.swift
@@ -37,16 +37,16 @@ public struct BiliDanmakuRepository: DanmakuSegmentRepository, Sendable {
         case .transportFailure:
             .transportFailure
         case .httpStatus(403), .nonProtobufResponse,
-             .apiRejected(code: -403, _), .apiRejected(code: -412, _):
+            .apiRejected(code: -403, _), .apiRejected(code: -412, _):
             .requestRestricted
         case .responseTooLarge, .decodingFailed, .missingData,
-             .invalidDanmakuData:
+            .invalidDanmakuData:
             .invalidResponse
         case .httpStatus, .apiRejected:
             .unavailable
         case .authorizationRequired, .nonJSONResponse, .invalidWBIKey,
-             .signingFailed, .invalidMediaData, .invalidSubtitleData,
-             .untrustedSubtitleOrigin, .noAVCVideo, .noAACAudio:
+            .signingFailed, .invalidMediaData, .invalidSubtitleData,
+            .untrustedSubtitleOrigin, .noAVCVideo, .noAACAudio:
             .invalidResponse
         }
     }

--- a/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliGuestRepository.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliGuestRepository.swift
@@ -59,24 +59,24 @@ public struct BiliGuestRepository: GuestContentRepository {
     }
 }
 
-private extension BiliAPIError {
-    var applicationError: GuestApplicationError {
+extension BiliAPIError {
+    fileprivate var applicationError: GuestApplicationError {
         switch self {
         case .invalidRequest, .authorizationRequired:
             .invalidRequest
         case .transportFailure:
             .transportFailure
         case .httpStatus(403), .nonJSONResponse,
-             .apiRejected(code: -403, _), .apiRejected(code: -412, _):
+            .apiRejected(code: -403, _), .apiRejected(code: -412, _):
             .requestRestricted
-        case let .apiRejected(code, _):
+        case .apiRejected(let code, _):
             .serviceRejected(code: code)
         case .noAVCVideo, .noAACAudio:
             .unsupportedMedia
         case .responseTooLarge, .decodingFailed, .missingData,
-             .invalidWBIKey, .signingFailed, .invalidMediaData,
-             .invalidSubtitleData, .untrustedSubtitleOrigin,
-             .nonProtobufResponse, .invalidDanmakuData:
+            .invalidWBIKey, .signingFailed, .invalidMediaData,
+            .invalidSubtitleData, .untrustedSubtitleOrigin,
+            .nonProtobufResponse, .invalidDanmakuData:
             .invalidResponse
         case .httpStatus:
             .unavailable

--- a/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliSubtitleRepository.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliSubtitleRepository.swift
@@ -76,8 +76,8 @@ public actor BiliSubtitleRepository: SubtitleRepository {
         identity: PlaybackItemIdentity
     ) async throws -> [SubtitleCue] {
         guard currentIdentity == identity,
-              let url = resourceURLs[trackID],
-              SubtitleURLPolicy().allows(url)
+            let url = resourceURLs[trackID],
+            SubtitleURLPolicy().allows(url)
         else {
             throw SubtitleApplicationError.invalidRequest
         }
@@ -95,7 +95,7 @@ public actor BiliSubtitleRepository: SubtitleRepository {
             let response = try await bodyClient.send(request)
             try Task.checkCancellation()
             guard generation == requestGeneration,
-                  currentIdentity == identity
+                currentIdentity == identity
             else {
                 throw CancellationError()
             }
@@ -119,7 +119,7 @@ public actor BiliSubtitleRepository: SubtitleRepository {
             throw CancellationError()
         } catch let error as HTTPClientError {
             switch error {
-            case let .unacceptableStatusCode(status):
+            case .unacceptableStatusCode(let status):
                 throw Self.applicationError(.httpStatus(status))
             case .nonHTTPResponse:
                 throw SubtitleApplicationError.transportFailure
@@ -147,16 +147,19 @@ public actor BiliSubtitleRepository: SubtitleRepository {
     }
 
     private static func looksLikeJSON(_ response: HTTPResponse) -> Bool {
-        guard let contentType = response.headers.first(where: {
-            $0.key.caseInsensitiveCompare("Content-Type") == .orderedSame
-        })?.value.lowercased(),
-              contentType.contains("json")
+        guard
+            let contentType = response.headers.first(where: {
+                $0.key.caseInsensitiveCompare("Content-Type") == .orderedSame
+            })?.value.lowercased(),
+            contentType.contains("json")
         else {
             return false
         }
-        guard let firstByte = response.body.first(where: {
-            ![9, 10, 13, 32].contains($0)
-        }) else {
+        guard
+            let firstByte = response.body.first(where: {
+                ![9, 10, 13, 32].contains($0)
+            })
+        else {
             return false
         }
         return firstByte == 0x7B
@@ -173,16 +176,16 @@ public actor BiliSubtitleRepository: SubtitleRepository {
         case .transportFailure:
             .transportFailure
         case .httpStatus(403), .nonJSONResponse,
-             .apiRejected(code: -403, _), .apiRejected(code: -412, _):
+            .apiRejected(code: -403, _), .apiRejected(code: -412, _):
             .requestRestricted
         case .responseTooLarge, .decodingFailed, .missingData,
-             .invalidSubtitleData, .untrustedSubtitleOrigin,
-             .nonProtobufResponse, .invalidDanmakuData:
+            .invalidSubtitleData, .untrustedSubtitleOrigin,
+            .nonProtobufResponse, .invalidDanmakuData:
             .invalidResponse
         case .httpStatus, .apiRejected:
             .unavailable
         case .invalidWBIKey, .signingFailed, .invalidMediaData,
-             .noAVCVideo, .noAACAudio:
+            .noAVCVideo, .noAACAudio:
             .invalidResponse
         }
     }

--- a/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliWatchHistoryRepository.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliWatchHistoryRepository.swift
@@ -29,21 +29,21 @@ public struct BiliWatchHistoryRepository: WatchHistoryRepository {
     private static func map(_ error: BiliAPIError) -> WatchHistoryError {
         switch error {
         case .authorizationRequired,
-             .apiRejected(code: -101, message: _):
+            .apiRejected(code: -101, message: _):
             .authenticationRequired
         case .apiRejected(code: -412, message: _),
-             .apiRejected(code: -403, message: _),
-             .nonJSONResponse:
+            .apiRejected(code: -403, message: _),
+            .nonJSONResponse:
             .requestRestricted
-        case let .apiRejected(code, _):
+        case .apiRejected(let code, _):
             .serviceRejected(code: code)
         case .transportFailure, .httpStatus:
             .transportFailure
         case .invalidRequest, .responseTooLarge, .decodingFailed,
-             .missingData, .invalidWBIKey, .signingFailed,
-             .invalidMediaData, .invalidSubtitleData,
-             .untrustedSubtitleOrigin, .nonProtobufResponse,
-             .invalidDanmakuData, .noAVCVideo, .noAACAudio:
+            .missingData, .invalidWBIKey, .signingFailed,
+            .invalidMediaData, .invalidSubtitleData,
+            .untrustedSubtitleOrigin, .nonProtobufResponse,
+            .invalidDanmakuData, .noAVCVideo, .noAACAudio:
             .invalidResponse
         }
     }

--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
@@ -102,7 +102,7 @@ public actor BiliAPIClient: BiliAPIService, BiliWatchHistoryService,
         ]
         do {
             return try await signedSearch(parameters: parameters, forceKeyRefresh: false)
-        } catch let BiliAPIError.apiRejected(code, _) where code == -403 {
+        } catch BiliAPIError.apiRejected(let code, _) where code == -403 {
             return try await signedSearch(parameters: parameters, forceKeyRefresh: true)
         } catch BiliAPIError.httpStatus(403) {
             return try await signedSearch(parameters: parameters, forceKeyRefresh: true)

--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
@@ -21,9 +21,12 @@ public protocol BiliWatchHistoryService: Sendable {
 public actor BiliAPIClient: BiliAPIService, BiliWatchHistoryService,
     AuthenticatedSessionInvalidating
 {
-    public static let productionBaseURL = URL(
-        string: "https://api.bilibili.com"
-    )!
+    public static let productionBaseURL: URL = {
+        guard let url = URL(string: "https://api.bilibili.com") else {
+            preconditionFailure("Static API base URL must be valid")
+        }
+        return url
+    }()
 
     private static let maximumResponseSize = 5 * 1_024 * 1_024
     private static let maximumSubtitleCatalogSize = 1 * 1_024 * 1_024
@@ -45,7 +48,8 @@ public actor BiliAPIClient: BiliAPIService, BiliWatchHistoryService,
         requestAuthorizer: (any HTTPRequestAuthorizing)? = nil,
         transportFactory: (@Sendable () -> any HTTPTransport)? = nil,
         baseURL: URL = BiliAPIClient.productionBaseURL,
-        userAgent: String = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 BiliKitMac/0.1",
+        userAgent: String =
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 BiliKitMac/0.1",
         timestampProvider: @escaping @Sendable () -> Int64 = {
             Int64(Date().timeIntervalSince1970)
         }
@@ -86,8 +90,8 @@ public actor BiliAPIClient: BiliAPIService, BiliWatchHistoryService,
     ) async throws -> SearchPage {
         let normalizedKeyword = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedKeyword.isEmpty,
-              normalizedKeyword.count <= 100,
-              page > 0
+            normalizedKeyword.count <= 100,
+            page > 0
         else {
             throw BiliAPIError.invalidRequest
         }
@@ -200,8 +204,8 @@ public actor BiliAPIClient: BiliAPIService, BiliWatchHistoryService,
         for identity: PlaybackItemIdentity
     ) async throws -> Data {
         guard Self.isValidBVID(identity.bvid),
-              identity.cid > 0,
-              (1...DanmakuSegmentUseCase.maximumSegmentIndex).contains(index)
+            identity.cid > 0,
+            (1...DanmakuSegmentUseCase.maximumSegmentIndex).contains(index)
         else {
             throw BiliAPIError.invalidRequest
         }
@@ -228,7 +232,7 @@ public actor BiliAPIClient: BiliAPIService, BiliWatchHistoryService,
             throw CancellationError()
         } catch let error as HTTPClientError {
             switch error {
-            case let .unacceptableStatusCode(status):
+            case .unacceptableStatusCode(let status):
                 throw BiliAPIError.httpStatus(status)
             case .nonHTTPResponse:
                 throw BiliAPIError.transportFailure
@@ -237,7 +241,7 @@ public actor BiliAPIClient: BiliAPIService, BiliWatchHistoryService,
             throw BiliAPIError.transportFailure
         }
         guard !response.body.isEmpty,
-              response.body.count <= Self.maximumDanmakuSegmentSize
+            response.body.count <= Self.maximumDanmakuSegmentSize
         else {
             if response.body.isEmpty {
                 throw BiliAPIError.invalidDanmakuData
@@ -391,7 +395,7 @@ public actor BiliAPIClient: BiliAPIService, BiliWatchHistoryService,
             throw CancellationError()
         } catch let error as HTTPClientError {
             switch error {
-            case let .unacceptableStatusCode(status):
+            case .unacceptableStatusCode(let status):
                 throw BiliAPIError.httpStatus(status)
             case .nonHTTPResponse:
                 throw BiliAPIError.transportFailure
@@ -464,10 +468,12 @@ public actor BiliAPIClient: BiliAPIService, BiliWatchHistoryService,
         path: String,
         queryItems: [URLQueryItem]
     ) throws -> URL {
-        guard var components = URLComponents(
-            url: baseURL,
-            resolvingAgainstBaseURL: false
-        ) else {
+        guard
+            var components = URLComponents(
+                url: baseURL,
+                resolvingAgainstBaseURL: false
+            )
+        else {
             throw BiliAPIError.invalidRequest
         }
         components.path = path
@@ -482,10 +488,12 @@ public actor BiliAPIClient: BiliAPIService, BiliWatchHistoryService,
         path: String,
         percentEncodedQuery: String
     ) throws -> URL {
-        guard var components = URLComponents(
-            url: baseURL,
-            resolvingAgainstBaseURL: false
-        ) else {
+        guard
+            var components = URLComponents(
+                url: baseURL,
+                resolvingAgainstBaseURL: false
+            )
+        else {
             throw BiliAPIError.invalidRequest
         }
         components.path = path
@@ -507,26 +515,30 @@ public actor BiliAPIClient: BiliAPIService, BiliWatchHistoryService,
     }
 
     private static func looksLikeJSON(_ response: HTTPResponse) -> Bool {
-        guard let contentType = response.headers.first(where: {
-            $0.key.caseInsensitiveCompare("Content-Type") == .orderedSame
-        })?.value.lowercased(),
-              contentType.contains("json")
+        guard
+            let contentType = response.headers.first(where: {
+                $0.key.caseInsensitiveCompare("Content-Type") == .orderedSame
+            })?.value.lowercased(),
+            contentType.contains("json")
         else {
             return false
         }
-        guard let firstByte = response.body.first(where: {
-            ![9, 10, 13, 32].contains($0)
-        }) else {
+        guard
+            let firstByte = response.body.first(where: {
+                ![9, 10, 13, 32].contains($0)
+            })
+        else {
             return false
         }
         return firstByte == 0x7B || firstByte == 0x5B
     }
 
     private static func looksLikeProtobuf(_ response: HTTPResponse) -> Bool {
-        guard let contentType = response.headers.first(where: {
-            $0.key.caseInsensitiveCompare("Content-Type") == .orderedSame
-        })?.value.lowercased(),
-              contentType.contains("application/octet-stream")
+        guard
+            let contentType = response.headers.first(where: {
+                $0.key.caseInsensitiveCompare("Content-Type") == .orderedSame
+            })?.value.lowercased(),
+            contentType.contains("application/octet-stream")
         else {
             return false
         }

--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIError.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIError.swift
@@ -26,9 +26,9 @@ public enum BiliAPIError: Error, Sendable, Equatable, CustomStringConvertible {
             "authorization-required"
         case .transportFailure:
             "transport-failure"
-        case let .httpStatus(status):
+        case .httpStatus(let status):
             "http-status-\(status)"
-        case let .responseTooLarge(size):
+        case .responseTooLarge(let size):
             "response-too-large-\(size)"
         case .nonJSONResponse:
             "non-json-response"
@@ -36,7 +36,7 @@ public enum BiliAPIError: Error, Sendable, Equatable, CustomStringConvertible {
             "non-protobuf-response"
         case .decodingFailed:
             "decoding-failed"
-        case let .apiRejected(code, _):
+        case .apiRejected(let code, _):
             "api-rejected-\(code)"
         case .missingData:
             "missing-data"

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/BiliMediaURLPolicy.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/BiliMediaURLPolicy.swift
@@ -12,7 +12,7 @@ struct BiliMediaURLPolicy: Sendable {
 
     func allows(_ url: URL) -> Bool {
         guard publicHTTPSPolicy.allows(url),
-              let host = url.host?.lowercased()
+            let host = url.host?.lowercased()
         else {
             return false
         }

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/DanmakuPayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/DanmakuPayloads.swift
@@ -27,16 +27,17 @@ enum DanmakuPayloadDecoder {
             let text = element.content.trimmingCharacters(
                 in: .whitespacesAndNewlines
             )
-            let id = element.idString.isEmpty
+            let id =
+                element.idString.isEmpty
                 ? (element.id > 0 ? String(element.id) : nil)
                 : element.idString
             guard let id,
-                  id.count <= 128,
-                  element.progressMilliseconds >= 0,
-                  element.progressMilliseconds <= maximumTimeMilliseconds,
-                  !text.isEmpty,
-                  text.count <= maximumEventTextLength,
-                  element.colorRgb <= 0xFF_FF_FF
+                id.count <= 128,
+                element.progressMilliseconds >= 0,
+                element.progressMilliseconds <= maximumTimeMilliseconds,
+                !text.isEmpty,
+                text.count <= maximumEventTextLength,
+                element.colorRgb <= 0xFF_FF_FF
             else {
                 throw BiliAPIError.invalidDanmakuData
             }

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/EndpointPayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/EndpointPayloads.swift
@@ -13,8 +13,8 @@ private enum WebImageURL {
             normalized = value
         }
         guard let url = URL(string: normalized),
-              url.scheme?.lowercased() == "https",
-              url.host != nil
+            url.scheme?.lowercased() == "https",
+            url.host != nil
         else {
             return nil
         }
@@ -183,22 +183,26 @@ struct DASHRepresentationPayload: Decodable, Sendable {
         id = try container.decode(Int.self, forKey: .id)
         codecid = try container.decodeIfPresent(Int.self, forKey: .codecid)
         codecs = try container.decode(String.self, forKey: .codecs)
-        mimeType = try container.decodeIfPresent(String.self, forKey: .mimeType)
+        mimeType =
+            try container.decodeIfPresent(String.self, forKey: .mimeType)
             ?? container.decode(String.self, forKey: .mimeTypeCamel)
         bandwidth = try container.decodeIfPresent(Int.self, forKey: .bandwidth)
-        baseURL = try container.decodeIfPresent(String.self, forKey: .baseURL)
+        baseURL =
+            try container.decodeIfPresent(String.self, forKey: .baseURL)
             ?? container.decode(String.self, forKey: .baseURLCamel)
-        backupURLs = try container.decodeIfPresent(
-            [String].self,
-            forKey: .backupURLs
-        ) ?? container.decodeIfPresent(
-            [String].self,
-            forKey: .backupURLsCamel
-        ) ?? []
-        segmentBase = try container.decodeIfPresent(
-            DASHSegmentBasePayload.self,
-            forKey: .segmentBase
-        ) ?? container.decode(DASHSegmentBasePayload.self, forKey: .segmentBaseCamel)
+        backupURLs =
+            try container.decodeIfPresent(
+                [String].self,
+                forKey: .backupURLs
+            ) ?? container.decodeIfPresent(
+                [String].self,
+                forKey: .backupURLsCamel
+            ) ?? []
+        segmentBase =
+            try container.decodeIfPresent(
+                DASHSegmentBasePayload.self,
+                forKey: .segmentBase
+            ) ?? container.decode(DASHSegmentBasePayload.self, forKey: .segmentBaseCamel)
     }
 
     func model(kind: MediaKind) throws -> MediaRepresentation {
@@ -223,7 +227,7 @@ struct DASHRepresentationPayload: Decodable, Sendable {
 
     private static func validMediaURL(_ value: String) -> URL? {
         guard let url = URL(string: value),
-              BiliMediaURLPolicy().allows(url)
+            BiliMediaURLPolicy().allows(url)
         else {
             return nil
         }
@@ -244,7 +248,8 @@ struct DASHSegmentBasePayload: Decodable, Sendable {
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         initialization = try container.decode(String.self, forKey: .initialization)
-        indexRange = try container.decodeIfPresent(String.self, forKey: .indexRange)
+        indexRange =
+            try container.decodeIfPresent(String.self, forKey: .indexRange)
             ?? container.decode(String.self, forKey: .indexRangeCamel)
     }
 
@@ -266,8 +271,8 @@ struct DASHSegmentBasePayload: Decodable, Sendable {
             omittingEmptySubsequences: false
         )
         guard bounds.count == 2,
-              let start = Int64(bounds[0]),
-              let end = Int64(bounds[1])
+            let start = Int64(bounds[0]),
+            let end = Int64(bounds[1])
         else {
             throw BiliAPIError.invalidMediaData
         }
@@ -338,7 +343,7 @@ struct WatchHistoryCursorPayload: Codable, Sendable {
 
     init(_ continuation: WatchHistoryContinuation) throws {
         guard let data = Data(base64Encoded: continuation.rawValue),
-              let cursor = try? JSONDecoder().decode(Self.self, from: data)
+            let cursor = try? JSONDecoder().decode(Self.self, from: data)
         else {
             throw BiliAPIError.invalidRequest
         }
@@ -389,20 +394,21 @@ struct WatchHistoryItemPayload: Decodable, Sendable {
     func model() throws -> WatchHistoryItem? {
         guard history.business == "archive" else { return nil }
         guard let bvid = history.bvid,
-              bvid.hasPrefix("BV"),
-              bvid.count <= 24,
-              bvid.dropFirst(2).allSatisfy({
-                  $0.isASCII && ($0.isLetter || $0.isNumber)
-              }),
-              !title.isEmpty,
-              !authorName.isEmpty,
-              authorID >= 0,
-              viewedAt > 0,
-              duration >= 0
+            bvid.hasPrefix("BV"),
+            bvid.count <= 24,
+            bvid.dropFirst(2).allSatisfy({
+                $0.isASCII && ($0.isLetter || $0.isNumber)
+            }),
+            !title.isEmpty,
+            !authorName.isEmpty,
+            authorID >= 0,
+            viewedAt > 0,
+            duration >= 0
         else {
             throw BiliAPIError.decodingFailed
         }
-        let normalizedProgress = progress < 0
+        let normalizedProgress =
+            progress < 0
             ? duration
             : min(progress, duration)
         return WatchHistoryItem(
@@ -446,7 +452,8 @@ struct SearchPayload: Decodable, Sendable {
             throw BiliAPIError.decodingFailed
         }
         return SearchPage(
-            videos: try result
+            videos:
+                try result
                 .filter(\.hasUsableBVID)
                 .map { try $0.model() },
             pageNumber: page,

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/SubtitlePayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/SubtitlePayloads.swift
@@ -57,15 +57,16 @@ struct SubtitleTrackPayload: Decodable, Sendable {
         guard let subtitleURL = Self.nonempty(subtitleURL) else {
             return nil
         }
-        let id = stringID.flatMap(Self.nonempty)
+        let id =
+            stringID.flatMap(Self.nonempty)
             ?? numericID.map(String.init)
         guard let id,
-              id.count <= 128,
-              let languageCode = Self.nonempty(languageCode),
-              languageCode.count <= 64,
-              let displayName = Self.nonempty(displayName),
-              displayName.count <= 128,
-              let url = Self.url(subtitleURL)
+            id.count <= 128,
+            let languageCode = Self.nonempty(languageCode),
+            languageCode.count <= 64,
+            let displayName = Self.nonempty(displayName),
+            displayName.count <= 128,
+            let url = Self.url(subtitleURL)
         else {
             throw BiliAPIError.invalidSubtitleData
         }
@@ -132,12 +133,12 @@ struct SubtitleCuePayload: Decodable, Sendable {
     func cue() throws -> SubtitleCue {
         let text = content.trimmingCharacters(in: .whitespacesAndNewlines)
         guard startSeconds.isFinite,
-              endSeconds.isFinite,
-              startSeconds >= 0,
-              endSeconds > startSeconds,
-              endSeconds <= 86_400,
-              !text.isEmpty,
-              text.count <= 4_096
+            endSeconds.isFinite,
+            startSeconds >= 0,
+            endSeconds > startSeconds,
+            endSeconds <= 86_400,
+            !text.isEmpty,
+            text.count <= 4_096
         else {
             throw BiliAPIError.invalidSubtitleData
         }

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/SubtitleURLPolicy.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/SubtitleURLPolicy.swift
@@ -2,22 +2,23 @@ import Foundation
 
 struct SubtitleURLPolicy: Sendable {
     private let allowedHosts: Set<String> = [
-        "aisubtitle.hdslb.com",
+        "aisubtitle.hdslb.com"
     ]
 
     func allows(_ url: URL) -> Bool {
-        guard let components = URLComponents(
-            url: url,
-            resolvingAgainstBaseURL: false
-        ),
-              components.scheme?.lowercased() == "https",
-              let host = components.host?.lowercased(),
-              allowedHosts.contains(host),
-              components.port == nil || components.port == 443,
-              components.user == nil,
-              components.password == nil,
-              components.fragment == nil,
-              components.path.hasPrefix("/bfs/")
+        guard
+            let components = URLComponents(
+                url: url,
+                resolvingAgainstBaseURL: false
+            ),
+            components.scheme?.lowercased() == "https",
+            let host = components.host?.lowercased(),
+            allowedHosts.contains(host),
+            components.port == nil || components.port == 443,
+            components.user == nil,
+            components.password == nil,
+            components.fragment == nil,
+            components.path.hasPrefix("/bfs/")
         else {
             return false
         }

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/WBISigner.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/WBISigner.swift
@@ -63,9 +63,11 @@ struct WBISigner: Sendable {
     }
 
     private static func percentEncode(_ value: String) throws -> String {
-        guard let encoded = value.addingPercentEncoding(
-            withAllowedCharacters: unreservedCharacters
-        ) else {
+        guard
+            let encoded = value.addingPercentEncoding(
+                withAllowedCharacters: unreservedCharacters
+            )
+        else {
             throw BiliAPIError.signingFailed
         }
         return encoded

--- a/Packages/BiliKitCore/Sources/BiliAPIProbe/main.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPIProbe/main.swift
@@ -7,9 +7,9 @@ struct BiliAPIProbe {
     static func main() async {
         do {
             switch try Configuration(arguments: CommandLine.arguments).mode {
-            case let .search(keyword, page):
+            case .search(let keyword, let page):
                 try await runSearch(keyword: keyword, page: page)
-            case let .m4Contract(bvid, cid):
+            case .m4Contract(let bvid, let cid):
                 try await M4ContractProbe().run(bvid: bvid, cid: cid)
             }
             print("RESULT: PASS")
@@ -156,17 +156,19 @@ private struct M4ContractProbe {
         guard contentType(response).contains("json") else {
             throw ProbeError.unexpectedContentType
         }
-        guard let envelope = try JSONSerialization.jsonObject(
-            with: response.body
-        ) as? [String: Any],
-              envelope["code"] as? Int == 0,
-              let data = envelope["data"] as? [String: Any],
-              let subtitle = data["subtitle"] as? [String: Any],
-              let tracks = subtitle["subtitles"] as? [[String: Any]]
+        guard
+            let envelope = try JSONSerialization.jsonObject(
+                with: response.body
+            ) as? [String: Any],
+            envelope["code"] as? Int == 0,
+            let data = envelope["data"] as? [String: Any],
+            let subtitle = data["subtitle"] as? [String: Any],
+            let tracks = subtitle["subtitles"] as? [[String: Any]]
         else {
             throw ProbeError.invalidJSONShape
         }
-        let fields = tracks.first.map { $0.keys.sorted().joined(separator: ",") }
+        let fields =
+            tracks.first.map { $0.keys.sorted().joined(separator: ",") }
             ?? "none"
         let needsLogin = data["need_login_subtitle"] as? Bool ?? false
         print(
@@ -190,7 +192,7 @@ private struct M4ContractProbe {
             throw ProbeError.unexpectedContentType
         }
         guard (try? JSONSerialization.jsonObject(with: response.body)) == nil,
-              !looksLikeHTML(response.body)
+            !looksLikeHTML(response.body)
         else {
             throw ProbeError.unexpectedBodyClass
         }
@@ -235,11 +237,11 @@ private struct Configuration {
         if arguments.first == "--m4-contract" {
             let values = try Self.values(from: Array(arguments.dropFirst()))
             guard values.count == 2,
-                  let bvid = values["--bvid"],
-                  Self.isValidBVID(bvid),
-                  let rawCID = values["--cid"],
-                  let cid = Int64(rawCID),
-                  cid > 0
+                let bvid = values["--bvid"],
+                Self.isValidBVID(bvid),
+                let rawCID = values["--cid"],
+                let cid = Int64(rawCID),
+                cid > 0
             else {
                 throw ProbeError.invalidRequest
             }
@@ -249,12 +251,12 @@ private struct Configuration {
 
         let values = try Self.values(from: arguments)
         guard values.count <= 2,
-              let keyword = values["--search"]?.trimmingCharacters(
-                  in: .whitespacesAndNewlines
-              ),
-              !keyword.isEmpty,
-              let page = Int(values["--page"] ?? "1"),
-              page > 0
+            let keyword = values["--search"]?.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            ),
+            !keyword.isEmpty,
+            let page = Int(values["--page"] ?? "1"),
+            page > 0
         else {
             throw ProbeError.invalidRequest
         }

--- a/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuContracts.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuContracts.swift
@@ -29,8 +29,8 @@ public struct DanmakuSegmentUseCase: Sendable {
         for identity: PlaybackItemIdentity
     ) async throws -> DanmakuSegment {
         guard (1...Self.maximumSegmentIndex).contains(index),
-              !identity.bvid.isEmpty,
-              identity.cid > 0
+            !identity.bvid.isEmpty,
+            identity.cid > 0
         else {
             throw DanmakuApplicationError.invalidRequest
         }

--- a/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestFeedUseCase.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestFeedUseCase.swift
@@ -20,18 +20,18 @@ public struct GuestFeedUseCase: Sendable {
 
     public func execute(_ request: GuestFeedRequest) async throws -> GuestFeedContent {
         switch request {
-        case let .popular(page, pageSize):
+        case .popular(let page, let pageSize):
             guard page > 0, (1...50).contains(pageSize) else {
                 throw GuestApplicationError.invalidRequest
             }
             return .popular(
                 try await repository.popular(page: page, pageSize: pageSize)
             )
-        case let .search(query, page):
+        case .search(let query, let page):
             let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !normalizedQuery.isEmpty,
-                  normalizedQuery.count <= 100,
-                  page > 0
+                normalizedQuery.count <= 100,
+                page > 0
             else {
                 throw GuestApplicationError.invalidRequest
             }

--- a/Packages/BiliKitCore/Sources/BiliApplication/History/WatchHistoryContracts.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/History/WatchHistoryContracts.swift
@@ -8,7 +8,9 @@ public enum WatchHistoryError: Error, Sendable, Equatable {
     case invalidResponse
 }
 
-/// API adapter 生成并消费的不透明分页令牌。Presentation 与 Use Case 只能保存和回传，
+/// API adapter 生成并消费的不透明分页令牌。
+///
+/// Presentation 与 Use Case 只能保存和回传，
 /// 不知道远端 cursor 的字段或编码。
 public struct WatchHistoryContinuation: Sendable, Equatable {
     package let rawValue: String

--- a/Packages/BiliKitCore/Sources/BiliApplication/History/WatchHistoryUseCase.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/History/WatchHistoryUseCase.swift
@@ -29,7 +29,7 @@ public struct WatchHistoryUseCase: Sendable {
                 pageSize: pageSize
             )
             guard page.items.isEmpty,
-                  let nextContinuation = page.continuation
+                let nextContinuation = page.continuation
             else {
                 return page
             }

--- a/Packages/BiliKitCore/Sources/BiliApplication/Playback/PlaybackTimeline.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Playback/PlaybackTimeline.swift
@@ -92,14 +92,14 @@ package final class PlaybackTimelineStore {
     package var subscriberCount: Int { continuations.count }
 
     private var currentToken: PlaybackTimelineItemToken?
-    private var continuations: [
-        UUID: AsyncStream<PlaybackTimelineSnapshot>.Continuation
-    ] = [:]
+    private var continuations: [UUID: AsyncStream<PlaybackTimelineSnapshot>.Continuation] = [:]
 
     package init() {}
 
     deinit {
-        continuations.values.forEach { $0.finish() }
+        for continuation in continuations.values {
+            continuation.finish()
+        }
     }
 
     package func updates() -> AsyncStream<PlaybackTimelineSnapshot> {
@@ -221,6 +221,8 @@ package final class PlaybackTimelineStore {
     private func publish(_ snapshot: PlaybackTimelineSnapshot) {
         guard snapshot != currentSnapshot else { return }
         currentSnapshot = snapshot
-        continuations.values.forEach { $0.yield(snapshot) }
+        for continuation in continuations.values {
+            continuation.yield(snapshot)
+        }
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliAuth/Application/BiliAuthenticationService.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/Application/BiliAuthenticationService.swift
@@ -198,10 +198,10 @@ public actor BiliAuthenticationService: AuthenticationServicing {
         case .requestingQRCode:
             qrCode = nil
             return .requestingQRCode
-        case let .awaitingScan(code):
+        case .awaitingScan(let code):
             qrCode = code
             return .awaitingScan
-        case let .awaitingConfirmation(code):
+        case .awaitingConfirmation(let code):
             qrCode = code
             return .awaitingConfirmation
         case .awaitingCredentialValidation:
@@ -210,7 +210,7 @@ public actor BiliAuthenticationService: AuthenticationServicing {
         case .expired:
             qrCode = nil
             return .expired
-        case let .failed(failure):
+        case .failed(let failure):
             qrCode = nil
             return .failed(Self.map(failure))
         }
@@ -225,7 +225,7 @@ public actor BiliAuthenticationService: AuthenticationServicing {
         case .serviceRejected:
             .serviceUnavailable
         case .noActiveChallenge, .responseTooLarge, .nonJSONResponse,
-             .invalidResponse, .incompleteCredential, .unsupportedStatus:
+            .invalidResponse, .incompleteCredential, .unsupportedStatus:
             .invalidResponse
         }
     }
@@ -239,7 +239,7 @@ public actor BiliAuthenticationService: AuthenticationServicing {
         case .credentialStoreUnavailable:
             .credentialUnavailable
         case .requestNotAllowed, .credentialHeaderAlreadyPresent,
-             .missingCredential, .expiredCredential, .invalidCredential:
+            .missingCredential, .expiredCredential, .invalidCredential:
             .invalidResponse
         }
     }

--- a/Packages/BiliKitCore/Sources/BiliAuth/Credential/BiliCredentialRequestAuthorizer.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/Credential/BiliCredentialRequestAuthorizer.swift
@@ -13,6 +13,16 @@ public enum BiliRequestAuthorizationError: Error, Sendable, Equatable {
 
 public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable {
     private static let maximumResponseSize = 256 * 1_024
+    private static let navigationValidationURL: URL = {
+        guard
+            let url = URL(
+                string: "https://api.bilibili.com/x/web-interface/nav"
+            )
+        else {
+            preconditionFailure("Static navigation validation URL must be valid")
+        }
+        return url
+    }()
 
     private let store: any WebCredentialStoring
     private let httpClient: HTTPClient
@@ -42,9 +52,11 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
         guard Self.isAllowed(request) else {
             throw BiliRequestAuthorizationError.requestNotAllowed
         }
-        guard !request.headers.keys.contains(where: {
-            $0.caseInsensitiveCompare("Cookie") == .orderedSame
-        }) else {
+        guard
+            !request.headers.keys.contains(where: {
+                $0.caseInsensitiveCompare("Cookie") == .orderedSame
+            })
+        else {
             throw BiliRequestAuthorizationError.credentialHeaderAlreadyPresent
         }
 
@@ -92,9 +104,7 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
 
     public func restoreLoginState() async throws -> Bool {
         let request = HTTPRequest(
-            url: URL(
-                string: "https://api.bilibili.com/x/web-interface/nav"
-            )!,
+            url: Self.navigationValidationURL,
             headers: [
                 "Accept": "application/json",
                 "Referer": "https://www.bilibili.com/",
@@ -105,8 +115,9 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
         do {
             authorized = try await authorize(request)
         } catch BiliRequestAuthorizationError.missingCredential,
-                BiliRequestAuthorizationError.expiredCredential,
-                BiliRequestAuthorizationError.invalidCredential {
+            BiliRequestAuthorizationError.expiredCredential,
+            BiliRequestAuthorizationError.invalidCredential
+        {
             return false
         }
 
@@ -119,13 +130,13 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
             throw BiliRequestAuthorizationError.validationUnavailable
         }
         guard response.body.count <= Self.maximumResponseSize,
-              Self.looksLikeJSON(response),
-              let envelope = try? JSONDecoder().decode(
-                  NavigationEnvelope.self,
-                  from: response.body
-              ),
-              envelope.code == 0,
-              let data = envelope.data
+            Self.looksLikeJSON(response),
+            let envelope = try? JSONDecoder().decode(
+                NavigationEnvelope.self,
+                from: response.body
+            ),
+            envelope.code == 0,
+            let data = envelope.data
         else {
             throw BiliRequestAuthorizationError.validationUnavailable
         }
@@ -137,19 +148,22 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
     }
 
     private static func isAllowed(_ request: HTTPRequest) -> Bool {
-        guard let components = URLComponents(
-            url: request.url,
-            resolvingAgainstBaseURL: false
-        ) else {
+        guard
+            let components = URLComponents(
+                url: request.url,
+                resolvingAgainstBaseURL: false
+            )
+        else {
             return false
         }
-        guard components.scheme?.lowercased() == "https"
-            && components.host?.lowercased() == "api.bilibili.com"
-            && (components.port == nil || components.port == 443)
-            && components.user == nil
-            && components.password == nil
-            && components.fragment == nil
-            && request.method == .get
+        guard
+            components.scheme?.lowercased() == "https"
+                && components.host?.lowercased() == "api.bilibili.com"
+                && (components.port == nil || components.port == 443)
+                && components.user == nil
+                && components.password == nil
+                && components.fragment == nil
+                && request.method == .get
         else {
             return false
         }
@@ -176,15 +190,15 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
             }
         }
         guard values.count == 2,
-              Set(values.keys) == ["bvid", "cid"],
-              let bvid = values["bvid"],
-              bvid.count == 12,
-              bvid.hasPrefix("BV"),
-              bvid.allSatisfy({
-                  $0.isASCII && ($0.isLetter || $0.isNumber)
-              }),
-              let cid = values["cid"].flatMap(Int64.init),
-              cid > 0
+            Set(values.keys) == ["bvid", "cid"],
+            let bvid = values["bvid"],
+            bvid.count == 12,
+            bvid.hasPrefix("BV"),
+            bvid.allSatisfy({
+                $0.isASCII && ($0.isLetter || $0.isNumber)
+            }),
+            let cid = values["cid"].flatMap(Int64.init),
+            cid > 0
         else {
             return false
         }
@@ -202,16 +216,16 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
             }
         }
         guard values.count == 4,
-              Set(values.keys) == ["max", "view_at", "business", "ps"],
-              let maximum = values["max"].flatMap(Int64.init),
-              let viewedAt = values["view_at"].flatMap(Int64.init),
-              let pageSize = values["ps"].flatMap(Int.init),
-              maximum >= 0,
-              viewedAt >= 0,
-              (1...50).contains(pageSize),
-              let business = values["business"],
-              business.count <= 64,
-              business.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber) })
+            Set(values.keys) == ["max", "view_at", "business", "ps"],
+            let maximum = values["max"].flatMap(Int64.init),
+            let viewedAt = values["view_at"].flatMap(Int64.init),
+            let pageSize = values["ps"].flatMap(Int.init),
+            maximum >= 0,
+            viewedAt >= 0,
+            (1...50).contains(pageSize),
+            let business = values["business"],
+            business.count <= 64,
+            business.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber) })
         else {
             return false
         }
@@ -230,12 +244,15 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
         if let contentType = response.headers.first(where: {
             $0.key.caseInsensitiveCompare("Content-Type") == .orderedSame
         })?.value.lowercased(),
-           !contentType.contains("json") {
+            !contentType.contains("json")
+        {
             return false
         }
-        guard let firstByte = response.body.first(where: {
-            ![9, 10, 13, 32].contains($0)
-        }) else {
+        guard
+            let firstByte = response.body.first(where: {
+                ![9, 10, 13, 32].contains($0)
+            })
+        else {
             return false
         }
         return firstByte == 0x7B

--- a/Packages/BiliKitCore/Sources/BiliAuth/Credential/WebCredential.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/Credential/WebCredential.swift
@@ -35,8 +35,8 @@ struct WebCredential: Sendable, Equatable,
         let expectedNames = Set(WebCredentialCookieName.allCases)
         let actualNames = Set(cookies.map(\.name))
         guard cookies.count == expectedNames.count,
-              actualNames == expectedNames,
-              cookies.allSatisfy(Self.isStructurallyValid)
+            actualNames == expectedNames,
+            cookies.allSatisfy(Self.isStructurallyValid)
         else {
             throw WebCredentialCodingError.invalidCredential
         }

--- a/Packages/BiliKitCore/Sources/BiliAuth/Credential/WebCredentialStore.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/Credential/WebCredentialStore.swift
@@ -102,7 +102,7 @@ struct KeychainWebCredentialStore: WebCredentialStoring, Sendable {
             throw WebCredentialStoreError.interactionNotAllowed
         }
         guard status != errSecMissingEntitlement,
-              status != errSecNotAvailable
+            status != errSecNotAvailable
         else {
             throw WebCredentialStoreError.unavailable
         }

--- a/Packages/BiliKitCore/Sources/BiliAuth/WebQR/WebQRCode.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/WebQR/WebQRCode.swift
@@ -49,7 +49,6 @@ public struct WebQRCode: Sendable, Equatable, CustomStringConvertible,
         }
         return image
     }
-
 }
 
 public enum WebQRCodeRenderingError: Error, Sendable, Equatable {

--- a/Packages/BiliKitCore/Sources/BiliAuth/WebQR/WebQRLoginSession.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/WebQR/WebQRLoginSession.swift
@@ -2,9 +2,22 @@ import BiliNetworking
 import Foundation
 
 public actor WebQRLoginSession {
-    public static let productionBaseURL = URL(
-        string: "https://passport.bilibili.com"
-    )!
+    public static let productionBaseURL: URL = {
+        guard let url = URL(string: "https://passport.bilibili.com") else {
+            preconditionFailure("Static Web QR base URL must be valid")
+        }
+        return url
+    }()
+    private static let navigationValidationURL: URL = {
+        guard
+            let url = URL(
+                string: "https://api.bilibili.com/x/web-interface/nav"
+            )
+        else {
+            preconditionFailure("Static navigation validation URL must be valid")
+        }
+        return url
+    }()
 
     private static let qrCodeHost = "account.bilibili.com"
     private static let maximumResponseSize = 256 * 1_024
@@ -71,8 +84,8 @@ public actor WebQRLoginSession {
                 )
             }
             guard let data = envelope.data,
-                  Self.isValidQRCodeKey(data.qrcodeKey),
-                  Self.isValidQRCodeURL(data.url)
+                Self.isValidQRCodeKey(data.qrcodeKey),
+                Self.isValidQRCodeURL(data.url)
             else {
                 return fail(.invalidResponse, generation: operationGeneration)
             }
@@ -100,7 +113,7 @@ public actor WebQRLoginSession {
     @discardableResult
     public func pollOnce() async throws -> WebQRLoginState {
         guard let challenge = activeChallenge,
-              challenge.generation == generation
+            challenge.generation == generation
         else {
             state = .failed(.noActiveChallenge)
             return state
@@ -113,7 +126,7 @@ public actor WebQRLoginSession {
             let response = try await send(
                 path: "/x/passport-login/web/qrcode/poll",
                 queryItems: [
-                    URLQueryItem(name: "qrcode_key", value: challenge.key),
+                    URLQueryItem(name: "qrcode_key", value: challenge.key)
                 ]
             )
             try Task.checkCancellation()
@@ -264,7 +277,7 @@ public actor WebQRLoginSession {
             throw CancellationError()
         } catch let error as HTTPClientError {
             switch error {
-            case let .unacceptableStatusCode(status):
+            case .unacceptableStatusCode(let status):
                 throw WebQRLoginFailure.httpStatus(status)
             case .nonHTTPResponse:
                 throw WebQRLoginFailure.network
@@ -286,10 +299,12 @@ public actor WebQRLoginSession {
         path: String,
         queryItems: [URLQueryItem]
     ) throws -> URL {
-        guard var components = URLComponents(
-            url: baseURL,
-            resolvingAgainstBaseURL: false
-        ) else {
+        guard
+            var components = URLComponents(
+                url: baseURL,
+                resolvingAgainstBaseURL: false
+            )
+        else {
             throw WebQRLoginFailure.invalidResponse
         }
         components.path = path
@@ -303,14 +318,11 @@ public actor WebQRLoginSession {
     private func sendNavigationValidation(
         cookieHeader: String
     ) async throws -> HTTPResponse {
-        let url = URL(
-            string: "https://api.bilibili.com/x/web-interface/nav"
-        )!
         let response: HTTPResponse
         do {
             response = try await httpClient.send(
                 HTTPRequest(
-                    url: url,
+                    url: Self.navigationValidationURL,
                     headers: [
                         "Accept": "application/json",
                         "Cookie": cookieHeader,
@@ -323,7 +335,7 @@ public actor WebQRLoginSession {
             throw CancellationError()
         } catch let error as HTTPClientError {
             switch error {
-            case let .unacceptableStatusCode(status):
+            case .unacceptableStatusCode(let status):
                 throw WebQRLoginFailure.httpStatus(status)
             case .nonHTTPResponse:
                 throw WebQRLoginFailure.network
@@ -351,7 +363,7 @@ public actor WebQRLoginSession {
         pollID expectedPollID: UInt64
     ) throws {
         guard generation == expectedGeneration,
-              latestPollID == expectedPollID
+            latestPollID == expectedPollID
         else {
             throw StaleOperationError()
         }
@@ -391,12 +403,15 @@ public actor WebQRLoginSession {
         if let contentType = response.headers.first(where: {
             $0.key.caseInsensitiveCompare("Content-Type") == .orderedSame
         })?.value.lowercased(),
-           !contentType.contains("json") {
+            !contentType.contains("json")
+        {
             return false
         }
-        guard let firstByte = response.body.first(where: {
-            ![9, 10, 13, 32].contains($0)
-        }) else {
+        guard
+            let firstByte = response.body.first(where: {
+                ![9, 10, 13, 32].contains($0)
+            })
+        else {
             return false
         }
         return firstByte == 0x7B
@@ -458,13 +473,13 @@ public actor WebQRLoginSession {
             for: productionBaseURL
         ).filter { allowedNames.contains($0.name) }
         guard cookies.count == allowedNames.count,
-              Set(cookies.map(\.name)) == allowedNames
+            Set(cookies.map(\.name)) == allowedNames
         else {
             return nil
         }
         let credentialCookies: [WebCredentialCookie] = cookies.compactMap { cookie in
             guard let name = WebCredentialCookieName(rawValue: cookie.name),
-                  let expiresAt = cookie.expiresDate
+                let expiresAt = cookie.expiresDate
             else {
                 return nil
             }

--- a/Packages/BiliKitCore/Sources/BiliAuth/WebQR/WebQRLoginState.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/WebQR/WebQRLoginState.swift
@@ -21,7 +21,7 @@ public enum WebQRLoginState: Sendable, Equatable, CustomStringConvertible {
             "awaiting-credential-validation"
         case .expired:
             "expired"
-        case let .failed(failure):
+        case .failed(let failure):
             "failed-\(failure.description)"
         }
     }
@@ -45,7 +45,7 @@ public enum WebQRLoginFailure: Error, Sendable, Equatable, CustomStringConvertib
             "no-active-challenge"
         case .network:
             "network"
-        case let .httpStatus(status):
+        case .httpStatus(let status):
             "http-status-\(status)"
         case .responseTooLarge:
             "response-too-large"
@@ -57,9 +57,9 @@ public enum WebQRLoginFailure: Error, Sendable, Equatable, CustomStringConvertib
             "incomplete-credential"
         case .credentialStoreUnavailable:
             "credential-store-unavailable"
-        case let .serviceRejected(code):
+        case .serviceRejected(let code):
             "service-rejected-\(code)"
-        case let .unsupportedStatus(observation):
+        case .unsupportedStatus(let observation):
             "unsupported-status-\(observation.code)"
         }
     }

--- a/Packages/BiliKitCore/Sources/BiliAuthFeature/Authentication/AuthenticationView.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuthFeature/Authentication/AuthenticationView.swift
@@ -77,7 +77,7 @@ public struct AuthenticationView: View {
                 systemImage: "clock.badge.exclamationmark",
                 detail: "请重新生成二维码。"
             )
-        case let .failed(failure):
+        case .failed(let failure):
             terminalContent(
                 title: "登录未完成",
                 systemImage: "exclamationmark.triangle",
@@ -105,12 +105,12 @@ public struct AuthenticationView: View {
                     orientation: .up,
                     label: Text("哔哩哔哩登录二维码")
                 )
-                    .interpolation(.none)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 240, height: 240)
-                    .accessibilityHint("使用手机客户端扫描")
-                    .accessibilityIdentifier("auth.qr-code")
+                .interpolation(.none)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 240, height: 240)
+                .accessibilityHint("使用手机客户端扫描")
+                .accessibilityIdentifier("auth.qr-code")
             } else {
                 ProgressView()
                     .frame(width: 240, height: 240)

--- a/Packages/BiliKitCore/Sources/BiliAuthFeature/Authentication/AuthenticationViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuthFeature/Authentication/AuthenticationViewModel.swift
@@ -29,8 +29,7 @@ public final class AuthenticationViewModel {
     }
 
     @ObservationIgnored private let service: any AuthenticationServicing
-    @ObservationIgnored private let qrCodeProvider:
-        any AuthenticationQRCodeProviding
+    @ObservationIgnored private let qrCodeProvider: any AuthenticationQRCodeProviding
     @ObservationIgnored private let pollInterval: Duration
     @ObservationIgnored private let pollTimeout: Duration
     @ObservationIgnored private let maximumPollAttempts: Int
@@ -136,7 +135,7 @@ public final class AuthenticationViewModel {
     public func cancelTransientWork() {
         switch state {
         case .restoring, .requestingQRCode, .awaitingScan, .awaitingConfirmation,
-             .finalizing, .expired:
+            .finalizing, .expired:
             cancelLogin()
         case .failed:
             if retryAction == .login {
@@ -161,7 +160,8 @@ public final class AuthenticationViewModel {
         task = nil
         state = initialState
         if initialState != .awaitingScan,
-           initialState != .awaitingConfirmation {
+            initialState != .awaitingConfirmation
+        {
             qrCodeImage = nil
         }
         task = Task { [weak self] in
@@ -177,7 +177,8 @@ public final class AuthenticationViewModel {
         var attempts = 0
 
         while generation == operationGeneration,
-              state == .awaitingScan || state == .awaitingConfirmation {
+            state == .awaitingScan || state == .awaitingConfirmation
+        {
             if attempts >= maximumPollAttempts || clock.now >= deadline {
                 await expireLocalChallenge(generation: operationGeneration)
                 return

--- a/Packages/BiliKitCore/Sources/BiliAuthProbe/main.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuthProbe/main.swift
@@ -64,7 +64,7 @@ private final class ProbeAppDelegate: NSObject, NSApplicationDelegate, NSWindowD
         print("state=requesting-qr-code")
         do {
             let initialState = try await session.requestQRCode()
-            guard case let .awaitingScan(qrCode) = initialState else {
+            guard case .awaitingScan(let qrCode) = initialState else {
                 await finish(with: initialState, exitCode: EXIT_FAILURE)
                 return
             }
@@ -103,7 +103,7 @@ private final class ProbeAppDelegate: NSObject, NSApplicationDelegate, NSWindowD
                         reportedAwaitingConfirmation = true
                     }
                     continue
-                case let .awaitingCredentialValidation(observation):
+                case .awaitingCredentialValidation(let observation):
                     print("state=awaiting-credential-validation")
                     printObservation(observation)
                     let isLoggedIn = try await session.validatePendingCredential()
@@ -185,7 +185,7 @@ private final class ProbeAppDelegate: NSObject, NSApplicationDelegate, NSWindowD
 
     private func finish(with state: WebQRLoginState, exitCode: Int32) async {
         print("state=\(state.description)")
-        if case let .failed(.unsupportedStatus(observation)) = state {
+        if case .failed(.unsupportedStatus(let observation)) = state {
             printObservation(observation)
         }
         await session.cancel()

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/BrowseScene/BrowseFailureView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/BrowseScene/BrowseFailureView.swift
@@ -22,7 +22,7 @@ struct BrowseFailureView: View {
 extension GuestFlowFailure {
     var title: String {
         switch self {
-        case let .content(error):
+        case .content(let error):
             error.guestTitle
         case .playback:
             "无法准备播放"
@@ -31,7 +31,7 @@ extension GuestFlowFailure {
 
     var message: String {
         switch self {
-        case let .content(error):
+        case .content(let error):
             error.guestMessage
         case .playback:
             "当前媒体轨道或网络响应无法交给系统播放器。"
@@ -57,7 +57,7 @@ extension GuestApplicationError {
             "请求参数无效，请重新选择内容。"
         case .requestRestricted:
             "服务可能返回了风控页，请降低请求频率后重试。"
-        case let .serviceRejected(code):
+        case .serviceRejected(let code):
             "服务暂时无法完成请求（代码 \(code)）。"
         case .transportFailure:
             "请检查网络连接后重试。"

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/Feed/GuestFeedViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/Feed/GuestFeedViewModel.swift
@@ -30,8 +30,8 @@ public final class GuestFeedViewModel {
         let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
         let request = GuestFeedRequest.search(query: normalizedQuery, page: page)
         guard !normalizedQuery.isEmpty,
-              normalizedQuery.count <= 100,
-              page > 0
+            normalizedQuery.count <= 100,
+            page > 0
         else {
             fail(request: request, error: .invalidRequest)
             return
@@ -40,7 +40,7 @@ public final class GuestFeedViewModel {
     }
 
     public func retry() {
-        guard case let .failed(request, _) = state else { return }
+        guard case .failed(let request, _) = state else { return }
         load(request)
     }
 

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/Feed/GuestVideoCard.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/Feed/GuestVideoCard.swift
@@ -83,11 +83,11 @@ struct GuestVideoCard: View {
         height: Int
     ) -> URL? {
         guard let url,
-              let host = url.host?.lowercased(),
-              host == "hdslb.com" || host.hasSuffix(".hdslb.com"),
-              url.query == nil,
-              url.fragment == nil,
-              !url.path.contains("@")
+            let host = url.host?.lowercased(),
+            host == "hdslb.com" || host.hasSuffix(".hdslb.com"),
+            url.query == nil,
+            url.fragment == nil,
+            !url.path.contains("@")
         else {
             return url
         }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/Feed/PopularFeedView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/Feed/PopularFeedView.swift
@@ -23,14 +23,14 @@ public struct PopularFeedView: View {
             ProgressView("正在加载热门视频…")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .accessibilityIdentifier("feed.loading")
-        case let .loaded(.popular(page)) where page.videos.isEmpty:
+        case .loaded(.popular(let page)) where page.videos.isEmpty:
             ContentUnavailableView(
                 "暂无热门视频",
                 systemImage: "rectangle.stack",
                 description: Text("稍后重试或检查网络连接。")
             )
             .accessibilityIdentifier("feed.empty")
-        case let .loaded(.popular(page)):
+        case .loaded(.popular(let page)):
             GeometryReader { geometry in
                 ScrollView {
                     LazyVGrid(
@@ -69,7 +69,7 @@ public struct PopularFeedView: View {
                     await model.waitForCurrentTask()
                 }
             }
-        case let .failed(request: .popular(_, _), error: error):
+        case .failed(request: .popular(_, _), let error):
             BrowseFailureView(
                 title: error.guestTitle,
                 message: error.guestMessage,

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/Formatting/VideoMetadataFormatting.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/Formatting/VideoMetadataFormatting.swift
@@ -26,11 +26,12 @@ enum VideoMetadataFormatting {
         calendar: Calendar = .current
     ) -> String {
         if calendar.isDate(date, inSameDayAs: now) {
-            let elapsedHours = calendar.dateComponents(
-                [.hour],
-                from: date,
-                to: now
-            ).hour ?? 0
+            let elapsedHours =
+                calendar.dateComponents(
+                    [.hour],
+                    from: date,
+                    to: now
+                ).hour ?? 0
             return "\(max(1, elapsedHours))小时前"
         }
 
@@ -39,7 +40,7 @@ enum VideoMetadataFormatting {
             value: -1,
             to: now
         ),
-           calendar.isDate(date, inSameDayAs: yesterday)
+            calendar.isDate(date, inSameDayAs: yesterday)
         {
             return "昨天"
         }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/Search/VideoSearchView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/Search/VideoSearchView.swift
@@ -23,14 +23,14 @@ public struct VideoSearchView: View {
     @ViewBuilder
     private var results: some View {
         switch model.state {
-        case let .loading(.search(query, _)):
+        case .loading(.search(let query, _)):
             ProgressView("正在搜索“\(query)”…")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .accessibilityIdentifier("search.loading")
-        case let .loaded(.search(query, page)) where page.videos.isEmpty:
+        case .loaded(.search(let query, let page)) where page.videos.isEmpty:
             ContentUnavailableView.search(text: query)
                 .accessibilityIdentifier("search.empty")
-        case let .loaded(.search(query, page)):
+        case .loaded(.search(let query, let page)):
             VStack(spacing: 0) {
                 HStack {
                     Text("“\(query)”")
@@ -82,7 +82,7 @@ public struct VideoSearchView: View {
                 }
             }
             .accessibilityIdentifier("search.results")
-        case let .failed(request: .search(_, _), error: error):
+        case .failed(request: .search(_, _), let error):
             BrowseFailureView(
                 title: error.guestTitle,
                 message: error.guestMessage,
@@ -98,5 +98,4 @@ public struct VideoSearchView: View {
             .accessibilityIdentifier("search.prompt")
         }
     }
-
 }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Subtitle/SubtitleControlsView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Subtitle/SubtitleControlsView.swift
@@ -19,7 +19,7 @@ struct SubtitleControlsView: View {
             case .unavailable:
                 Text("此视频没有可用字幕")
                     .foregroundStyle(.secondary)
-            case let .failed(_, failure):
+            case .failed(_, let failure):
                 Text(failure.message)
                     .foregroundStyle(.secondary)
                 Button("重试", action: model.retry)
@@ -51,8 +51,8 @@ struct SubtitleControlsView: View {
     }
 }
 
-private extension SubtitleFailure {
-    var message: String {
+extension SubtitleFailure {
+    fileprivate var message: String {
         switch self {
         case .authenticationRequired:
             "登录后可查看字幕"
@@ -66,8 +66,8 @@ private extension SubtitleFailure {
     }
 }
 
-private extension SubtitleTrack {
-    var label: String {
+extension SubtitleTrack {
+    fileprivate var label: String {
         switch kind {
         case .standard:
             displayName

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Subtitle/SubtitleViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Subtitle/SubtitleViewModel.swift
@@ -164,7 +164,7 @@ public final class SubtitleViewModel {
             let tracks = try await useCase.tracks(for: identity)
             try Task.checkCancellation()
             guard self.identity == identity,
-                  contentGeneration == generation
+                contentGeneration == generation
             else { return }
             self.tracks = tracks
             guard let firstTrack = tracks.first else {
@@ -200,8 +200,8 @@ public final class SubtitleViewModel {
             )
             try Task.checkCancellation()
             guard self.identity == identity,
-                  selectedTrackID == trackID,
-                  contentGeneration == generation
+                selectedTrackID == trackID,
+                contentGeneration == generation
             else { return }
             self.cues = cues
             updateCurrentCue(positionSeconds: latestPositionSeconds)
@@ -317,7 +317,7 @@ public final class SubtitleViewModel {
         generation: Int
     ) {
         guard self.identity == identity,
-              contentGeneration == generation
+            contentGeneration == generation
         else { return }
         cues = []
         currentCueText = nil

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoDetailColumn.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoDetailColumn.swift
@@ -36,7 +36,7 @@ public struct VideoDetailColumn<PlayerContent: View>: View {
             case .loading:
                 ProgressView("正在加载视频详情…")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-            case let .preparingPlayback(context):
+            case .preparingPlayback(let context):
                 GuestVideoDetailView(
                     context: context,
                     isPreparingPlayback: true,
@@ -44,7 +44,7 @@ public struct VideoDetailColumn<PlayerContent: View>: View {
                     danmakuModel: danmakuModel,
                     playerContent: playerContent
                 )
-            case let .ready(context):
+            case .ready(let context):
                 GuestVideoDetailView(
                     context: context,
                     isPreparingPlayback: false,
@@ -52,7 +52,7 @@ public struct VideoDetailColumn<PlayerContent: View>: View {
                     danmakuModel: danmakuModel,
                     playerContent: playerContent
                 )
-            case let .failed(_, failure):
+            case .failed(_, let failure):
                 BrowseFailureView(
                     title: failure.title,
                     message: failure.message,
@@ -73,7 +73,7 @@ public struct VideoDetailColumn<PlayerContent: View>: View {
 
     private var playbackIdentity: PlaybackItemIdentity? {
         switch model.state {
-        case let .preparingPlayback(context), let .ready(context):
+        case .preparingPlayback(let context), .ready(let context):
             PlaybackItemIdentity(
                 bvid: context.detail.bvid,
                 cid: context.selectedPage.cid

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuRenderer.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuRenderer.swift
@@ -47,7 +47,7 @@ public final class CoreAnimationDanmakuRenderer:
 
     public func measure(_ event: DanmakuEvent) -> DanmakuTextMetrics {
         guard !event.text.isEmpty,
-              event.text.utf16.count <= Self.maximumTextUTF16Length
+            event.text.utf16.count <= Self.maximumTextUTF16Length
         else {
             return DanmakuTextMetrics(width: 0, height: 0)
         }
@@ -66,11 +66,11 @@ public final class CoreAnimationDanmakuRenderer:
         let widthPixels = ceil(measured.width * contentsScale) + 8
         let heightPixels = ceil(measured.height * contentsScale) + 8
         guard widthPixels.isFinite,
-              heightPixels.isFinite,
-              widthPixels > 0,
-              heightPixels > 0,
-              widthPixels <= Self.maximumTextWidthPixels,
-              heightPixels <= Self.maximumTextHeightPixels
+            heightPixels.isFinite,
+            widthPixels > 0,
+            heightPixels > 0,
+            widthPixels <= Self.maximumTextWidthPixels,
+            heightPixels <= Self.maximumTextHeightPixels
         else {
             return DanmakuTextMetrics(width: 0, height: 0)
         }
@@ -83,10 +83,10 @@ public final class CoreAnimationDanmakuRenderer:
     public func render(_ placement: DanmakuLanePlacement) {
         let event = placement.request.event
         guard entries[event.id] == nil,
-              entries.count
+            entries.count
                 < DanmakuLaneConfiguration.hardMaximumActiveCount,
-              surfaceSize.width > 0,
-              surfaceSize.height > 0
+            surfaceSize.width > 0,
+            surfaceSize.height > 0
         else {
             return
         }
@@ -134,7 +134,8 @@ public final class CoreAnimationDanmakuRenderer:
         let newRate = rate.isFinite ? max(rate, 0) : 0
         guard Double(rootLayer.speed) != newRate else { return }
         let mediaTime = CACurrentMediaTime()
-        let parentTime = rootLayer.superlayer?
+        let parentTime =
+            rootLayer.superlayer?
             .convertTime(mediaTime, from: nil)
             ?? mediaTime
         let localTime = rootLayer.convertTime(mediaTime, from: nil)
@@ -176,8 +177,8 @@ public final class CoreAnimationDanmakuRenderer:
         renderEpoch completionEpoch: UInt64
     ) {
         guard completionEpoch == renderEpoch,
-              let entry = entries[eventID],
-              entry.objectIdentity == objectIdentity
+            let entry = entries[eventID],
+            entry.objectIdentity == objectIdentity
         else {
             return
         }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneAllocator.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneAllocator.swift
@@ -87,9 +87,9 @@ public struct DanmakuLaneAllocator: Sendable {
         for request in requests {
             let result = admit(request, at: playbackTime)
             switch result {
-            case let .success(placement):
+            case .success(let placement):
                 admitted.append(placement)
-            case let .failure(reason):
+            case .failure(let reason):
                 dropCounts.record(reason)
             }
         }
@@ -105,9 +105,9 @@ public struct DanmakuLaneAllocator: Sendable {
         at playbackTime: Double
     ) -> Result<DanmakuLanePlacement, DanmakuLaneDropReason> {
         guard configuration.isValid,
-              request.isValid,
-              request.height <= configuration.laneHeight,
-              active[request.event.id] == nil
+            request.isValid,
+            request.height <= configuration.laneHeight,
+            active[request.event.id] == nil
         else {
             return .failure(.invalidRequest)
         }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneModels.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneModels.swift
@@ -36,12 +36,12 @@ public struct DanmakuLaneConfiguration: Sendable, Equatable {
             displayAreaFraction,
         ]
         guard values.allSatisfy(\.isFinite),
-              surfaceWidth > 0,
-              surfaceHeight > 0,
-              laneHeight > 0,
-              minimumHorizontalGap >= 0,
-              maximumActiveCount > 0,
-              maximumActiveCount <= Self.hardMaximumActiveCount
+            surfaceWidth > 0,
+            surfaceHeight > 0,
+            laneHeight > 0,
+            minimumHorizontalGap >= 0,
+            maximumActiveCount > 0,
+            maximumActiveCount <= Self.hardMaximumActiveCount
         else {
             return false
         }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
@@ -72,7 +72,7 @@ public final class DanmakuPresentationController:
         let changesIdentity = identity != updateIdentity
         let changesGeneration =
             discontinuityGeneration
-                != update.snapshot.discontinuityGeneration
+            != update.snapshot.discontinuityGeneration
         if changesIdentity
             || changesGeneration
             || matchingBatch?.clearsExisting == true
@@ -83,13 +83,14 @@ public final class DanmakuPresentationController:
         discontinuityGeneration =
             update.snapshot.discontinuityGeneration
 
-        let effectiveRate = update.snapshot.state == .playing
+        let effectiveRate =
+            update.snapshot.state == .playing
             ? update.snapshot.rate
             : 0
         backend.setPlaybackRate(effectiveRate)
 
         guard let batch = matchingBatch,
-              !batch.clearsExisting
+            !batch.clearsExisting
         else {
             return
         }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Scheduling/DanmakuScheduler.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Scheduling/DanmakuScheduler.swift
@@ -30,11 +30,12 @@ public struct DanmakuFilter: Sendable, Equatable {
 
     func allows(_ event: DanmakuEvent) -> Bool {
         guard event.weight >= minimumWeight else { return false }
-        let showsMode = switch event.mode {
-        case .scrolling: showsScrolling
-        case .top: showsTop
-        case .bottom: showsBottom
-        }
+        let showsMode =
+            switch event.mode {
+            case .scrolling: showsScrolling
+            case .top: showsTop
+            case .bottom: showsBottom
+            }
         guard showsMode else { return false }
         return !blockedKeywords.contains { keyword in
             event.text.range(
@@ -134,9 +135,9 @@ public struct DanmakuScheduler: Sendable {
         var indices = [current]
         let next = current + 1
         if next <= DanmakuSegmentUseCase.maximumSegmentIndex,
-           snapshot.durationSeconds.map({
-               Double(current) * Self.segmentDurationSeconds < $0
-           }) ?? true
+            snapshot.durationSeconds.map({
+                Double(current) * Self.segmentDurationSeconds < $0
+            }) ?? true
         {
             indices.append(next)
         }
@@ -161,8 +162,8 @@ public struct DanmakuScheduler: Sendable {
         }
 
         guard isEnabled,
-              snapshot.state == .playing,
-              snapshot.rate > 0
+            snapshot.state == .playing,
+            snapshot.rate > 0
         else {
             previousPositionSeconds = snapshot.positionSeconds
             return nil
@@ -190,8 +191,8 @@ public struct DanmakuScheduler: Sendable {
             for index in lowerIndex...upperIndex {
                 for event in segments[index] ?? [] {
                     guard event.timeSeconds > previousPositionSeconds,
-                          event.timeSeconds <= snapshot.positionSeconds,
-                          filter.allows(event)
+                        event.timeSeconds <= snapshot.positionSeconds,
+                        filter.allows(event)
                     else { continue }
 
                     let wasDelivered = hasDelivered(event.id)
@@ -243,7 +244,8 @@ public struct DanmakuScheduler: Sendable {
     }
 
     private static func segmentIndex(at positionSeconds: Double) -> Int {
-        let normalized = positionSeconds.isFinite
+        let normalized =
+            positionSeconds.isFinite
             ? max(positionSeconds, 0)
             : 0
         return Int(normalized / segmentDurationSeconds) + 1

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Session/DanmakuSession.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Session/DanmakuSession.swift
@@ -23,9 +23,7 @@ public final class DanmakuSession: DanmakuPresentationControlling {
     private var generation = 0
     private var timelineTask: Task<Void, Never>?
     private var loadTasks: [Int: Task<Void, Never>] = [:]
-    private var continuations: [
-        UUID: AsyncStream<DanmakuBatch>.Continuation
-    ] = [:]
+    private var continuations: [UUID: AsyncStream<DanmakuBatch>.Continuation] = [:]
 
     public init(
         useCase: DanmakuSegmentUseCase,
@@ -39,8 +37,12 @@ public final class DanmakuSession: DanmakuPresentationControlling {
 
     deinit {
         timelineTask?.cancel()
-        loadTasks.values.forEach { $0.cancel() }
-        continuations.values.forEach { $0.finish() }
+        for task in loadTasks.values {
+            task.cancel()
+        }
+        for continuation in continuations.values {
+            continuation.finish()
+        }
     }
 
     public func batches() -> AsyncStream<DanmakuBatch> {
@@ -108,7 +110,9 @@ public final class DanmakuSession: DanmakuPresentationControlling {
         generation &+= 1
         timelineTask?.cancel()
         timelineTask = nil
-        loadTasks.values.forEach { $0.cancel() }
+        for task in loadTasks.values {
+            task.cancel()
+        }
         loadTasks.removeAll(keepingCapacity: false)
         identity = nil
         scheduler.reset()
@@ -129,10 +133,13 @@ public final class DanmakuSession: DanmakuPresentationControlling {
             DanmakuPresentationUpdate(snapshot: snapshot, batch: batch)
         )
         if let batch {
-            continuations.values.forEach { $0.yield(batch) }
+            for continuation in continuations.values {
+                continuation.yield(batch)
+            }
         }
         let required = scheduler.desiredSegmentIndices(for: snapshot)
-        for index in required where
+        for index in required
+        where
             !scheduler.containsSegment(index: index)
             && loadTasks[index] == nil
             && loadTasks.count < 2
@@ -154,28 +161,28 @@ public final class DanmakuSession: DanmakuPresentationControlling {
                 )
                 try Task.checkCancellation()
                 guard let self,
-                      self.generation == requestGeneration,
-                      self.identity == identity
+                    self.generation == requestGeneration,
+                    self.identity == identity
                 else { return }
                 self.scheduler.store(segment, for: identity)
                 self.loadTasks[index] = nil
                 self.state = .ready(identity)
             } catch is CancellationError {
                 guard let self,
-                      self.generation == requestGeneration
+                    self.generation == requestGeneration
                 else { return }
                 self.loadTasks[index] = nil
             } catch let error as DanmakuApplicationError {
                 guard let self,
-                      self.generation == requestGeneration,
-                      self.identity == identity
+                    self.generation == requestGeneration,
+                    self.identity == identity
                 else { return }
                 self.loadTasks[index] = nil
                 self.state = .failed(identity, error)
             } catch {
                 guard let self,
-                      self.generation == requestGeneration,
-                      self.identity == identity
+                    self.generation == requestGeneration,
+                    self.identity == identity
                 else { return }
                 self.loadTasks[index] = nil
                 self.state = .failed(identity, .unavailable)

--- a/Packages/BiliKitCore/Sources/BiliDanmakuProbe/BiliDanmakuProbe.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmakuProbe/BiliDanmakuProbe.swift
@@ -33,9 +33,11 @@ struct BiliDanmakuProbe {
             if let configuredCID = configuration.cid {
                 cid = configuredCID
             } else {
-                guard let firstPage = try await client.pages(
-                    for: configuration.bvid
-                ).first else {
+                guard
+                    let firstPage = try await client.pages(
+                        for: configuration.bvid
+                    ).first
+                else {
                     throw DanmakuApplicationError.invalidResponse
                 }
                 cid = firstPage.cid
@@ -55,7 +57,8 @@ struct BiliDanmakuProbe {
             var scheduler = DanmakuScheduler()
             scheduler.begin(for: identity)
             scheduler.store(segment, for: identity)
-            let start = Double(configuration.segmentIndex - 1)
+            let start =
+                Double(configuration.segmentIndex - 1)
                 * DanmakuScheduler.segmentDurationSeconds
             _ = scheduler.consume(
                 snapshot(
@@ -138,13 +141,13 @@ private struct Configuration {
             index += 2
         }
         guard (2...3).contains(values.count),
-              let bvid = values["--bvid"],
-              bvid.count == 12,
-              bvid.hasPrefix("BV"),
-              bvid.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber) }),
-              let rawSegmentIndex = values["--segment-index"],
-              let segmentIndex = Int(rawSegmentIndex),
-              (1...DanmakuSegmentUseCase.maximumSegmentIndex).contains(segmentIndex)
+            let bvid = values["--bvid"],
+            bvid.count == 12,
+            bvid.hasPrefix("BV"),
+            bvid.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber) }),
+            let rawSegmentIndex = values["--segment-index"],
+            let segmentIndex = Int(rawSegmentIndex),
+            (1...DanmakuSegmentUseCase.maximumSegmentIndex).contains(segmentIndex)
         else {
             throw DanmakuApplicationError.invalidRequest
         }

--- a/Packages/BiliKitCore/Sources/BiliDanmakuProbe/RendererLoadProbe.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmakuProbe/RendererLoadProbe.swift
@@ -74,7 +74,8 @@ enum RendererLoadProbe {
         )
 
         for index in 0..<targetCount {
-            let deadline = start
+            let deadline =
+                start
                 + Double(index + 1) / Double(configuration.rate)
             let remainingSeconds = deadline - CACurrentMediaTime()
             if remainingSeconds > 0 {
@@ -120,9 +121,10 @@ enum RendererLoadProbe {
             requestedSegmentCount > DanmakuScheduler.maximumCachedSegments
         let shouldCrossRetentionWindow =
             configuration.durationSeconds
-                > DanmakuScheduler.segmentDurationSeconds
-                    * Double(DanmakuScheduler.maximumCachedSegments)
-        let accountedEventCount = statistics.admitted
+            > DanmakuScheduler.segmentDurationSeconds
+            * Double(DanmakuScheduler.maximumCachedSegments)
+        let accountedEventCount =
+            statistics.admitted
             + statistics.droppedNoLane
             + statistics.droppedCapacity
         let sessionStopped = session.state == .idle
@@ -133,7 +135,7 @@ enum RendererLoadProbe {
         let rootAttachedAfterStop = renderer.rootLayer.superlayer != nil
         let residentMemoryAfterStop = residentMemoryBytes()
         guard residentMemorySamples.allSatisfy({ $0 > 0 }),
-              residentMemoryAfterStop > 0
+            residentMemoryAfterStop > 0
         else {
             throw DanmakuApplicationError.invalidResponse
         }
@@ -163,14 +165,14 @@ enum RendererLoadProbe {
         ]
         print(fields.joined(separator: " "))
         guard emitted == targetCount,
-              activeAfterStop == 0,
-              layersAfterStop == 0,
-              !rootAttachedAfterStop,
-              requestedSegmentCount > 0,
-              accountedEventCount == targetCount,
-              !shouldCrossRetentionWindow || crossedRetentionWindow,
-              timelineSubscribersAfterStop == 0,
-              sessionStopped
+            activeAfterStop == 0,
+            layersAfterStop == 0,
+            !rootAttachedAfterStop,
+            requestedSegmentCount > 0,
+            accountedEventCount == targetCount,
+            !shouldCrossRetentionWindow || crossedRetentionWindow,
+            timelineSubscribersAfterStop == 0,
+            sessionStopped
         else {
             throw DanmakuApplicationError.invalidResponse
         }
@@ -296,9 +298,7 @@ enum RendererLoadProbe {
 @MainActor
 private final class RendererProbeTimeline: PlaybackTimelineProviding {
     private var snapshot = PlaybackTimelineSnapshot.idle
-    private var continuations: [
-        UUID: AsyncStream<PlaybackTimelineSnapshot>.Continuation
-    ] = [:]
+    private var continuations: [UUID: AsyncStream<PlaybackTimelineSnapshot>.Continuation] = [:]
 
     var currentTimelineSnapshot: PlaybackTimelineSnapshot { snapshot }
     var subscriberCount: Int { continuations.count }
@@ -320,7 +320,9 @@ private final class RendererProbeTimeline: PlaybackTimelineProviding {
 
     func publish(_ snapshot: PlaybackTimelineSnapshot) {
         self.snapshot = snapshot
-        continuations.values.forEach { $0.yield(snapshot) }
+        for continuation in continuations.values {
+            continuation.yield(snapshot)
+        }
     }
 }
 
@@ -337,7 +339,7 @@ private actor RendererProbeRepository: DanmakuSegmentRepository {
         for identity: PlaybackItemIdentity
     ) async throws -> DanmakuSegment {
         guard identity.cid > 0,
-              (1...DanmakuSegmentUseCase.maximumSegmentIndex).contains(index)
+            (1...DanmakuSegmentUseCase.maximumSegmentIndex).contains(index)
         else {
             throw DanmakuApplicationError.invalidRequest
         }
@@ -346,7 +348,8 @@ private actor RendererProbeRepository: DanmakuSegmentRepository {
             DanmakuScheduler.segmentDurationSeconds * Double(rate)
         )
         let firstGlobalIndex = (index - 1) * eventsPerSegment
-        let segmentStart = Double(index - 1)
+        let segmentStart =
+            Double(index - 1)
             * DanmakuScheduler.segmentDurationSeconds
         let events = (0..<eventsPerSegment).map { offset in
             RendererLoadProbe.event(
@@ -379,13 +382,13 @@ private struct Configuration {
             index += 2
         }
         guard values.count == 2,
-              let rawRate = values["--renderer-rate"],
-              let rate = Int(rawRate),
-              rate == 40 || rate == 80,
-              let rawDuration = values["--duration"],
-              let durationSeconds = Double(rawDuration),
-              durationSeconds.isFinite,
-              (1...1_800).contains(durationSeconds)
+            let rawRate = values["--renderer-rate"],
+            let rate = Int(rawRate),
+            rate == 40 || rate == 80,
+            let rawDuration = values["--duration"],
+            let durationSeconds = Double(rawDuration),
+            durationSeconds.isFinite,
+            (1...1_800).contains(durationSeconds)
         else {
             throw DanmakuApplicationError.invalidRequest
         }

--- a/Packages/BiliKitCore/Sources/BiliLibraryFeature/History/WatchHistoryView.swift
+++ b/Packages/BiliKitCore/Sources/BiliLibraryFeature/History/WatchHistoryView.swift
@@ -42,7 +42,7 @@ public struct WatchHistoryView: View {
             ProgressView("正在加载观看历史…")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .accessibilityIdentifier("history.loading")
-        case let .loaded(items, continuation, loadMoreError):
+        case .loaded(let items, let continuation, let loadMoreError):
             if items.isEmpty {
                 emptyHistory(
                     canLoadMore: continuation != nil,
@@ -56,14 +56,14 @@ public struct WatchHistoryView: View {
                     loadMoreError: loadMoreError
                 )
             }
-        case let .loadingMore(items, _):
+        case .loadingMore(let items, _):
             historyList(
                 items: items,
                 canLoadMore: true,
                 isLoadingMore: true,
                 loadMoreError: nil
             )
-        case let .failed(error):
+        case .failed(let error):
             failure(error)
         }
     }
@@ -184,7 +184,7 @@ public struct WatchHistoryView: View {
             "请重新扫码登录后再试。"
         case .requestRestricted:
             "服务暂时拒绝了请求，请降低频率后重试。"
-        case let .serviceRejected(code):
+        case .serviceRejected(let code):
             "服务暂时无法完成请求（代码 \(code)）。"
         case .transportFailure:
             "请检查网络连接后重试。"

--- a/Packages/BiliKitCore/Sources/BiliLibraryFeature/History/WatchHistoryViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliLibraryFeature/History/WatchHistoryViewModel.swift
@@ -26,7 +26,7 @@ public final class WatchHistoryViewModel {
     public var requiresAuthentication: Bool {
         switch state {
         case .failed(.authenticationRequired),
-             .loaded(_, _, .authenticationRequired):
+            .loaded(_, _, .authenticationRequired):
             true
         default:
             false
@@ -79,7 +79,7 @@ public final class WatchHistoryViewModel {
     }
 
     public func loadMore() {
-        guard case let .loaded(items, .some(continuation), _) = state else { return }
+        guard case .loaded(let items, .some(let continuation), _) = state else { return }
         begin(
             state: .loadingMore(items: items, continuation: continuation),
             clearExistingTask: false
@@ -88,9 +88,11 @@ public final class WatchHistoryViewModel {
             do {
                 let page = try await useCase.load(after: continuation)
                 var seen = Set(items.map(\.bvid))
-                let merged = items + page.items.filter {
-                    seen.insert($0.bvid).inserted
-                }
+                let merged =
+                    items
+                    + page.items.filter {
+                        seen.insert($0.bvid).inserted
+                    }
                 apply(
                     .loaded(
                         items: merged,
@@ -142,7 +144,7 @@ public final class WatchHistoryViewModel {
         switch state {
         case .loading:
             state = .idle
-        case let .loadingMore(items, continuation):
+        case .loadingMore(let items, let continuation):
             state = .loaded(
                 items: items,
                 continuation: continuation,

--- a/Packages/BiliKitCore/Sources/BiliNetworking/Range/HTTPRangeClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliNetworking/Range/HTTPRangeClient.swift
@@ -54,7 +54,7 @@ public struct HTTPContentRange: Sendable, Equatable {
             whereSeparator: { $0.isWhitespace }
         )
         guard unitAndValue.count == 2,
-              unitAndValue[0].lowercased() == "bytes"
+            unitAndValue[0].lowercased() == "bytes"
         else {
             throw HTTPContentRangeError.invalidValue
         }
@@ -74,8 +74,8 @@ public struct HTTPContentRange: Sendable, Equatable {
             omittingEmptySubsequences: false
         )
         guard bounds.count == 2,
-              let start = Int64(bounds[0]),
-              let endInclusive = Int64(bounds[1])
+            let start = Int64(bounds[0]),
+            let endInclusive = Int64(bounds[1])
         else {
             throw HTTPContentRangeError.invalidValue
         }
@@ -256,7 +256,7 @@ public struct HTTPRangeClient: Sendable {
         }
 
         guard contentRange.start == expectedRange.start,
-              contentRange.endInclusive == expectedRange.endInclusive
+            contentRange.endInclusive == expectedRange.endInclusive
         else {
             throw HTTPRangeAttemptFailureError(
                 .mismatchedContentRange(
@@ -290,8 +290,8 @@ private struct HTTPRangeAttemptFailureError: Error {
     }
 }
 
-private extension HTTPResponse {
-    func headerValue(named expectedName: String) -> String? {
+extension HTTPResponse {
+    fileprivate func headerValue(named expectedName: String) -> String? {
         headers.first { name, _ in
             name.caseInsensitiveCompare(expectedName) == .orderedSame
         }?.value

--- a/Packages/BiliKitCore/Sources/BiliNetworking/Transport/HTTPClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliNetworking/Transport/HTTPClient.swift
@@ -85,12 +85,13 @@ public final class URLSessionTransport: HTTPTransport, HTTPTransportInvalidating
         configuration: URLSessionConfiguration,
         redirectPolicy: HTTPRedirectPolicy
     ) {
-        let delegate: URLSessionTaskDelegate? = switch redirectPolicy {
-        case .follow:
-            nil
-        case .reject:
-            RejectHTTPRedirectDelegate()
-        }
+        let delegate: URLSessionTaskDelegate? =
+            switch redirectPolicy {
+            case .follow:
+                nil
+            case .reject:
+                RejectHTTPRedirectDelegate()
+            }
         self.init(
             session: URLSession(
                 configuration: configuration,

--- a/Packages/BiliKitCore/Sources/BiliNetworking/Transport/PublicHTTPSURLPolicy.swift
+++ b/Packages/BiliKitCore/Sources/BiliNetworking/Transport/PublicHTTPSURLPolicy.swift
@@ -6,25 +6,25 @@ public struct PublicHTTPSURLPolicy: Sendable {
 
     public func allows(_ url: URL) -> Bool {
         guard url.scheme?.lowercased() == "https",
-              url.user == nil,
-              url.password == nil,
-              url.fragment == nil,
-              url.port == nil || url.port == 443,
-              let rawHost = url.host?.lowercased(),
-              !rawHost.isEmpty
+            url.user == nil,
+            url.password == nil,
+            url.fragment == nil,
+            url.port == nil || url.port == 443,
+            let rawHost = url.host?.lowercased(),
+            !rawHost.isEmpty
         else {
             return false
         }
 
         let host = rawHost.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
         guard !host.isEmpty,
-              host != "localhost",
-              !host.hasSuffix(".localhost"),
-              !host.hasSuffix(".local"),
-              !host.hasSuffix(".internal"),
-              host != "home.arpa",
-              !host.hasSuffix(".home.arpa"),
-              !Self.isIPAddress(host)
+            host != "localhost",
+            !host.hasSuffix(".localhost"),
+            !host.hasSuffix(".local"),
+            !host.hasSuffix(".internal"),
+            host != "home.arpa",
+            !host.hasSuffix(".home.arpa"),
+            !Self.isIPAddress(host)
         else {
             return false
         }

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Bridge/HLSPlaylistBuilder.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Bridge/HLSPlaylistBuilder.swift
@@ -27,7 +27,8 @@ public struct HLSMediaPlaylistBuilder: Sendable {
             throw HLSPlaylistBuilderError.invalidTimescale
         }
         let uri = try safeURI(mediaURI)
-        let maximumDuration = index.references
+        let maximumDuration =
+            index.references
             .map { Double($0.duration) / Double(index.timescale) }
             .max() ?? 0
         let targetDuration = max(1, Int(ceil(maximumDuration)))
@@ -74,9 +75,9 @@ public struct HLSMediaPlaylistBuilder: Sendable {
     private func safeURI(_ url: URL) throws -> String {
         let value = url.absoluteString
         guard !value.isEmpty,
-              !value.contains("\r"),
-              !value.contains("\n"),
-              !value.contains("\"")
+            !value.contains("\r"),
+            !value.contains("\n"),
+            !value.contains("\"")
         else {
             throw HLSPlaylistBuilderError.unsafeURI
         }
@@ -146,9 +147,9 @@ public struct HLSMasterPlaylistBuilder: Sendable {
 
     private func safeAttribute(_ value: String) throws -> String {
         guard !value.isEmpty,
-              !value.contains("\r"),
-              !value.contains("\n"),
-              !value.contains("\"")
+            !value.contains("\r"),
+            !value.contains("\n"),
+            !value.contains("\"")
         else {
             throw HLSPlaylistBuilderError.unsafeAttributeValue
         }
@@ -158,9 +159,9 @@ public struct HLSMasterPlaylistBuilder: Sendable {
     private func safeURI(_ url: URL) throws -> String {
         let value = url.absoluteString
         guard !value.isEmpty,
-              !value.contains("\r"),
-              !value.contains("\n"),
-              !value.contains("\"")
+            !value.contains("\r"),
+            !value.contains("\n"),
+            !value.contains("\"")
         else {
             throw HLSPlaylistBuilderError.unsafeURI
         }

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Bridge/LoopbackPlaybackServer.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Bridge/LoopbackPlaybackServer.swift
@@ -1,6 +1,6 @@
-@preconcurrency import Network
 import BiliNetworking
 import Foundation
+@preconcurrency import Network
 
 public struct LoopbackRemoteResource: Sendable, Equatable {
     public let candidateURLs: [URL]
@@ -34,18 +34,18 @@ public enum LoopbackPlaybackResource: Sendable, Equatable {
 
     fileprivate var contentLength: Int64 {
         switch self {
-        case let .inMemory(data, _):
+        case .inMemory(let data, _):
             Int64(data.count)
-        case let .remote(resource):
+        case .remote(let resource):
             resource.contentLength
         }
     }
 
     fileprivate var contentType: String {
         switch self {
-        case let .inMemory(_, contentType):
+        case .inMemory(_, let contentType):
             contentType
-        case let .remote(resource):
+        case .remote(let resource):
             resource.contentType
         }
     }
@@ -130,7 +130,7 @@ public final class LoopbackPlaybackServer: @unchecked Sendable {
                     self.port = boundPort
                 }
                 startBox.resume()
-            case let .failed(error):
+            case .failed(let error):
                 startBox.resume(
                     throwing: LoopbackPlaybackServerError.listenerFailed(
                         String(describing: error)
@@ -186,11 +186,12 @@ public final class LoopbackPlaybackServer: @unchecked Sendable {
     }
 
     public func stop() {
-        let state = lock.withLock { () -> (
-            NWListener?,
-            [NWConnection],
-            [Task<Void, Never>]
-        ) in
+        let state = lock.withLock {
+            () -> (
+                NWListener?,
+                [NWConnection],
+                [Task<Void, Never>]
+            ) in
             let state = (
                 listener,
                 Array(connections.values),
@@ -205,8 +206,12 @@ public final class LoopbackPlaybackServer: @unchecked Sendable {
         }
 
         state.0?.cancel()
-        state.1.forEach { $0.cancel() }
-        state.2.forEach { $0.cancel() }
+        for connection in state.1 {
+            connection.cancel()
+        }
+        for task in state.2 {
+            task.cancel()
+        }
     }
 
     func diagnosticsSnapshot() -> LoopbackPlaybackServerDiagnostics {
@@ -300,7 +305,7 @@ public final class LoopbackPlaybackServer: @unchecked Sendable {
             return
         }
         guard request.target.hasPrefix("/\(sessionToken)/"),
-              let resource = lock.withLock({ routes[request.target] })
+            let resource = lock.withLock({ routes[request.target] })
         else {
             sendStatus(404, reason: "Not Found", on: connection)
             return
@@ -352,7 +357,7 @@ public final class LoopbackPlaybackServer: @unchecked Sendable {
         }
 
         switch resource {
-        case let .inMemory(data, _):
+        case .inMemory(let data, _):
             let body: Data
             if let requestedRange {
                 body = data.subdata(
@@ -373,7 +378,7 @@ public final class LoopbackPlaybackServer: @unchecked Sendable {
                 body: body,
                 on: connection
             )
-        case let .remote(remote):
+        case .remote(let remote):
             guard let requestedRange else {
                 sendStatus(400, reason: "Range Required", on: connection)
                 return
@@ -414,7 +419,8 @@ public final class LoopbackPlaybackServer: @unchecked Sendable {
                 : "\(bodyLength)",
         ]
         if let range {
-            headers["Content-Range"] = "bytes \(range.start)-\(range.endInclusive)/\(resource.contentLength)"
+            headers["Content-Range"] =
+                "bytes \(range.start)-\(range.endInclusive)/\(resource.contentLength)"
         }
         return headers
     }
@@ -425,7 +431,7 @@ public final class LoopbackPlaybackServer: @unchecked Sendable {
     ) throws -> HTTPByteRange? {
         guard let value else { return nil }
         guard value.lowercased().hasPrefix("bytes="),
-              !value.contains(",")
+            !value.contains(",")
         else {
             throw LoopbackPlaybackServerError.invalidRangeHeader
         }
@@ -436,9 +442,9 @@ public final class LoopbackPlaybackServer: @unchecked Sendable {
             omittingEmptySubsequences: false
         )
         guard bounds.count == 2,
-              let start = Int64(bounds[0]),
-              start >= 0,
-              start < contentLength
+            let start = Int64(bounds[0]),
+            start >= 0,
+            start < contentLength
         else {
             throw LoopbackPlaybackServerError.invalidRangeHeader
         }
@@ -479,9 +485,11 @@ public final class LoopbackPlaybackServer: @unchecked Sendable {
     ) {
         var responseHeaders = headers
         responseHeaders["Connection"] = "close"
-        responseHeaders["Content-Length"] = responseHeaders["Content-Length"]
+        responseHeaders["Content-Length"] =
+            responseHeaders["Content-Length"]
             ?? "\(body.count)"
-        let head = (["HTTP/1.1 \(status) \(reason)"]
+        let head =
+            (["HTTP/1.1 \(status) \(reason)"]
             + responseHeaders.sorted { $0.key < $1.key }.map { "\($0.key): \($0.value)" }
             + ["", ""])
             .joined(separator: "\r\n")
@@ -506,9 +514,9 @@ public final class LoopbackPlaybackServer: @unchecked Sendable {
 
     private func isValidRoute(_ route: String) -> Bool {
         guard !route.isEmpty,
-              !route.hasPrefix("/"),
-              !route.hasSuffix("/"),
-              !route.contains("..")
+            !route.hasPrefix("/"),
+            !route.hasSuffix("/"),
+            !route.contains("..")
         else {
             return false
         }
@@ -531,7 +539,7 @@ private struct LoopbackHTTPRequest: Sendable {
         let lines = text.components(separatedBy: "\r\n")
         let requestLine = lines[0].split(separator: " ")
         guard requestLine.count == 3,
-              requestLine[2].hasPrefix("HTTP/1.")
+            requestLine[2].hasPrefix("HTTP/1.")
         else {
             throw LoopbackPlaybackServerError.invalidHTTPRequest
         }

--- a/Packages/BiliKitCore/Sources/BiliPlayback/MediaIndex/SIDXParser.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/MediaIndex/SIDXParser.swift
@@ -67,7 +67,7 @@ public struct SIDXParser: Sendable {
         var reader = BigEndianReader(data: data)
         let declaredSize = try reader.readUInt32()
         guard data.count <= UInt32.max,
-              declaredSize == UInt32(data.count)
+            declaredSize == UInt32(data.count)
         else {
             throw SIDXParserError.invalidBoxSize(
                 declared: declaredSize,
@@ -129,7 +129,7 @@ public struct SIDXParser: Sendable {
             let sap = try reader.readUInt32()
             let endExclusive = try adding(nextMediaOffset, referencedSize)
             guard nextMediaOffset <= UInt64(Int64.max),
-                  endExclusive - 1 <= UInt64(Int64.max)
+                endExclusive - 1 <= UInt64(Int64.max)
             else {
                 throw SIDXParserError.integerOverflow
             }

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
@@ -205,7 +205,8 @@ public final class AVPlayerEngine: PlayerEngine, PlaybackControlling {
             throw AVPlayerEngineError.seekFailed
         }
         let components = time.components
-        let seconds = Double(components.seconds)
+        let seconds =
+            Double(components.seconds)
             + Double(components.attoseconds) / 1_000_000_000_000_000_000
         timeline.prepareExplicitSeek(to: seconds)
         let didSeek = await player.seek(
@@ -238,9 +239,11 @@ public final class AVPlayerEngine: PlayerEngine, PlaybackControlling {
         for request: PlaybackRequest
     ) throws -> MediaRepresentation {
         if let preferredID = request.preferredVideoRepresentationID {
-            guard let representation = request.manifest.videoRepresentations.first(
-                where: { $0.id == preferredID }
-            ) else {
+            guard
+                let representation = request.manifest.videoRepresentations.first(
+                    where: { $0.id == preferredID }
+                )
+            else {
                 throw AVPlayerEngineError.preferredVideoRepresentationNotFound(
                     preferredID
                 )
@@ -257,9 +260,11 @@ public final class AVPlayerEngine: PlayerEngine, PlaybackControlling {
         for request: PlaybackRequest
     ) throws -> MediaRepresentation {
         if let preferredID = request.preferredAudioRepresentationID {
-            guard let representation = request.manifest.audioRepresentations.first(
-                where: { $0.id == preferredID }
-            ) else {
+            guard
+                let representation = request.manifest.audioRepresentations.first(
+                    where: { $0.id == preferredID }
+                )
+            else {
                 throw AVPlayerEngineError.preferredAudioRepresentationNotFound(
                     preferredID
                 )

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerItemReadiness.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerItemReadiness.swift
@@ -23,9 +23,10 @@ enum AVPlayerItemReadiness {
             case .readyToPlay:
                 return
             case .failed:
-                let errorType = item.error.map {
-                    String(reflecting: type(of: $0))
-                } ?? "UnknownAVPlayerItemError"
+                let errorType =
+                    item.error.map {
+                        String(reflecting: type(of: $0))
+                    } ?? "UnknownAVPlayerItemError"
                 throw AVPlayerEngineError.itemFailed(errorType: errorType)
             case .unknown:
                 continue

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerTimelineAdapter.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerTimelineAdapter.swift
@@ -42,7 +42,7 @@ final class AVPlayerTimelineAdapter {
         ) { [weak self, weak item] time in
             Task { @MainActor in
                 guard let self, let item, self.player.currentItem === item,
-                      let seconds = Self.seconds(from: time)
+                    let seconds = Self.seconds(from: time)
                 else { return }
                 self.store.update(
                     token: token,
@@ -125,12 +125,13 @@ final class AVPlayerTimelineAdapter {
         ) { [weak self, weak item] _ in
             Task { @MainActor in
                 guard let self, let item, self.player.currentItem === item,
-                      self.store.currentSnapshot.state != .loading,
-                      let position = Self.seconds(from: item.currentTime())
+                    self.store.currentSnapshot.state != .loading,
+                    let position = Self.seconds(from: item.currentTime())
                 else { return }
 
                 if let explicit = self.pendingExplicitSeekPosition,
-                   abs(explicit - position) <= 0.25 {
+                    abs(explicit - position) <= 0.25
+                {
                     self.pendingExplicitSeekPosition = nil
                     return
                 }
@@ -272,7 +273,8 @@ private final class PlayerTimelineObserverBag: Sendable {
 
     private static func remove(_ storage: Storage) {
         if let player = storage.player,
-           let periodicTimeObserver = storage.periodicTimeObserver {
+            let periodicTimeObserver = storage.periodicTimeObserver
+        {
             player.removeTimeObserver(periodicTimeObserver)
         }
         storage.rateObservation?.invalidate()

--- a/Packages/BiliKitCore/Sources/BiliPlaybackProbe/main.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlaybackProbe/main.swift
@@ -45,14 +45,18 @@ struct BiliPlaybackProbe {
             cid: cid,
             quality: 32
         )
-        guard let video = playback.manifest.videoRepresentations.max(
-            by: { $0.id < $1.id }
-        ) else {
+        guard
+            let video = playback.manifest.videoRepresentations.max(
+                by: { $0.id < $1.id }
+            )
+        else {
             throw ProbeError.noAVCVideo
         }
-        guard let audio = playback.manifest.audioRepresentations.min(
-            by: { ($0.bandwidth ?? .max) < ($1.bandwidth ?? .max) }
-        ) else {
+        guard
+            let audio = playback.manifest.audioRepresentations.min(
+                by: { ($0.bandwidth ?? .max) < ($1.bandwidth ?? .max) }
+            )
+        else {
             throw ProbeError.noAACAudio
         }
 
@@ -337,9 +341,9 @@ private struct ProbeConfiguration {
         }
 
         guard let bvid = values["--bvid"],
-              bvid.hasPrefix("BV"),
-              bvid.count <= 24,
-              bvid.dropFirst(2).allSatisfy({ $0.isLetter || $0.isNumber })
+            bvid.hasPrefix("BV"),
+            bvid.count <= 24,
+            bvid.dropFirst(2).allSatisfy({ $0.isLetter || $0.isNumber })
         else {
             throw ProbeError.invalidArguments
         }
@@ -410,7 +414,7 @@ private final class VideoTimelineSampler {
         output = AVPlayerItemVideoOutput(
             pixelBufferAttributes: [
                 kCVPixelBufferPixelFormatTypeKey as String:
-                    Int(kCVPixelFormatType_32BGRA),
+                    Int(kCVPixelFormatType_32BGRA)
             ]
         )
         item.add(output)
@@ -419,17 +423,19 @@ private final class VideoTimelineSampler {
     func sample(player: AVPlayer) {
         let requestedTime = output.itemTime(forHostTime: CACurrentMediaTime())
         guard requestedTime.isValid,
-              requestedTime.seconds.isFinite,
-              output.hasNewPixelBuffer(forItemTime: requestedTime)
+            requestedTime.seconds.isFinite,
+            output.hasNewPixelBuffer(forItemTime: requestedTime)
         else {
             return
         }
 
         var displayTime = CMTime.invalid
-        guard output.copyPixelBuffer(
-            forItemTime: requestedTime,
-            itemTimeForDisplay: &displayTime
-        ) != nil else {
+        guard
+            output.copyPixelBuffer(
+                forItemTime: requestedTime,
+                itemTimeForDisplay: &displayTime
+            ) != nil
+        else {
             return
         }
         let frameTime = displayTime.isValid ? displayTime : requestedTime
@@ -470,11 +476,11 @@ private enum ProbeError: Error, CustomStringConvertible {
         case .playerItemFailed: "player-item-failed"
         case .insufficientVideoTimelineSamples:
             "insufficient-video-timeline-samples"
-        case let .videoTimelineDrift(delta):
+        case .videoTimelineDrift(let delta):
             "video-timeline-drift-\(delta)"
         case .memoryMeasurementUnavailable:
             "memory-measurement-unavailable"
-        case let .memoryGrowthExceeded(growth):
+        case .memoryGrowthExceeded(let growth):
             "memory-growth-exceeded-\(growth)-mib"
         case .timedOut: "timed-out"
         }

--- a/Packages/BiliKitCore/Sources/BiliUI/VideoCard.swift
+++ b/Packages/BiliKitCore/Sources/BiliUI/VideoCard.swift
@@ -58,7 +58,7 @@ package struct VideoCard: View {
             .overlay {
                 AsyncImage(url: coverURL) { phase in
                     switch phase {
-                    case let .success(image):
+                    case .success(let image):
                         image
                             .resizable()
                             .scaledToFill()
@@ -105,7 +105,7 @@ package struct VideoCard: View {
             if showsAvatar {
                 AsyncImage(url: avatarURL) { phase in
                     switch phase {
-                    case let .success(image):
+                    case .success(let image):
                         image
                             .resizable()
                             .scaledToFill()

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
@@ -91,10 +91,12 @@ struct BiliAPIClientTests {
         #expect(page.videos[1].durationSeconds == 754)
 
         let requests = await transport.capturedRequests()
-        #expect(requests.map(\.url.path) == [
-            "/x/web-interface/nav",
-            "/x/web-interface/wbi/search/type",
-        ])
+        #expect(
+            requests.map(\.url.path) == [
+                "/x/web-interface/nav",
+                "/x/web-interface/wbi/search/type",
+            ]
+        )
         let searchQuery = URLComponents(
             url: requests[1].url,
             resolvingAgainstBaseURL: false
@@ -152,13 +154,16 @@ struct BiliAPIClientTests {
 
         #expect(page.videos.count == 2)
         let requests = await transport.capturedRequests()
-        #expect(requests.map(\.url.path) == [
-            "/x/web-interface/nav",
-            "/x/web-interface/wbi/search/type",
-            "/x/web-interface/nav",
-            "/x/web-interface/wbi/search/type",
-        ])
-        let signatures = requests
+        #expect(
+            requests.map(\.url.path) == [
+                "/x/web-interface/nav",
+                "/x/web-interface/wbi/search/type",
+                "/x/web-interface/nav",
+                "/x/web-interface/wbi/search/type",
+            ]
+        )
+        let signatures =
+            requests
             .filter { $0.url.path.contains("/wbi/search/") }
             .compactMap {
                 URLComponents(url: $0.url, resolvingAgainstBaseURL: false)?
@@ -187,12 +192,14 @@ struct BiliAPIClientTests {
 
         _ = try await client.searchVideos(keyword: "macOS", page: 1)
 
-        #expect(await transport.capturedRequests().map(\.url.path) == [
-            "/x/web-interface/nav",
-            "/x/web-interface/wbi/search/type",
-            "/x/web-interface/nav",
-            "/x/web-interface/wbi/search/type",
-        ])
+        #expect(
+            await transport.capturedRequests().map(\.url.path) == [
+                "/x/web-interface/nav",
+                "/x/web-interface/wbi/search/type",
+                "/x/web-interface/nav",
+                "/x/web-interface/wbi/search/type",
+            ]
+        )
     }
 
     @Test
@@ -304,10 +311,12 @@ struct BiliAPIClientTests {
                 URLQueryItem(name: "business", value: "archive")
             ) == true
         )
-        #expect(await authorizer.capturedPaths() == [
-            "/x/web-interface/history/cursor",
-            "/x/web-interface/history/cursor",
-        ])
+        #expect(
+            await authorizer.capturedPaths() == [
+                "/x/web-interface/history/cursor",
+                "/x/web-interface/history/cursor",
+            ]
+        )
     }
 
     @Test

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliDanmakuRepositoryTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliDanmakuRepositoryTests.swift
@@ -3,6 +3,7 @@ import BiliModels
 import BiliNetworking
 import Foundation
 import Testing
+
 @testable import BiliAPI
 
 @Suite

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliMediaURLPolicyTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliMediaURLPolicyTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import BiliAPI
 
 struct BiliMediaURLPolicyTests {

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliSubtitleRepositoryTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliSubtitleRepositoryTests.swift
@@ -3,6 +3,7 @@ import BiliModels
 import BiliNetworking
 import Foundation
 import Testing
+
 @testable import BiliAPI
 
 @Suite
@@ -285,12 +286,13 @@ struct BiliSubtitleRepositoryTests {
             )
         var body = Data(source.utf8)
         if prependingEmptyURLTrack {
-            guard var envelope = try JSONSerialization.jsonObject(with: body)
+            guard
+                var envelope = try JSONSerialization.jsonObject(with: body)
                     as? [String: Any],
-                  var data = envelope["data"] as? [String: Any],
-                  var subtitle = data["subtitle"] as? [String: Any],
-                  var tracks = subtitle["subtitles"] as? [[String: Any]],
-                  var placeholder = tracks.first
+                var data = envelope["data"] as? [String: Any],
+                var subtitle = data["subtitle"] as? [String: Any],
+                var tracks = subtitle["subtitles"] as? [[String: Any]],
+                var placeholder = tracks.first
             else {
                 throw SubtitleTestTransportError.missingResponse
             }

--- a/Packages/BiliKitCore/Tests/BiliAPITests/WBISignerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/WBISignerTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import BiliAPI
 
 struct WBISignerTests {

--- a/Packages/BiliKitCore/Tests/BiliApplicationTests/GuestFeedUseCaseTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliApplicationTests/GuestFeedUseCaseTests.swift
@@ -14,16 +14,17 @@ struct GuestFeedUseCaseTests {
         )
 
         #expect(
-            content == .search(
-                query: "macOS",
-                page: SearchPage(
-                    videos: [],
-                    pageNumber: 2,
-                    pageSize: 20,
-                    totalResults: 0,
-                    totalPages: 0
+            content
+                == .search(
+                    query: "macOS",
+                    page: SearchPage(
+                        videos: [],
+                        pageNumber: 2,
+                        pageSize: 20,
+                        totalResults: 0,
+                        totalPages: 0
+                    )
                 )
-            )
         )
         #expect(await repository.searchQueries() == ["macOS"])
     }

--- a/Packages/BiliKitCore/Tests/BiliApplicationTests/GuestVideoUseCaseTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliApplicationTests/GuestVideoUseCaseTests.swift
@@ -53,7 +53,7 @@ private actor GuestRepositoryStub: GuestContentRepository {
     }
 
     func videoDetail(for bvid: String) async throws -> VideoDetail {
-        return makeDetail(bvid: bvid)
+        makeDetail(bvid: bvid)
     }
 
     func pages(for bvid: String) async throws -> [VideoPage] {
@@ -125,7 +125,7 @@ private actor GuestRepositoryStub: GuestContentRepository {
                         mimeType: "video/mp4",
                         primaryURL: videoURL,
                         segmentBase: segmentBase
-                    ),
+                    )
                 ],
                 audioRepresentations: [
                     MediaRepresentation(
@@ -135,7 +135,7 @@ private actor GuestRepositoryStub: GuestContentRepository {
                         mimeType: "audio/mp4",
                         primaryURL: audioURL,
                         segmentBase: segmentBase
-                    ),
+                    )
                 ]
             ),
             mediaHeaders: [:]

--- a/Packages/BiliKitCore/Tests/BiliApplicationTests/PlaybackTimelineStoreTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliApplicationTests/PlaybackTimelineStoreTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import BiliApplication
 
 @Suite

--- a/Packages/BiliKitCore/Tests/BiliApplicationTests/WatchHistoryUseCaseTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliApplicationTests/WatchHistoryUseCaseTests.swift
@@ -14,9 +14,11 @@ struct WatchHistoryUseCaseTests {
 
         _ = try await useCase.load(after: continuation, pageSize: 30)
 
-        #expect(await repository.requests() == [
-            Request(continuation: continuation, pageSize: 30),
-        ])
+        #expect(
+            await repository.requests() == [
+                Request(continuation: continuation, pageSize: 30)
+            ]
+        )
     }
 
     @Test

--- a/Packages/BiliKitCore/Tests/BiliAuthFeatureTests/AuthenticationViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthFeatureTests/AuthenticationViewModelTests.swift
@@ -2,6 +2,7 @@ import BiliApplication
 import CoreGraphics
 import Foundation
 import Testing
+
 @testable import BiliAuthFeature
 
 struct AuthenticationViewModelTests {

--- a/Packages/BiliKitCore/Tests/BiliAuthTests/BiliAuthenticationServiceTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthTests/BiliAuthenticationServiceTests.swift
@@ -2,6 +2,7 @@ import BiliApplication
 import BiliNetworking
 import Foundation
 import Testing
+
 @testable import BiliAuth
 
 struct BiliAuthenticationServiceTests {
@@ -105,7 +106,7 @@ struct BiliAuthenticationServiceTests {
                 )
             },
             additionalSessionInvalidators: [
-                RecordingAuthenticatedSessionInvalidator(events: events),
+                RecordingAuthenticatedSessionInvalidator(events: events)
             ]
         )
 
@@ -113,12 +114,14 @@ struct BiliAuthenticationServiceTests {
         #expect(await service.logout() == .signedOut)
 
         #expect(try store.load() == nil)
-        #expect(events.values() == [
-            "credential-deleted",
-            "qr-invalidated",
-            "validation-invalidated",
-            "api-invalidated",
-        ])
+        #expect(
+            events.values() == [
+                "credential-deleted",
+                "qr-invalidated",
+                "validation-invalidated",
+                "api-invalidated",
+            ]
+        )
     }
 
     @Test
@@ -160,7 +163,7 @@ struct BiliAuthenticationServiceTests {
                 )
             },
             additionalSessionInvalidators: [
-                RecordingAuthenticatedSessionInvalidator(events: events),
+                RecordingAuthenticatedSessionInvalidator(events: events)
             ]
         )
 
@@ -169,12 +172,14 @@ struct BiliAuthenticationServiceTests {
         #expect(await service.cancelLogin() == .failed(.credentialUnavailable))
 
         #expect(try store.load() != nil)
-        #expect(events.values() == [
-            "credential-delete-failed",
-            "qr-invalidated",
-            "validation-invalidated",
-            "api-invalidated",
-        ])
+        #expect(
+            events.values() == [
+                "credential-delete-failed",
+                "qr-invalidated",
+                "validation-invalidated",
+                "api-invalidated",
+            ]
+        )
     }
 
     private func makeService(

--- a/Packages/BiliKitCore/Tests/BiliAuthTests/Credential/BiliCredentialRequestAuthorizerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthTests/Credential/BiliCredentialRequestAuthorizerTests.swift
@@ -1,6 +1,7 @@
 import BiliNetworking
 import Foundation
 import Testing
+
 @testable import BiliAuth
 
 struct BiliCredentialRequestAuthorizerTests {
@@ -25,7 +26,8 @@ struct BiliCredentialRequestAuthorizerTests {
         let historyRequest = HTTPRequest(
             url: try #require(
                 URL(
-                    string: "https://api.bilibili.com/x/web-interface/history/cursor?max=0&view_at=0&business=&ps=20"
+                    string:
+                        "https://api.bilibili.com/x/web-interface/history/cursor?max=0&view_at=0&business=&ps=20"
                 )
             )
         )
@@ -55,13 +57,22 @@ struct BiliCredentialRequestAuthorizerTests {
             ("https://api.bilibili.com/x/web-interface/popular", .get),
             ("https://api.bilibili.com/x/web-interface/nav?extra=1", .get),
             ("https://api.bilibili.com/x/web-interface/history/cursor?ps=20", .get),
-            ("https://api.bilibili.com/x/web-interface/history/cursor?max=0&view_at=0&business=&ps=20&extra=1", .get),
-            ("https://api.bilibili.com/x/web-interface/history/cursor?max=-1&view_at=0&business=&ps=20", .get),
+            (
+                "https://api.bilibili.com/x/web-interface/history/cursor?max=0&view_at=0&business=&ps=20&extra=1",
+                .get
+            ),
+            (
+                "https://api.bilibili.com/x/web-interface/history/cursor?max=-1&view_at=0&business=&ps=20",
+                .get
+            ),
             ("https://api.bilibili.com/x/player/v2?bvid=BV1Fixture01", .get),
             ("https://api.bilibili.com/x/player/v2?bvid=BV1Fixture01&cid=0", .get),
             ("https://api.bilibili.com/x/player/v2?bvid=BV1Fixture01&cid=900001&extra=1", .get),
             ("https://api.bilibili.com/x/player/v2?bvid=invalid&cid=900001", .get),
-            ("https://api.bilibili.com/x/player/v2?bvid=BV1Fixture01&bvid=BV1Fixture02&cid=900001", .get),
+            (
+                "https://api.bilibili.com/x/player/v2?bvid=BV1Fixture01&bvid=BV1Fixture02&cid=900001",
+                .get
+            ),
             ("https://api.bilibili.com/x/web-interface/nav", .post),
             ("https://user@api.bilibili.com/x/web-interface/nav", .get),
             ("https://api.bilibili.com/x/web-interface/nav#fragment", .get),

--- a/Packages/BiliKitCore/Tests/BiliAuthTests/Credential/CredentialTestSupport.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthTests/Credential/CredentialTestSupport.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 @testable import BiliAuth
 
 func makeFixtureCredential(

--- a/Packages/BiliKitCore/Tests/BiliAuthTests/Credential/WebCredentialTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthTests/Credential/WebCredentialTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Security
 import Testing
+
 @testable import BiliAuth
 
 struct WebCredentialTests {
@@ -13,7 +14,8 @@ struct WebCredentialTests {
 
         #expect(decoded == credential)
         #expect(String(decoding: encoded, as: UTF8.self).contains(#""version":1"#))
-        let diagnostics = String(describing: credential)
+        let diagnostics =
+            String(describing: credential)
             + String(reflecting: credential)
             + credential.cookies.map(String.init(reflecting:)).joined()
         #expect(!diagnostics.contains("FIXTURE_"))

--- a/Packages/BiliKitCore/Tests/BiliAuthTests/WebQRLoginSessionTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthTests/WebQRLoginSessionTests.swift
@@ -1,6 +1,7 @@
 import BiliNetworking
 import Foundation
 import Testing
+
 @testable import BiliAuth
 
 struct WebQRLoginSessionTests {
@@ -11,7 +12,7 @@ struct WebQRLoginSessionTests {
 
         let state = try await session.requestQRCode()
 
-        guard case let .awaitingScan(qrCode) = state else {
+        guard case .awaitingScan(let qrCode) = state else {
             Issue.record("应进入等待扫码状态")
             return
         }
@@ -76,7 +77,7 @@ struct WebQRLoginSessionTests {
         _ = try await session.requestQRCode()
         let state = try await session.pollOnce()
 
-        guard case let .awaitingConfirmation(qrCode) = state else {
+        guard case .awaitingConfirmation(let qrCode) = state else {
             Issue.record("86090 应进入等待手机确认状态")
             return
         }
@@ -120,20 +121,24 @@ struct WebQRLoginSessionTests {
         _ = try await session.requestQRCode()
         let state = try await session.pollOnce()
 
-        guard case let .awaitingCredentialValidation(observation) = state else {
+        guard case .awaitingCredentialValidation(let observation) = state else {
             Issue.record("code=0 应等待登录态校验，不能直接视为已登录")
             return
         }
         #expect(observation.code == 0)
         #expect(observation.urlHost == "passport.biligame.com")
-        #expect(observation.urlQueryNames == [
-            "DedeUserID", "Expires", "SESSDATA", "bili_jct", "first_domain", "gourl",
-        ])
+        #expect(
+            observation.urlQueryNames == [
+                "DedeUserID", "Expires", "SESSDATA", "bili_jct", "first_domain", "gourl",
+            ]
+        )
         #expect(observation.refreshTokenPresent)
-        #expect(observation.cookieNames == [
-            "DedeUserID", "DedeUserID__ckMd5", "SESSDATA", "bili_jct", "sid",
-            "unknown_cookie",
-        ])
+        #expect(
+            observation.cookieNames == [
+                "DedeUserID", "DedeUserID__ckMd5", "SESSDATA", "bili_jct", "sid",
+                "unknown_cookie",
+            ]
+        )
         #expect(state.description == "awaiting-credential-validation")
         #expect(!String(describing: observation).contains("FIXTURE_VALUE"))
     }
@@ -339,14 +344,16 @@ struct WebQRLoginSessionTests {
         _ = try await session.requestQRCode()
         let state = try await session.pollOnce()
 
-        guard case let .failed(.unsupportedStatus(observation)) = state else {
+        guard case .failed(.unsupportedStatus(let observation)) = state else {
             Issue.record("未知状态应生成安全观察结果")
             return
         }
         #expect(observation.code == 12_345)
-        #expect(observation.dataFieldNames == [
-            "code", "message", "refresh_token", "timestamp", "url",
-        ])
+        #expect(
+            observation.dataFieldNames == [
+                "code", "message", "refresh_token", "timestamp", "url",
+            ]
+        )
         #expect(observation.urlHost == nil)
         #expect(observation.urlQueryNames.isEmpty)
         #expect(observation.refreshTokenPresent)
@@ -363,10 +370,12 @@ struct WebQRLoginSessionTests {
             statusCode: 200,
             headers: [
                 "Content-Type": "application/json",
-                "Set-Cookie": "fixture_cookie=TOP_SECRET_SHOULD_NOT_REACH_DIAGNOSTICS; Path=/; Secure; HttpOnly",
+                "Set-Cookie":
+                    "fixture_cookie=TOP_SECRET_SHOULD_NOT_REACH_DIAGNOSTICS; Path=/; Secure; HttpOnly",
             ],
             body: Data(
-                #"{"code":0,"data":{"url":"https://www.bilibili.com/?first_name=TOP_SECRET_SHOULD_NOT_REACH_DIAGNOSTICS&second_name=TOP_SECRET_SHOULD_NOT_REACH_DIAGNOSTICS","refresh_token":"TOP_SECRET_SHOULD_NOT_REACH_DIAGNOSTICS","timestamp":1700000001,"code":12345,"message":"fixture"}}"#.utf8
+                #"{"code":0,"data":{"url":"https://www.bilibili.com/?first_name=TOP_SECRET_SHOULD_NOT_REACH_DIAGNOSTICS&second_name=TOP_SECRET_SHOULD_NOT_REACH_DIAGNOSTICS","refresh_token":"TOP_SECRET_SHOULD_NOT_REACH_DIAGNOSTICS","timestamp":1700000001,"code":12345,"message":"fixture"}}"#
+                    .utf8
             )
         )
         let transport = RecordingAuthTransport(
@@ -377,7 +386,7 @@ struct WebQRLoginSessionTests {
         _ = try await session.requestQRCode()
         let state = try await session.pollOnce()
 
-        guard case let .failed(.unsupportedStatus(observation)) = state else {
+        guard case .failed(.unsupportedStatus(let observation)) = state else {
             Issue.record("未知状态应生成安全观察结果")
             return
         }
@@ -389,7 +398,8 @@ struct WebQRLoginSessionTests {
         #expect(observation.cookieAttributeNames.contains("Name"))
         #expect(observation.cookieAttributeNames.contains("Value"))
 
-        let diagnostics = String(describing: observation)
+        let diagnostics =
+            String(describing: observation)
             + String(reflecting: observation)
             + state.description
         #expect(!diagnostics.contains("TOP_SECRET"))
@@ -454,7 +464,8 @@ struct WebQRLoginSessionTests {
     @Test
     func rejectsQRCodeURLOutsideExactHostAllowlist() async throws {
         let body = Data(
-            #"{"code":0,"data":{"url":"https://account.bilibili.com.evil.invalid/login","qrcode_key":"FIXTURE_QR_KEY_00000000000000000"}}"#.utf8
+            #"{"code":0,"data":{"url":"https://account.bilibili.com.evil.invalid/login","qrcode_key":"FIXTURE_QR_KEY_00000000000000000"}}"#
+                .utf8
         )
         let session = WebQRLoginSession(
             transport: RecordingAuthTransport(
@@ -463,7 +474,7 @@ struct WebQRLoginSessionTests {
                         statusCode: 200,
                         headers: ["Content-Type": "application/json"],
                         body: body
-                    ),
+                    )
                 ]
             )
         )

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestVideoCardFormattingTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestVideoCardFormattingTests.swift
@@ -1,6 +1,7 @@
-@testable import BiliBrowseFeature
 import Foundation
 import Testing
+
+@testable import BiliBrowseFeature
 
 struct VideoMetadataFormattingTests {
     @Test

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestViewModelTests.swift
@@ -26,15 +26,16 @@ struct GuestViewModelTests {
         await model.waitForCurrentTask()
 
         #expect(
-            model.state == .loaded(
-                .popular(
-                    PopularPage(
-                        videos: [fixture.popularVideo],
-                        pageNumber: 2,
-                        pageSize: 10
+            model.state
+                == .loaded(
+                    .popular(
+                        PopularPage(
+                            videos: [fixture.popularVideo],
+                            pageNumber: 2,
+                            pageSize: 10
+                        )
                     )
                 )
-            )
         )
     }
 
@@ -52,18 +53,19 @@ struct GuestViewModelTests {
         await model.waitForCurrentTask()
 
         #expect(
-            model.state == .loaded(
-                .search(
-                    query: "macOS",
-                    page: SearchPage(
-                        videos: [fixture.searchVideo],
-                        pageNumber: 2,
-                        pageSize: 20,
-                        totalResults: 1,
-                        totalPages: 1
+            model.state
+                == .loaded(
+                    .search(
+                        query: "macOS",
+                        page: SearchPage(
+                            videos: [fixture.searchVideo],
+                            pageNumber: 2,
+                            pageSize: 20,
+                            totalResults: 1,
+                            totalPages: 1
+                        )
                     )
                 )
-            )
         )
     }
 
@@ -84,15 +86,16 @@ struct GuestViewModelTests {
         try await Task.sleep(for: .milliseconds(30))
 
         #expect(
-            model.state == .loaded(
-                .popular(
-                    PopularPage(
-                        videos: [fixture.popularVideo],
-                        pageNumber: 1,
-                        pageSize: 20
+            model.state
+                == .loaded(
+                    .popular(
+                        PopularPage(
+                            videos: [fixture.popularVideo],
+                            pageNumber: 1,
+                            pageSize: 20
+                        )
                     )
                 )
-            )
         )
     }
 
@@ -109,27 +112,29 @@ struct GuestViewModelTests {
         model.search("macOS", page: 2)
         await model.waitForCurrentTask()
         #expect(
-            model.state == .failed(
-                request: .search(query: "macOS", page: 2),
-                error: .requestRestricted
-            )
+            model.state
+                == .failed(
+                    request: .search(query: "macOS", page: 2),
+                    error: .requestRestricted
+                )
         )
 
         model.retry()
         await model.waitForCurrentTask()
         #expect(
-            model.state == .loaded(
-                .search(
-                    query: "macOS",
-                    page: SearchPage(
-                        videos: [fixture.searchVideo],
-                        pageNumber: 2,
-                        pageSize: 20,
-                        totalResults: 1,
-                        totalPages: 1
+            model.state
+                == .loaded(
+                    .search(
+                        query: "macOS",
+                        page: SearchPage(
+                            videos: [fixture.searchVideo],
+                            pageNumber: 2,
+                            pageSize: 20,
+                            totalResults: 1,
+                            totalPages: 1
+                        )
                     )
                 )
-            )
         )
     }
 
@@ -161,7 +166,7 @@ struct GuestViewModelTests {
                 PlaybackItemIdentity(
                     bvid: fixture.detail.bvid,
                     cid: fixture.page.cid
-                ),
+                )
             ]
         )
     }
@@ -205,7 +210,7 @@ struct GuestViewModelTests {
         await model.waitForCurrentTask()
         try await Task.sleep(for: .milliseconds(120))
 
-        guard case let .ready(context) = model.state else {
+        guard case .ready(let context) = model.state else {
             Issue.record("最新视频未进入就绪状态")
             return
         }
@@ -218,7 +223,6 @@ struct GuestViewModelTests {
             ) == true
         )
     }
-
 }
 
 private struct GuestFixtures: Sendable {

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/PlaybackPageLayoutTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/PlaybackPageLayoutTests.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Testing
+
 @testable import BiliBrowseFeature
 
 struct PlaybackPageLayoutTests {

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/SubtitleViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/SubtitleViewModelTests.swift
@@ -610,7 +610,8 @@ private actor ABAResetSubtitleRepository: SubtitleRepository {
     ) async throws -> [SubtitleTrack] {
         trackRequestCounts[identity, default: 0] += 1
         if identity == repeatedIdentity,
-           trackRequestCounts[identity] == 2 {
+            trackRequestCounts[identity] == 2
+        {
             repeatedReloadBeganBeforeResetCompleted =
                 !staleResetHasCompleted
         }
@@ -643,7 +644,7 @@ private actor ABAResetSubtitleRepository: SubtitleRepository {
         }
 
         guard currentIdentity == identity,
-              generation == requestGeneration
+            generation == requestGeneration
         else {
             throw CancellationError()
         }
@@ -656,7 +657,7 @@ private actor ABAResetSubtitleRepository: SubtitleRepository {
                         ? "初始会话字幕"
                         : "新会话字幕")
                     : "其他视频字幕"
-            ),
+            )
         ]
     }
 

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/SubtitleViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/SubtitleViewModelTests.swift
@@ -2,6 +2,7 @@ import BiliApplication
 import BiliModels
 import Foundation
 import Testing
+
 @testable import BiliBrowseFeature
 
 @Suite
@@ -362,10 +363,11 @@ struct SubtitleViewModelTests {
         authModel.selectVideo(identity)
         await authModel.waitForCurrentTask()
         #expect(
-            authModel.state == .failed(
-                identity,
-                .authenticationRequired
-            )
+            authModel.state
+                == .failed(
+                    identity,
+                    .authenticationRequired
+                )
         )
 
         authModel.reset()
@@ -483,7 +485,7 @@ private actor SubtitleRepositoryStub: SubtitleRepository {
                     startSeconds: 1,
                     endSeconds: 3.5,
                     text: "自动生成字幕"
-                ),
+                )
             ]
         }
         return [
@@ -731,9 +733,7 @@ private actor ABAResetSubtitleRepository: SubtitleRepository {
 @MainActor
 private final class SubtitleTimelineStub: PlaybackTimelineProviding {
     private(set) var currentTimelineSnapshot = PlaybackTimelineSnapshot.idle
-    private var continuations: [
-        UUID: AsyncStream<PlaybackTimelineSnapshot>.Continuation
-    ] = [:]
+    private var continuations: [UUID: AsyncStream<PlaybackTimelineSnapshot>.Continuation] = [:]
 
     func timelineUpdates() -> AsyncStream<PlaybackTimelineSnapshot> {
         let id = UUID()
@@ -752,6 +752,8 @@ private final class SubtitleTimelineStub: PlaybackTimelineProviding {
 
     func publish(_ snapshot: PlaybackTimelineSnapshot) {
         currentTimelineSnapshot = snapshot
-        continuations.values.forEach { $0.yield(snapshot) }
+        for continuation in continuations.values {
+            continuation.yield(snapshot)
+        }
     }
 }

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/VideoCardInteractionTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/VideoCardInteractionTests.swift
@@ -1,4 +1,5 @@
 import Testing
+
 @testable import BiliUI
 
 struct VideoCardInteractionTests {

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuLaneAllocatorTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuLaneAllocatorTests.swift
@@ -259,12 +259,15 @@ struct DanmakuLaneAllocatorTests {
 
     @Test
     func displayAreaFractionMirrorsBottomFromSurfaceEdge() {
-        let cases: [(fraction: Double, expectedTop: [Double],
-                     expectedBottom: [Double])] = [
-            (0.5, [0, 20], [60, 40]),
-            (0.75, [0, 20, 40], [60, 40, 20]),
-            (1, [0, 20, 40, 60], [60, 40, 20, 0]),
-        ]
+        let cases:
+            [(
+                fraction: Double, expectedTop: [Double],
+                expectedBottom: [Double]
+            )] = [
+                (0.5, [0, 20], [60, 40]),
+                (0.75, [0, 20, 40], [60, 40, 20]),
+                (1, [0, 20, 40, 60], [60, 40, 20, 0]),
+            ]
 
         for testCase in cases {
             var allocator = DanmakuLaneAllocator(

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
@@ -1,9 +1,10 @@
 import AppKit
 import BiliApplication
-@testable import BiliDanmaku
 import BiliModels
 import QuartzCore
 import Testing
+
+@testable import BiliDanmaku
 
 @MainActor
 @Suite
@@ -520,12 +521,15 @@ struct DanmakuPresentationControllerTests {
             state: state,
             discontinuityGeneration: generation
         )
-        let batch = events.isEmpty ? nil : DanmakuBatch(
-            identity: identity,
-            discontinuityGeneration: generation,
-            events: events,
-            clearsExisting: false
-        )
+        let batch =
+            events.isEmpty
+            ? nil
+            : DanmakuBatch(
+                identity: identity,
+                discontinuityGeneration: generation,
+                events: events,
+                clearsExisting: false
+            )
         return DanmakuPresentationUpdate(snapshot: snapshot, batch: batch)
     }
 

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSchedulerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSchedulerTests.swift
@@ -1,8 +1,9 @@
 import BiliApplication
-@testable import BiliDanmaku
 import BiliModels
 import Foundation
 import Testing
+
+@testable import BiliDanmaku
 
 @Suite
 struct DanmakuSchedulerTests {
@@ -268,7 +269,8 @@ struct DanmakuSchedulerTests {
         _ = scheduler.consume(snapshot(position: 0, rate: 1, generation: 1))
 
         for index in 1...8 {
-            let start = Double(index - 1)
+            let start =
+                Double(index - 1)
                 * DanmakuScheduler.segmentDurationSeconds
             var events = [
                 event(id: "unique-\(index)", time: start + 1),
@@ -302,18 +304,16 @@ struct DanmakuSchedulerTests {
             let batch = try #require(value)
             #expect(
                 batch.events.map(\.id)
-                    == (
-                        index == 1
-                            ? [
-                                "unique-1",
-                                "rolling-duplicate",
-                                "boundary-1",
-                            ]
-                            : [
-                                "unique-\(index)",
-                                "boundary-\(index)",
-                            ]
-                    )
+                    == (index == 1
+                        ? [
+                            "unique-1",
+                            "rolling-duplicate",
+                            "boundary-1",
+                        ]
+                        : [
+                            "unique-\(index)",
+                            "boundary-\(index)",
+                        ])
             )
             #expect(
                 scheduler.retainedDeliveredSegmentCount

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSessionTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSessionTests.swift
@@ -23,7 +23,7 @@ struct DanmakuSessionTests {
         let deadline = clock.now.advanced(by: .seconds(1))
         do {
             while await repository.requestedIndices().count < 2,
-                  clock.now < deadline
+                clock.now < deadline
             {
                 try await Task.sleep(for: .milliseconds(5))
             }
@@ -62,7 +62,7 @@ struct DanmakuSessionTests {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: .seconds(1))
         while session.state != .ready(second),
-              clock.now < deadline
+            clock.now < deadline
         {
             try await Task.sleep(for: .milliseconds(5))
         }
@@ -199,9 +199,7 @@ private final class SessionPresentationSink: DanmakuPresentationSink {
 @MainActor
 private final class SessionTimeline: PlaybackTimelineProviding {
     private var snapshot = PlaybackTimelineSnapshot.idle
-    private var continuations: [
-        UUID: AsyncStream<PlaybackTimelineSnapshot>.Continuation
-    ] = [:]
+    private var continuations: [UUID: AsyncStream<PlaybackTimelineSnapshot>.Continuation] = [:]
 
     var currentTimelineSnapshot: PlaybackTimelineSnapshot { snapshot }
 
@@ -222,7 +220,9 @@ private final class SessionTimeline: PlaybackTimelineProviding {
 
     func publish(_ snapshot: PlaybackTimelineSnapshot) {
         self.snapshot = snapshot
-        continuations.values.forEach { $0.yield(snapshot) }
+        for continuation in continuations.values {
+            continuation.yield(snapshot)
+        }
     }
 }
 
@@ -247,7 +247,7 @@ private actor SessionRecordingRepository: DanmakuSegmentRepository {
         maximumActive = max(maximumActive, active)
         do {
             try await Task.sleep(for: delay)
-        } catch where !ignoresCancellation {
+        } catch  where !ignoresCancellation {
             active -= 1
             throw CancellationError()
         } catch {}
@@ -294,6 +294,8 @@ private actor ControlledPrefetchRepository: DanmakuSegmentRepository {
         requestsReleased = true
         let waiters = releaseWaiters
         releaseWaiters.removeAll(keepingCapacity: false)
-        waiters.forEach { $0.resume() }
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 }

--- a/Packages/BiliKitCore/Tests/BiliLibraryFeatureTests/WatchHistoryCardFormattingTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliLibraryFeatureTests/WatchHistoryCardFormattingTests.swift
@@ -1,6 +1,7 @@
-@testable import BiliLibraryFeature
 import Foundation
 import Testing
+
+@testable import BiliLibraryFeature
 
 struct WatchHistoryCardFormattingTests {
     @Test

--- a/Packages/BiliKitCore/Tests/BiliLibraryFeatureTests/WatchHistoryViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliLibraryFeatureTests/WatchHistoryViewModelTests.swift
@@ -2,6 +2,7 @@ import BiliApplication
 import BiliModels
 import Foundation
 import Testing
+
 @testable import BiliLibraryFeature
 
 struct WatchHistoryViewModelTests {
@@ -38,7 +39,7 @@ struct WatchHistoryViewModelTests {
         await model.waitForCurrentTask()
         #expect(!model.isBusy)
 
-        guard case let .loaded(items, nextContinuation, error) = model.state else {
+        guard case .loaded(let items, let nextContinuation, let error) = model.state else {
             Issue.record("历史状态不是 loaded")
             return
         }
@@ -87,7 +88,7 @@ struct WatchHistoryViewModelTests {
         model.loadIfNeeded()
         await model.waitForCurrentTask()
 
-        guard case let .loaded(items, nextContinuation, error) = model.state else {
+        guard case .loaded(let items, let nextContinuation, let error) = model.state else {
             Issue.record("历史状态不是 loaded")
             return
         }
@@ -117,7 +118,7 @@ struct WatchHistoryViewModelTests {
         await model.waitForCurrentTask()
         try await Task.sleep(for: .milliseconds(60))
 
-        guard case let .loaded(items, _, _) = model.state else {
+        guard case .loaded(let items, _, _) = model.state else {
             Issue.record("历史状态不是 loaded")
             return
         }
@@ -134,7 +135,7 @@ struct WatchHistoryViewModelTests {
                         items: [item("BV1HistoryA1")],
                         continuation: nil
                     )
-                ),
+                )
             ]
         )
         let model = WatchHistoryViewModel(
@@ -158,7 +159,7 @@ struct WatchHistoryViewModelTests {
                         items: [item("BV1HistoryA1")],
                         continuation: nil
                     )
-                ),
+                )
             ],
             firstDelay: .milliseconds(40)
         )
@@ -186,7 +187,7 @@ struct WatchHistoryViewModelTests {
                         items: [item("BV1HistoryA1")],
                         continuation: nil
                     )
-                ),
+                )
             ],
             firstDelay: .milliseconds(40)
         )
@@ -239,11 +240,12 @@ struct WatchHistoryViewModelTests {
         #expect(lateResultReturned)
 
         #expect(
-            model.state == .loaded(
-                items: [item("BV1HistoryA1")],
-                continuation: continuation,
-                loadMoreError: nil
-            )
+            model.state
+                == .loaded(
+                    items: [item("BV1HistoryA1")],
+                    continuation: continuation,
+                    loadMoreError: nil
+                )
         )
     }
 }

--- a/Packages/BiliKitCore/Tests/BiliModelsTests/PlaybackManifestTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliModelsTests/PlaybackManifestTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import BiliModels
 
 struct PlaybackManifestTests {

--- a/Packages/BiliKitCore/Tests/BiliNetworkingTests/HTTPClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliNetworkingTests/HTTPClientTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import BiliNetworking
 
 struct HTTPClientTests {
@@ -32,7 +33,10 @@ struct HTTPClientTests {
     func redactsSensitiveRequestData() throws {
         let redactor = HTTPLogRedactor()
         let url = try #require(
-            URL(string: "https://example.com/play?bvid=BV1xx&access_key=secret&w_rid=signed&qrcode_key=qr-secret")
+            URL(
+                string:
+                    "https://example.com/play?bvid=BV1xx&access_key=secret&w_rid=signed&qrcode_key=qr-secret"
+            )
         )
 
         let redactedURL = redactor.redact(url: url)

--- a/Packages/BiliKitCore/Tests/BiliNetworkingTests/HTTPRangeClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliNetworkingTests/HTTPRangeClientTests.swift
@@ -86,7 +86,7 @@ struct HTTPRangeClientTests {
                 range: try HTTPByteRange(start: 0, endInclusive: 2)
             )
             Issue.record("Expected every CDN candidate to fail")
-        } catch let HTTPRangeClientError.allCandidatesFailed(attempts) {
+        } catch HTTPRangeClientError.allCandidatesFailed(let attempts) {
             #expect(
                 attempts == [
                     HTTPRangeAttempt(url: first, failure: .statusCode(403)),

--- a/Packages/BiliKitCore/Tests/BiliNetworkingTests/HTTPRangeClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliNetworkingTests/HTTPRangeClientTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import BiliNetworking
 
 struct HTTPRangeClientTests {
@@ -12,7 +13,7 @@ struct HTTPRangeClientTests {
                     statusCode: 206,
                     headers: ["content-range": "bytes 10-12/100"],
                     body: Data([0xaa, 0xbb, 0xcc])
-                ),
+                )
             ]
         )
         let client = HTTPRangeClient(transport: transport)
@@ -133,7 +134,7 @@ struct HTTPRangeClientTests {
                     statusCode: 206,
                     headers: ["Content-Range": "bytes 0-2/100"],
                     body: Data([0, 1, 2])
-                ),
+                )
             ]
         )
         let client = HTTPRangeClient(transport: transport)

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/HLSPlaylistBuilderTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/HLSPlaylistBuilderTests.swift
@@ -1,6 +1,7 @@
 import BiliModels
 import Foundation
 import Testing
+
 @testable import BiliPlayback
 
 struct HLSPlaylistBuilderTests {

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
@@ -4,6 +4,7 @@ import BiliModels
 import BiliNetworking
 import Foundation
 import Testing
+
 @testable import BiliPlayback
 
 struct LoopbackPlaybackServerTests {
@@ -680,10 +681,10 @@ private actor FixtureRangeTransport: HTTPTransport {
             return HTTPResponse(statusCode: 403, body: Data())
         }
         guard let data = media[request.url],
-              let rangeHeader = request.headers.first(where: { name, _ in
-                  name.caseInsensitiveCompare("Range") == .orderedSame
-              })?.value,
-              let range = parseRange(rangeHeader, contentLength: data.count)
+            let rangeHeader = request.headers.first(where: { name, _ in
+                name.caseInsensitiveCompare("Range") == .orderedSame
+            })?.value,
+            let range = parseRange(rangeHeader, contentLength: data.count)
         else {
             return HTTPResponse(statusCode: 400, body: Data())
         }
@@ -694,7 +695,7 @@ private actor FixtureRangeTransport: HTTPTransport {
         return HTTPResponse(
             statusCode: 206,
             headers: [
-                "Content-Range": "bytes \(range.start)-\(range.endInclusive)/\(data.count)",
+                "Content-Range": "bytes \(range.start)-\(range.endInclusive)/\(data.count)"
             ],
             body: body
         )
@@ -711,11 +712,11 @@ private actor FixtureRangeTransport: HTTPTransport {
             omittingEmptySubsequences: false
         )
         guard bounds.count == 2,
-              let start = Int64(bounds[0]),
-              let end = Int64(bounds[1]),
-              start >= 0,
-              end >= start,
-              end < Int64(contentLength)
+            let start = Int64(bounds[0]),
+            let end = Int64(bounds[1]),
+            start >= 0,
+            end >= start,
+            end < Int64(contentLength)
         else {
             return nil
         }
@@ -742,16 +743,16 @@ private actor ReplacementRangeTransport: HTTPTransport {
 
     func send(_ request: HTTPRequest) async throws -> HTTPResponse {
         guard let data = media[request.url],
-              let rangeHeader = request.headers.first(where: { name, _ in
-                  name.caseInsensitiveCompare("Range") == .orderedSame
-              })?.value,
-              let requestedRange = parseRange(rangeHeader)
+            let rangeHeader = request.headers.first(where: { name, _ in
+                name.caseInsensitiveCompare("Range") == .orderedSame
+            })?.value,
+            let requestedRange = parseRange(rangeHeader)
         else {
             return HTTPResponse(statusCode: 400, body: Data())
         }
 
         if blockedMediaURLs.contains(request.url),
-           requestedRange != indexRanges[request.url]
+            requestedRange != indexRanges[request.url]
         {
             startedMediaRequestCount += 1
             do {
@@ -768,7 +769,8 @@ private actor ReplacementRangeTransport: HTTPTransport {
         return HTTPResponse(
             statusCode: 206,
             headers: [
-                "Content-Range": "bytes \(requestedRange.start)-\(requestedRange.endInclusive)/\(data.count)",
+                "Content-Range":
+                    "bytes \(requestedRange.start)-\(requestedRange.endInclusive)/\(data.count)"
             ],
             body: body
         )
@@ -782,8 +784,8 @@ private actor ReplacementRangeTransport: HTTPTransport {
             omittingEmptySubsequences: false
         )
         guard bounds.count == 2,
-              let start = Int64(bounds[0]),
-              let end = Int64(bounds[1])
+            let start = Int64(bounds[0]),
+            let end = Int64(bounds[1])
         else {
             return nil
         }

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/PlaybackRequestTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/PlaybackRequestTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import BiliModels
 @testable import BiliPlayback
 

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/SIDXParserTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/SIDXParserTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import BiliModels
 @testable import BiliNetworking
 @testable import BiliPlayback

--- a/Scripts/check-project-contract.sh
+++ b/Scripts/check-project-contract.sh
@@ -13,7 +13,8 @@ assert_occurrences() {
     file="$3"
     description="$4"
     actual=$(awk -v needle="$text" 'index($0, needle) { count += 1 } END { print count + 0 }' "$file")
-    [ "$actual" -eq "$expected" ] || fail "$description（期望 $expected 处，实际 $actual 处）"
+    [ "$actual" -eq "$expected" ] \
+        || fail "${description}（期望 $expected 处，实际 $actual 处）"
 }
 
 project_file="BiliKitMac.xcodeproj/project.pbxproj"
@@ -21,6 +22,25 @@ entitlements_file="BiliKitMac/BiliKitMac.entitlements"
 package_file="Packages/BiliKitCore/Package.swift"
 package_resolution_file="Packages/BiliKitCore/Package.resolved"
 xcode_resolution_file="BiliKitMac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+quality_gate_file="Scripts/run-quality-gates.sh"
+swift_format_config=".swift-format"
+swift_format_check="Scripts/check-swift-format.sh"
+ci_file=".github/workflows/ci.yml"
+
+[ -f "$swift_format_config" ] || fail "缺少仓库根 Swift 格式配置"
+[ -x "$swift_format_check" ] || fail "Swift 格式检查脚本缺失或不可执行"
+assert_occurrences 1 \
+    'sh Scripts/check-swift-format.sh || return $?' \
+    "$quality_gate_file" \
+    "统一质量 Gate 必须强制执行 Swift 格式检查"
+assert_occurrences 1 \
+    'Run App quality gate (includes strict Swift format lint)' \
+    "$ci_file" \
+    "CI 必须明确通过统一 App Gate 执行 strict Swift 格式检查"
+assert_occurrences 1 \
+    'run: sh Scripts/run-quality-gates.sh app' \
+    "$ci_file" \
+    "CI 必须运行统一 App Gate"
 
 /usr/bin/plutil -lint "$entitlements_file" >/dev/null \
     || fail "entitlements 不是有效 plist"
@@ -59,7 +79,7 @@ deployment_count=$(awk '/MACOSX_DEPLOYMENT_TARGET = / { count += 1; if ($0 !~ /M
 set -- $deployment_count
 [ "$1" -gt 0 ] || fail "Xcode 工程没有 deployment target"
 [ "$2" -eq 0 ] || fail "Xcode target 的最低系统版本没有统一为 macOS 15"
-assert_occurrences 1 '.macOS(.v15),' "$package_file" "Swift Package 最低系统版本必须为 macOS 15"
+assert_occurrences 1 '.macOS(.v15)' "$package_file" "Swift Package 最低系统版本必须为 macOS 15"
 
 for product in BiliBrowseFeature BiliLibraryFeature BiliAuthFeature; do
     assert_occurrences 1 \

--- a/Scripts/check-swift-format.sh
+++ b/Scripts/check-swift-format.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -eu
+
+fail() {
+    echo "Swift 格式检查失败：$1" >&2
+    exit 1
+}
+
+[ -f ".swift-format" ] || fail "仓库根目录缺少 .swift-format"
+
+swift_format=$(xcrun --find swift-format 2>/dev/null) \
+    || fail "当前 Xcode/Command Line Tools 不提供 swift-format"
+
+# Protobuf 生成物由 schema 与固定 generator 负责，不把机械格式化结果作为源码契约。
+"$swift_format" lint \
+    --strict \
+    --parallel \
+    --configuration .swift-format \
+    Packages/BiliKitCore/Package.swift
+
+find BiliKitMac BiliKitMacTests BiliKitMacUITests \
+    Packages/BiliKitCore/Sources Packages/BiliKitCore/Tests \
+    -type f \
+    -name '*.swift' \
+    ! -name '*.pb.swift' \
+    -exec "$swift_format" lint \
+        --strict \
+        --parallel \
+        --configuration .swift-format \
+        {} +
+
+echo "Swift 格式检查通过"

--- a/Scripts/run-quality-gates.sh
+++ b/Scripts/run-quality-gates.sh
@@ -55,6 +55,7 @@ run_static_contracts() {
     sh Scripts/check-architecture.sh || return $?
     sh Scripts/check-secrets.sh || return $?
     sh Scripts/check-project-contract.sh || return $?
+    sh Scripts/check-swift-format.sh || return $?
     git diff --check || return $?
     git diff --cached --check || return $?
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@
 - [`validation/M4.5-slice-a-2026-07-23.md`](./validation/M4.5-slice-a-2026-07-23.md)：Slice A 两栏路由、卡片流、播放返回、生命周期与本机 Gate 的候选证据。
 - [`validation/M4.5-slice-b-2026-07-24.md`](./validation/M4.5-slice-b-2026-07-24.md)：Slice B 播放页响应式布局、单 host 生命周期、签名 App 与本机 Gate 的候选证据。
 - [`product/PRODUCT-VISION.md`](./product/PRODUCT-VISION.md)：首页个性推荐起点的日常观看核心闭环、v1 截线与 M4.5 之后的产品优先级。
+- [`validation/M4.7-architecture-lint-governance-2026-07-25.md`](./validation/M4.7-architecture-lint-governance-2026-07-25.md)：按需架构 reviewer、Swift 格式基线、负向 lint 与本机统一 Gate 证据。
 - [`product/UIUX-VISION.md`](./product/UIUX-VISION.md)：App 级 UI/UX 长期产品蓝图，以及搜索空页、播放页和未来数据能力的边界。
 - [`development/M5.0-daily-client-state-retention-decision.md`](./development/M5.0-daily-client-state-retention-decision.md)：热门／最后搜索工作集保留、刷新、上限、清理与后续缓存边界的待确认 D2 契约。
 - [`development/M4.6-subtitle-lifecycle-roadmap-decision.md`](./development/M4.6-subtitle-lifecycle-roadmap-decision.md)：已确认的字幕生命周期稳定化、真实证据边界与精简 v1 截线。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -491,6 +491,35 @@ Gate：
 - ROADMAP、产品愿景与 UI/UX 蓝图必须统一上述截线，同时继续把各 M5 切片写成待确认
   契约而非生产授权。
 
+### M4.7：架构审查与 Swift 格式基线
+
+目标：在后续功能继续扩大 Browse、Library、Application 与 adapter 边界前，补齐自动
+依赖检查无法证明的架构审查视角，并让本地与 CI 对全部手写 Swift 源码执行同一套强制
+格式规则。
+
+交付物：
+
+- 将按需 `architecture_reviewer` 的选择方法写回独立
+  `project-governance-bootstrap` Skill，再用 upgrade 模式更新本项目配置。
+- 架构 reviewer 只在确实改变跨 target 的依赖／owner／公共面／迁移责任、公共 API、
+  Composition、抽象准入、迁移双轨、语义 ownership 或重要架构 Gate 时启动；纯机械
+  跨 target 改动不单独触发，也不增加主观 clean-code reviewer。
+- 将 `/Volumes/Data/Projects/.swift-format` 复制为仓库根配置；统一 Gate 对 App、
+  App Tests／UI Tests、Package manifest、Sources 与 Tests 执行 strict lint，排除固定
+  generator 产生的 protobuf。
+- 对既有手写 Swift 源码建立一次性格式基线；CI 复用统一 App Gate，不维护第二套规则。
+- 用新 reviewer 对当前仓库执行一次真实只读架构审查，以 blocker／improvement／reject
+  检查角色边界、触发条件与输出是否具有决策价值。
+
+Gate：
+
+- 独立 Skills 仓库验证与 BiliKit 最高适用统一 App Gate 通过。
+- `Scripts/check-swift-format.sh` 对未跟踪和已跟踪的范围一致生效，故意制造的格式错误
+  能让检查失败，恢复后通过。
+- 架构 reviewer 不重复普通行为审查或红区安全终审，不把文件长度、命名偏好和对称性
+  单独升级为 blocker；实际审查结果能指出静态 import Gate 无法证明的边界。
+- macOS 15/26 CI 的统一 App Gate 包含 strict Swift format lint。
+
 ### M5：日常观看核心闭环
 
 目标：完成“首页个性推荐流 → 视频／字幕／弹幕 → 推荐连续切换 → 返回来源”的

--- a/docs/development/QUALITY-GATES.md
+++ b/docs/development/QUALITY-GATES.md
@@ -81,6 +81,15 @@
 - reviewer 结论冲突或共同导致预算超限时，主 Agent 返回决策价值 Gate；不得把三份意见机械合并成更大的方案。
 - 路径和调用链已经明确时不重复启动 `explorer`；边界很小且主 Agent 可以直接完成时不启动 `worker`。reviewer 优先复用证据包中的验证摘要，只在证据不足或需要独立复现具体失败时运行定点测试，不为形式完整重复全量 Gate。
 
+架构审查是按需视角，不是所有黄区改动的附加仪式。任务确实改变 target 间依赖、owner、
+公共面或迁移责任，修改 Package product／公共 API／Composition root，新增 Repository／
+Use Case／共享组件，触发 ADR 0006 的职责规模审查，迁移可能留下新旧双轨，语义命名
+不再匹配 owner，或准备关闭重要架构 Gate 时，使用独立 `architecture_reviewer`。它沿
+一条代表性产品路径检查依赖方向、类型归属、具体 adapter 可见性、公共面最小性、
+Composition 纯度、抽象真实调用方和迁移完整性。纯机械跨 target 改动、文件长度、
+target 数、覆盖率、命名偏好和对称性只是线索，不能单独成为 blocker。机械格式由
+确定性 lint 负责，不创建 clean-code reviewer。
+
 ## 模型路由与升级
 
 项目配置位于 `.codex/config.toml` 与 `.codex/agents/`。默认主 Agent 为 Sol Medium；子 Agent 按任务的认知难度路由：
@@ -90,6 +99,7 @@
 | `explorer` | Luna Low，只读 | 找符号、入口、依赖、有限调用链和整理日志 | 架构取舍、竞态、安全或生命周期结论 |
 | `worker` | Terra Medium | 按已确认契约实现可独立验证的窄切片 | 改变公共 API、架构、安全边界或验收条件 |
 | `reviewer` | Terra High，只读 | 黄区的契约、失败、取消、测试与维护性审查 | 红区最终签字 |
+| `architecture_reviewer` | Sol High，只读，按需 | 依赖方向、类型归属、公共面、Composition、抽象准入与迁移完整性 | 一般行为审查、红区安全终审、主观样式统一 |
 | `red_reviewer` | Sol High，只读 | 线程、生命周期、认证、安全、播放、renderer、迁移和重要 Gate 终审 | 代替真实探针、长时测量或用户确认 |
 
 满足任一条件时停止当前低成本路线并升级主 Agent 或 `red_reviewer`：
@@ -113,6 +123,12 @@ sh Scripts/run-quality-gates.sh app      # App/Xcode/composition；包含 packag
 ```
 
 每次只运行最高适用模式，不顺序执行 `static → package → app`。风险等级只会追加验证，不会降低基线：所有代码改动至少运行 `package`，涉及 App/Xcode/composition 时运行 `app`。本地 Agent 运行 Gate 时默认使用 `BILIKIT_COMPACT_LOGS=1 sh Scripts/run-quality-gates.sh <mode>`：成功时只输出阶段结果和临时完整日志路径，失败时输出有界日志尾部；完整日志属于临时诊断证据，可能被系统清理。CI 不设置该变量，继续保留完整日志。reviewer 默认读取主 Agent 提供的 Gate 摘要，只在证据不足或需要独立复现时运行定点测试；整改完成后由主 Agent 运行一次最高适用的最终 Gate。
+
+三个统一模式都通过 `Scripts/check-swift-format.sh` 对 App、App Tests／UI Tests、
+Package manifest、Sources 与 Tests 中的 Swift 源码执行根目录 `.swift-format` 的
+strict lint；固定 generator 产生的 `*.pb.swift` 除外。CI 调用同一 App Gate，不维护
+第二套格式规则。格式修复使用相同配置运行 `swift-format format --in-place`，不得通过
+放宽规则、复制配置或只检查 changed files 让既有源码与新代码形成双重标准。
 
 脚本尊重当前 `xcode-select`；只有调用方显式设置时才使用 `DEVELOPER_DIR`。本地 whitespace 检查覆盖 tracked 的 unstaged/staged diff，untracked 文件在暂存后或 CI 的提交范围检查中覆盖。上述命令只证明构建、确定性测试和静态契约。红区任务必须在任务契约中追加具体命令和阈值，例如受控播放探针、弹幕高密度基准、30 分钟 soak、签名 Keychain smoke 或真实 UI 检查。普通 `swift test` 输出保留在 CI；只有难以自动化、以后需要复查的真实设备、网络、性能、安全或兼容性证据才写入 `docs/validation/`。
 

--- a/docs/validation/M4.7-architecture-lint-governance-2026-07-25.md
+++ b/docs/validation/M4.7-architecture-lint-governance-2026-07-25.md
@@ -10,7 +10,7 @@
 - BiliKit 增加 `architecture_reviewer`，并固定与普通 reviewer、`red_reviewer` 的职责；
 - 根目录 `.swift-format`、覆盖 App、App Tests／UI Tests、Package manifest、Sources
   与 Tests 的 strict lint 脚本、统一 Gate 和 CI 接线；
-- 138 个手写 Swift 文件的一次性格式基线，固定 generator 产生的 protobuf 不在范围内。
+- 139 个手写 Swift 文件的一次性格式基线，固定 generator 产生的 protobuf 不在范围内。
 
 ## 确定性验证
 

--- a/docs/validation/M4.7-architecture-lint-governance-2026-07-25.md
+++ b/docs/validation/M4.7-architecture-lint-governance-2026-07-25.md
@@ -1,0 +1,52 @@
+# M4.7 架构审查与 Swift 格式基线验证
+
+- 日期：2026-07-25（Asia/Tokyo）
+- 环境：macOS 26.5.2 arm64、Xcode 26.6、Swift Format 6.3.0
+- 分支：`codex/m4.7-architecture-lint-governance`
+
+## 范围
+
+- 独立 `project-governance-bootstrap` Skill 增加按需架构 reviewer 选择规则；
+- BiliKit 增加 `architecture_reviewer`，并固定与普通 reviewer、`red_reviewer` 的职责；
+- 根目录 `.swift-format`、覆盖 App、App Tests／UI Tests、Package manifest、Sources
+  与 Tests 的 strict lint 脚本、统一 Gate 和 CI 接线；
+- 138 个手写 Swift 文件的一次性格式基线，固定 generator 产生的 protobuf 不在范围内。
+
+## 确定性验证
+
+- `sh scripts/validate-all-skills.sh`：通过，两个独立 Skill 的 metadata、链接、shell
+  syntax 与仓库检查均通过。
+- `Scripts/check-swift-format.sh` 负向验证：在受检目录加入未跟踪且故意缩进错误的
+  Swift 文件后正确失败；删除该文件后 strict lint 通过。
+- `BILIKIT_COMPACT_LOGS=1 sh Scripts/run-quality-gates.sh app`：在
+  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer` 下通过 static、Package
+  tests、无签名 App build-for-testing 与 App unit tests。
+- `apple-dev-preflight.sh`：项目、scheme、Xcode 26.6、mcpbridge、xcresulttool、
+  xctrace、devicectl 与 simctl 可用；沙箱内无法读取 Xcode process list，不影响本次
+  CLI Gate。
+
+## 独立审查
+
+Skill 只读审查未发现 blocker；其 improvement 要求主 Skill 以详细 agent-routing
+准入规则为准，避免单一重复风险就创建常驻 reviewer，已整改。
+
+新架构 reviewer 沿
+`App/Composition → BiliBrowseFeature → BiliApplication port → BiliAPI adapter → Models`
+执行真实只读审查：
+
+- 当前 Browse 纵向链未发现 Feature 直连 adapter、Composition 夹带 Feed 流程或旧
+  Feature target 双轨；
+- 首轮发现 Roadmap 错把 Package Gate 写成关闭证据，并发现“跨 target”触发条件会
+  误收纯机械格式化；两项均已整改为最高适用 App Gate，以及只有改变依赖、owner、
+  公共面或迁移责任才触发；
+- 记录一项非阻断后续问题：`BiliAPIService` 与 Application-owned
+  `GuestContentRepository` 暴露近似能力，前者可能只是 adapter 内测试 seam 却保持
+  public。它不属于 M4.7，不在本切片顺手修改公共 API。
+
+## 边界
+
+- 本次没有真实 UI、签名、账号、网络 endpoint、设备或 Instruments 需求，也未据此
+  声称产品运行时行为得到重新验收。
+- macOS 15/26 CI 只有在提交并推送后才能形成远程证据；本地 App Gate 不能代替它。
+- 当前任务中的独立试运行直接读取新 reviewer 配置作为 mandate；新 Codex 任务对项目
+  agent 配置的自动重载仍需在后续新任务中观察。


### PR DESCRIPTION
## Goal

建立 M4.7 的架构审查路由与全仓 Swift 格式强制门禁，使架构、代码纯净度和格式问题能在本地与 CI 中按风险一致地被发现。

## Context / Constraints

- 对应 `docs/ROADMAP.md` 的 M4.7，不改变用户可见产品行为。
- 保持单一本地 Swift Package 和现有 target 拓扑，不新增 Feature target、产品依赖或运行时组件。
- 复用仓库统一 App Gate；CI 不另建一套配置或命令。
- `.swift-format` 与 `/Volumes/Data/Projects/.swift-format` 保持一致；生成的 protobuf Swift 文件继续排除，手写 Swift 源码全部纳入。
- 本次只记录架构审查发现，不顺带调整 `BiliAPIService` 等生产接口；后续改进进入 M4.7.1 单独处理。

## Done when

- `.swift-format` 成为仓库根目录的唯一格式配置。
- App、App tests/UI tests、Package manifest、Package Sources/Tests 的 139 个手写 Swift 文件通过 strict lint。
- `Scripts/run-quality-gates.sh` 和 GitHub Actions 的 App Gate 强制执行格式检查。
- 项目按需提供独立的 architecture reviewer，并由 AGENTS/QUALITY-GATES 约束触发条件与输出。
- 使用新配置完成一次真实只读架构审查并记录结论。

## 决策价值与复杂度预算

- 本变更支持的 1–2 个决策：是否需要独立架构审查角色；是否将 Swift 格式从约定升级为强制 Gate。
- 会改变下一步的结果 / 不会改变决策的非目标：会统一后续 PR 的审查与格式证据；不改变产品架构、API 语义或 UI。
- 候选理由 / 更便宜的淘汰方式：仅增加一个按需 architecture reviewer 和一条既有 Gate 内的 lint 检查；未增加常驻 clean-code reviewer 或第二套 CI。
- 候选、指标、矩阵与实施组件预算：1 个 reviewer 定义、1 个根配置、1 个 lint 脚本入口、既有 App Gate 与 CI 接线、1 份验证记录。
- 是否超预算；若是，用户确认与受保护决策：未超预算。

## 风险与关键路径

- 风险等级：黄区
- 风险理由：修改项目级 Agent 路由、质量 Gate、CI 行为并对全仓手写 Swift 建立机械格式基线，但不改变生产运行时语义。
- 人工追踪的关键路径：根配置 → `check-swift-format.sh` → `run-quality-gates.sh app` → GitHub Actions；AGENTS/QUALITY-GATES → architecture reviewer → 只读审查记录。
- 回滚方式：回滚本 PR 的提交；产品代码与持久化数据无需迁移。

## 验证

- [x] `sh Scripts/run-quality-gates.sh static`
- [x] `sh Scripts/run-quality-gates.sh package`（由最高适用的 App Gate 覆盖）
- [x] `sh Scripts/run-quality-gates.sh app`
- [x] 任务专用真实探针/测量（不适用；本次不触及红区生产行为。已额外验证错误格式的临时 Swift 文件会被 lint 拒绝）

补充结果：

- 本地 Xcode 26.6 App Gate：static contracts、Swift Package、App build-for-testing、App unit tests 全部通过。
- [GitHub Actions run 30148711775](https://github.com/shiinayane/BiliKit-Mac/actions/runs/30148711775)：macOS 15 / Xcode 16.4 与 macOS 26 / Xcode 26.5 双矩阵全部通过。
- strict lint 覆盖 139 个手写 Swift 文件；生成 protobuf 文件按策略排除。
- 独立 Skill 校验器通过。

未验证或跳过项：

- 可复用 `project-governance-bootstrap` Skill 的源仓库是独立、尚未初始化远端的本地仓库，其更新已在本地验证，但不属于本 PR 的提交范围。

## 独立审查

- 价值与简化审查：保留 architecture reviewer；不新增泛化 clean-code reviewer，代码纯净度继续由静态脚本与现有 reviewer 契约承担。
- 可理解性审查：修正了机械跨 target 变更的触发歧义，并明确 reviewer 是按结构风险触发而非按文件数量触发。
- 技术正确性审查：对 Browse 链路执行真实只读审查，未发现当前阻断；`BiliAPIService` 可能形成重复于 Application port 的过宽测试 seam，记录为 M4.7.1 改进项。
- 是否触发升级，原因：未触发红区升级；本次没有认证、媒体、持久化、资源生命周期或不可逆生产契约变化。
- reviewer 建议是否导致预算超限；如何处理：没有；两处治理歧义已在本 PR 修正，生产接口建议延期。
- 已知剩余边界：M4.7.1 需要确认 `BiliAPIService` 的真实调用方与测试价值后，再决定收窄、内化或保留。

红区附加记录：不适用。