### PR TITLE
docs: 建立本地入门文档目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ DerivedData/
 # nor redistribution inputs, and the directory is intentionally absent from the
 # Xcode project. See docs/README.md for the policy.
 /references/
+
+# Personal project-learning notes. They describe one local checkout and are not
+# a project contract or release input.
+/docs/_local/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+# Give newly created Codex managed worktrees a read-only snapshot of the local
+# project-learning notes. The Local checkout remains their source of truth.
+docs/_local/


### PR DESCRIPTION
## 变化

- 在 `.gitignore` 中增加 `docs/_local/`，为个人项目学习材料保留明确的本地空间
- 新增 `.worktreeinclude`，让新建 Codex managed Worktree 在创建时得到该目录的只读快照
- 本地入门文档正文继续保持 ignored，不进入仓库、CI 或发布输入

## 原因

项目已经形成导航、认证、播放、字幕、弹幕和多层状态 owner。个人学习笔记需要与正式 ROADMAP、ADR 和验证记录分开，避免为了帮助理解而把大量教程性说明塞进生产源码。

## 用户影响

用户可以在 Local checkout 维护一份项目入门地图；后续 managed Worktree 可读取创建时快照，但不会把个人笔记提交到远端。App 产品行为不变。

## 验证

- `git check-ignore -v docs/_local/README.md`
- 本地入门文档相对链接检查
- `sh Scripts/run-quality-gates.sh static`

## 未覆盖边界

- `.worktreeinclude` 只在 managed Worktree 创建时复制快照，不提供持续双向同步
- `docs/_local/` 的内容不是项目契约，不能作为功能完成或外部协议正确性的证据