### PR TITLE
docs: 规范Codex托管工作树流程

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,9 @@ BiliKit App = App/ + Composition/ + Platform/
 - 修复优先复现问题；异步测试使用事件、状态或 continuation 判断完成，固定时间只作超时。
 - 外部 CLI 在受限网络中报告认证或连接失败时，先在获准联网的等价只读环境复核，
   不要直接要求用户重新登录或修改凭据。
+- 需要隔离开发时，默认新建独立的 Codex managed Worktree 对话；不要在现有对话中手动
+  执行 `git worktree add`，也不要通过切换工作目录跨工作树修改。只有用户明确要求时才使用
+  Local、Handoff、permanent worktree 或手工 Git worktree。
 - 保留已有工作树改动。没有用户明确要求时，不提交、不推送、不创建 PR、不改写 Git 历史。
 - reviewer、subagent、Plan mode 和专项 Skill 都按任务需要使用，不是必经流程。
 


### PR DESCRIPTION
## 变化

- 在仓库级 `AGENTS.md` 中规定：需要隔离开发时，默认新建独立的 Codex managed Worktree 对话
- 禁止在现有对话中手动执行 `git worktree add` 或通过切换工作目录跨工作树修改
- 仅在用户明确要求时使用 Local、Handoff、permanent worktree 或手工 Git worktree

## 原因

此前“新开 worktree”没有明确区分 Codex 托管工作树与手工 Git worktree，导致同一对话可能跨目录操作，削弱对话与工作树之间的隔离和可追踪性。该规则把默认解释固定为 Codex 原生托管流程。

## 用户影响

后续隔离任务默认采用“一项任务、一个 managed Worktree 对话”的工作方式，减少跨工作树误改和工作目录分散。该变更仅影响协作流程，不改变 App 产品代码或运行行为。

## 验证

- `git diff --check`
- `sh Scripts/run-quality-gates.sh static`

## 未覆盖边界

- Worktree root 仍由 Codex 客户端全局设置管理，不在仓库内配置
- 本规则不机械阻止 Git 命令；显式用户指令仍可选择其他工作方式