### PR TITLE
docs(swift): 补全关键边界文档注释

### DIFF
--- a/BiliKitMac/App/AppNavigationCoordinator.swift
+++ b/BiliKitMac/App/AppNavigationCoordinator.swift
@@ -12,6 +12,10 @@ struct PlaybackDestination: Hashable {
 
 @MainActor
 @Observable
+/// 协调窗口内的顶层 Tab、原生导航路径与播放生命周期副作用。
+///
+/// Coordinator 不拥有播放器；它把路径是否存在视为播放资源是否应存活的事实，
+/// 因而系统返回、切换 Tab 与关窗都通过同一条 `startPlayback`/`stopPlayback` 边界收口。
 final class AppNavigationCoordinator {
     var selectedTab: AppTab = .popular {
         didSet {
@@ -45,6 +49,7 @@ final class AppNavigationCoordinator {
         self.stopPlayback = stopPlayback
     }
 
+    /// 用当前 Tab 的类型化路径打开视频，并由路径差异触发播放准备。
     func openPlayback(_ bvid: String) {
         guard !bvid.isEmpty else { return }
         playbackPath = [PlaybackDestination(bvid: bvid)]
@@ -55,6 +60,7 @@ final class AppNavigationCoordinator {
         startPlayback(bvid)
     }
 
+    /// 清空所有 Tab 的播放路径，并只对当前可见播放目的地执行一次停止副作用。
     func resetForWindowClosure() {
         let previousPath = playbackPath
         replacePlaybackPath([], for: .search)
@@ -65,6 +71,7 @@ final class AppNavigationCoordinator {
         searchDraft = ""
     }
 
+    /// 接收 `NavigationStack` 的系统回写；非当前 Tab 的迟到回写不会改变播放 owner。
     func updatePlaybackPath(
         _ path: [PlaybackDestination],
         for tab: AppTab

--- a/BiliKitMac/App/AppRootView.swift
+++ b/BiliKitMac/App/AppRootView.swift
@@ -11,6 +11,10 @@ import BiliLibraryFeature
 import SwiftUI
 
 @MainActor
+/// 保存一个窗口内必须同代且跨 SwiftUI `body` 重算保持稳定的对象图。
+///
+/// 尤其是视频、字幕、弹幕模型与 `playerContent` 必须共享 `AppEnvironment` 中同一个
+/// `AVPlayerEngine`；分别重建会造成画面、时间线与 overlay 指向不同播放项目。
 private final class AppWindowOwner {
     let navigationCoordinator: AppNavigationCoordinator
     let browseModel: GuestBrowseViewModel
@@ -71,6 +75,10 @@ private final class AppWindowOwner {
     }
 }
 
+/// 窗口级生命周期入口，连接导航激活、认证变化与最终资源清理。
+///
+/// 页面 View 只表达局部意图；关窗时需要在这里清除 Browse/History 工作集、认证临时任务，
+/// 并借导航路径清空统一停止播放、字幕和弹幕资源。
 struct AppRootView: View {
     @State private var windowOwner: AppWindowOwner
     @State private var isAuthenticationPresented = false
@@ -187,6 +195,7 @@ struct AppRootView: View {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// 提交规范化搜索意图；编辑中的 draft 本身不会触发网络请求。
     private func performSearch() {
         guard !normalizedSearchDraft.isEmpty else { return }
         navigationCoordinator.searchDraft = normalizedSearchDraft
@@ -205,6 +214,7 @@ struct AppRootView: View {
         }
     }
 
+    /// 激活当前 Tab 对应的 Browse 工作集并等待当前模型任务；任务所有权与取消仍由 ViewModel 管理。
     private func applyBrowseActivation(
         for activation: BrowseActivation
     ) async {

--- a/BiliKitMac/App/AppShellView.swift
+++ b/BiliKitMac/App/AppShellView.swift
@@ -3,6 +3,10 @@ import BiliBrowseFeature
 import BiliLibraryFeature
 import SwiftUI
 
+/// 描述窗口的原生 Tab/NavigationStack 外壳，同时保留每个来源独立的路径与滚动位置。
+///
+/// 系统返回通过 path Binding 回写 coordinator，使播放停止与视觉导航保持同一事实来源；
+/// SwiftUI `body` 与普通样式 modifier 不承担资源生命周期。
 struct AppShellView: View {
     let navigationCoordinator: AppNavigationCoordinator
     let browseModel: GuestBrowseViewModel

--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -12,6 +12,10 @@ import Foundation
 import SwiftUI
 
 @MainActor
+/// App 的 Composition Root：创建具体 adapter，并把它们收窄为 Feature 所需的 port。
+///
+/// 这里刻意同时看见 API、认证、播放和弹幕实现。一个环境只创建一个 `AVPlayerEngine`，
+/// 字幕、弹幕、视频模型与 AppKit player host 必须共享它的播放 identity 和时间线。
 struct AppEnvironment {
     private let playerEngine: AVPlayerEngine
     private let guestContentRepository: any GuestContentRepository
@@ -101,6 +105,10 @@ struct AppEnvironment {
         )
     }
 
+    /// 创建生产对象图，并保持游客、媒体与字幕正文请求不自动继承登录 Cookie。
+    ///
+    /// 只有显式声明为已认证的 API 请求才经过 authorizer；登出还会替换 API 的
+    /// ephemeral transport，使旧认证会话中的在途请求失效。
     static func live() -> AppEnvironment {
         let requestAuthorizer = BiliCredentialRequestAuthorizer()
         let transportFactory: @Sendable () -> any HTTPTransport = {

--- a/BiliKitMac/Platform/DanmakuOverlayHostView.swift
+++ b/BiliKitMac/Platform/DanmakuOverlayHostView.swift
@@ -2,6 +2,10 @@ import AppKit
 import BiliDanmaku
 
 @MainActor
+/// 将 renderer 的 layer 挂到当前 `AVPlayerView` overlay，并独占其尺寸更新权。
+///
+/// `ownerID` 防止已拆除 host 的迟到 layout/detach 清空新 host；零尺寸只表示 surface
+/// 尚未完成布局，不会扩大为另一个渲染会话。
 final class DanmakuOverlayView: NSView {
     private let renderer: CoreAnimationDanmakuRenderer
     private let controller: DanmakuPresentationController
@@ -44,6 +48,7 @@ final class DanmakuOverlayView: NSView {
         nil
     }
 
+    /// 仅由当前 surface owner 发布布局尺寸；尺寸变化会清空无法安全迁移的活动弹幕。
     func updateSurfaceIfNeeded() {
         guard bounds.size != previousSize else { return }
         previousSize = bounds.size
@@ -63,6 +68,7 @@ final class DanmakuOverlayView: NSView {
         )
     }
 
+    /// 撤销当前 host 的 ownership；不是 owner 时不会触碰后来接管的 surface。
     func detachSurface() {
         guard isSurfaceAttached else { return }
         isSurfaceAttached = false

--- a/BiliKitMac/Platform/PlayerHostView.swift
+++ b/BiliKitMac/Platform/PlayerHostView.swift
@@ -2,6 +2,10 @@ import AVKit
 import BiliDanmaku
 import SwiftUI
 
+/// 把唯一 `AVPlayer` 宿主与字幕、弹幕 overlay 组合为稳定的播放 surface。
+///
+/// 响应式页面可以重排这个 View，但不应创建第二个 player host；AppKit host 的销毁会
+/// 主动断开 player 并释放弹幕 surface ownership。
 struct PlayerHostView<Overlay: View>: View {
     let player: AVPlayer
     let danmakuRenderer: CoreAnimationDanmakuRenderer
@@ -99,6 +103,7 @@ private struct AVPlayerContainerView: NSViewRepresentable {
         }
     }
 
+    /// 在 SwiftUI 销毁宿主时先撤销弹幕 surface，再断开 AVPlayer，避免旧 host 继续呈现。
     static func dismantleNSView(
         _ view: DanmakuPlayerView,
         coordinator: Coordinator

--- a/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliSubtitleRepository.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliSubtitleRepository.swift
@@ -3,6 +3,10 @@ import BiliModels
 import BiliNetworking
 import Foundation
 
+/// 保存当前播放 identity 的字幕轨→正文 URL 映射，并按需读取正文。
+///
+/// URL 不越过 adapter；正文使用独立无 Cookie、无缓存、拒绝重定向的 transport。
+/// generation 与 identity 共同防止旧目录或正文结果进入新视频。
 public actor BiliSubtitleRepository: SubtitleRepository {
     private static let maximumBodySize = 2 * 1_024 * 1_024
 
@@ -133,6 +137,7 @@ public actor BiliSubtitleRepository: SubtitleRepository {
         }
     }
 
+    /// 仅清理仍匹配的 identity，避免迟到的旧 reset 清除后来加载的映射。
     public func reset(for identity: PlaybackItemIdentity) {
         guard currentIdentity == identity else { return }
         generation &+= 1

--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
@@ -3,6 +3,11 @@ import BiliModels
 import BiliNetworking
 import Foundation
 
+/// Bilibili endpoint/DTO adapter；把远端协议限制在 `BiliAPI`，并返回稳定模型。
+///
+/// 匿名请求永不经过 authorizer。只有显式认证 endpoint 才临时授权；响应在解码前还要满足
+/// 状态、大小与 Content-Type 边界。actor 隔离可变 transport/WBI cache；跨 `await` 可重入，
+/// 用户意图的取消与写回代次仍由上层 owner 管理。
 public actor BiliAPIClient: AuthenticatedSessionInvalidating {
     public static let productionBaseURL: URL = {
         guard let url = URL(string: "https://api.bilibili.com") else {
@@ -120,6 +125,7 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
         return try payload.map { try $0.model() }
     }
 
+    /// 取得匿名 AVC/AAC DASH 清单与媒体所需的非认证 header，不下载媒体正文。
     public func playback(
         for bvid: String,
         cid: Int64,
@@ -272,6 +278,7 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
         return try payload.model(pageSize: pageSize)
     }
 
+    /// 登出时取消旧 transport 中的请求、换入干净 session，并丢弃可能来自登录会话的 WBI key。
     public func invalidateAuthenticatedSession() {
         if let invalidating = transport as? any HTTPTransportInvalidating {
             invalidating.invalidateAndCancel()

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/BiliMediaURLPolicy.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/BiliMediaURLPolicy.swift
@@ -1,6 +1,10 @@
 import BiliNetworking
 import Foundation
 
+/// 媒体 Range 候选的用途专属 URL 形状 allowlist。
+///
+/// 它在公共 HTTPS 基线上收窄到已审计 CDN host；不负责 Cookie 或重定向，生产
+/// `HTTPRangeClient` 另以无 Cookie、拒绝重定向的 transport 执行请求。
 struct BiliMediaURLPolicy: Sendable {
     private static let dedicatedDomainSuffixes = [
         "bilivideo.com",

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/SubtitleURLPolicy.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/SubtitleURLPolicy.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+/// 字幕正文 URL 的精确 HTTPS host/path allowlist。
+///
+/// 该策略只判断来源形状；正文 repository 仍须使用无 Cookie、无缓存且拒绝重定向的
+/// 独立 transport，不能把通过此检查等同于可复用认证会话。
 struct SubtitleURLPolicy: Sendable {
     private let allowedHosts: Set<String> = [
         "aisubtitle.hdslb.com"

--- a/Packages/BiliKitCore/Sources/BiliApplication/Auth/AuthenticationContracts.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Auth/AuthenticationContracts.swift
@@ -1,3 +1,4 @@
+/// Feature 可观察的非秘密认证状态；不携带二维码 payload、Cookie 或 Keychain 细节。
 public enum AuthenticationState: Sendable, Equatable {
     case signedOut
     case restoring
@@ -18,6 +19,9 @@ public enum AuthenticationFailure: Error, Sendable, Equatable {
     case credentialUnavailable
 }
 
+/// 认证 adapter 暴露给 Presentation 的用户意图边界。
+///
+/// 每次调用返回 adapter 的当前安全投影；调用方仍负责 UI Task 的取消与迟到结果隔离。
 public protocol AuthenticationServicing: Sendable {
     func restore() async -> AuthenticationState
     func requestQRCode() async -> AuthenticationState
@@ -27,6 +31,7 @@ public protocol AuthenticationServicing: Sendable {
     func logout() async -> AuthenticationState
 }
 
+/// 登出时由认证 owner 通知仍可能持有已授权在途请求的会话。
 public protocol AuthenticatedSessionInvalidating: Sendable {
     func invalidateAuthenticatedSession() async
 }

--- a/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuContracts.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuContracts.swift
@@ -15,6 +15,7 @@ public protocol DanmakuSegmentRepository: Sendable {
     ) async throws -> DanmakuSegment
 }
 
+/// 验证弹幕分段请求边界，并拒绝 adapter 返回与请求 index 不一致的结果。
 public struct DanmakuSegmentUseCase: Sendable {
     public static let maximumSegmentIndex = 10_000
 

--- a/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuPresentationControlling.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuPresentationControlling.swift
@@ -1,4 +1,5 @@
 @MainActor
+/// 让 Feature 驱动弹幕会话开始、可见性与完整停止，而不暴露 scheduler 或 renderer。
 public protocol DanmakuPresentationControlling: AnyObject {
     func start(for identity: PlaybackItemIdentity)
     func setEnabled(_ enabled: Bool)

--- a/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestContracts.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestContracts.swift
@@ -10,6 +10,7 @@ public enum GuestApplicationError: Error, Sendable, Equatable {
     case unavailable
 }
 
+/// 游客浏览用例所需的远端内容 port，不暴露 endpoint DTO 或具体网络 client。
 public protocol GuestContentRepository: Sendable {
     func popular(page: Int, pageSize: Int) async throws -> PopularPage
     func searchVideos(keyword: String, page: Int) async throws -> SearchPage

--- a/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestFeedUseCase.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestFeedUseCase.swift
@@ -11,6 +11,7 @@ public enum GuestFeedContent: Sendable, Equatable {
     case search(query: String, page: SearchPage)
 }
 
+/// 在进入 adapter 前验证并规范化 Feed 意图的一次性用例。
 public struct GuestFeedUseCase: Sendable {
     private let repository: any GuestContentRepository
 
@@ -18,6 +19,7 @@ public struct GuestFeedUseCase: Sendable {
         self.repository = repository
     }
 
+    /// 执行一个独立请求；取消和“哪次意图仍可写回 UI”由上层 ViewModel 保留。
     public func execute(_ request: GuestFeedRequest) async throws -> GuestFeedContent {
         switch request {
         case .popular(let page, let pageSize):

--- a/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestVideoUseCase.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestVideoUseCase.swift
@@ -1,5 +1,6 @@
 import BiliModels
 
+/// 播放页一次准备所聚合的详情、分 P、选中分 P 与播放清单。
 public struct GuestVideoContext: Sendable, Equatable {
     public let detail: VideoDetail
     public let pages: [VideoPage]
@@ -19,6 +20,9 @@ public struct GuestVideoContext: Sendable, Equatable {
     }
 }
 
+/// 并行取得详情与分 P，再为排序后的首分 P 取得播放清单。
+///
+/// 用例不拥有播放器，也不保留可变状态；任何一个阶段取消都会阻止后续播放请求或结果返回。
 public struct GuestVideoUseCase: Sendable {
     private let repository: any GuestContentRepository
 

--- a/Packages/BiliKitCore/Sources/BiliApplication/History/WatchHistoryContracts.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/History/WatchHistoryContracts.swift
@@ -33,6 +33,9 @@ public struct WatchHistoryPage: Sendable, Equatable {
     }
 }
 
+/// 观看历史的认证数据 port；Presentation 只能回传 adapter 生成的不透明 continuation。
+///
+/// Endpoint、凭据与远端错误映射属于具体 adapter，不进入 Application。
 public protocol WatchHistoryRepository: Sendable {
     func watchHistory(
         after continuation: WatchHistoryContinuation?,

--- a/Packages/BiliKitCore/Sources/BiliApplication/History/WatchHistoryUseCase.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/History/WatchHistoryUseCase.swift
@@ -1,5 +1,8 @@
 import BiliModels
 
+/// 把远端分页适配为可显示的历史页，并有界跳过映射后为空的页面。
+///
+/// 空页 continuation 必须前进；达到跳过上限时返回令牌供用户显式继续，避免后台无界扫描。
 public struct WatchHistoryUseCase: Sendable {
     private let repository: any WatchHistoryRepository
     private let maximumEmptyPagesToSkip: Int

--- a/Packages/BiliKitCore/Sources/BiliApplication/Playback/PlaybackTimeline.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Playback/PlaybackTimeline.swift
@@ -1,6 +1,7 @@
 import BiliModels
 import Foundation
 
+/// 跨播放器、字幕与弹幕共享的播放项目身份；日志描述会主动隐藏真实内容标识。
 public struct PlaybackItemIdentity: Sendable, Hashable {
     public let bvid: String
     public let cid: Int64
@@ -27,6 +28,9 @@ public enum PlaybackTimelineState: Sendable, Equatable {
     case failed
 }
 
+/// 平台无关的媒体时间事实。
+///
+/// `discontinuityGeneration` 在换项、seek 或时间跳变时前进，消费者不能只比较秒数来判断连续性。
 public struct PlaybackTimelineSnapshot: Sendable, Equatable {
     public let identity: PlaybackItemIdentity?
     public let positionSeconds: Double
@@ -67,12 +71,14 @@ public struct PlaybackTimelineSnapshot: Sendable, Equatable {
 }
 
 @MainActor
+/// 字幕和弹幕消费的唯一播放时钟；新订阅者应先得到当前快照。
 public protocol PlaybackTimelineProviding: AnyObject {
     var currentTimelineSnapshot: PlaybackTimelineSnapshot { get }
     func timelineUpdates() -> AsyncStream<PlaybackTimelineSnapshot>
 }
 
 @MainActor
+/// Feature 可驱动的最小播放命令边界；具体 AVPlayer 和 bridge 生命周期留在 adapter。
 public protocol PlaybackControlling: AnyObject {
     func load(
         _ playback: VideoPlayback,
@@ -87,6 +93,7 @@ package struct PlaybackTimelineItemToken: Sendable, Equatable {
 }
 
 @MainActor
+/// 以不可复用 item token 拒绝旧 AVPlayer observer 写回的时间线状态容器。
 package final class PlaybackTimelineStore {
     package private(set) var currentSnapshot = PlaybackTimelineSnapshot.idle
     package var subscriberCount: Int { continuations.count }
@@ -102,6 +109,7 @@ package final class PlaybackTimelineStore {
         }
     }
 
+    /// 创建只保留最新值的订阅，并在消费方结束时移除 continuation。
     package func updates() -> AsyncStream<PlaybackTimelineSnapshot> {
         let subscriptionID = UUID()
         let stream = AsyncStream<PlaybackTimelineSnapshot>.makeStream(

--- a/Packages/BiliKitCore/Sources/BiliApplication/Subtitle/SubtitleContracts.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Subtitle/SubtitleContracts.swift
@@ -9,6 +9,9 @@ public enum SubtitleApplicationError: Error, Sendable, Equatable {
     case unavailable
 }
 
+/// 字幕目录与正文的 identity-scoped port。
+///
+/// `reset` 是 adapter 清除当前身份 URL 映射的生命周期操作，不是一般缓存清理。
 public protocol SubtitleRepository: Sendable {
     func tracks(
         for identity: PlaybackItemIdentity
@@ -22,6 +25,7 @@ public protocol SubtitleRepository: Sendable {
     func reset(for identity: PlaybackItemIdentity) async
 }
 
+/// 在 adapter 前验证字幕 identity/track 输入，同时保持取消原样传播。
 public struct SubtitleUseCase: Sendable {
     private let repository: any SubtitleRepository
 

--- a/Packages/BiliKitCore/Sources/BiliAuth/Application/BiliAuthenticationService.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/Application/BiliAuthenticationService.swift
@@ -2,6 +2,10 @@ import BiliApplication
 import CoreGraphics
 import Foundation
 
+/// 认证流程 owner，串行协调 QR session、凭据验证、Keychain authorizer 与登出。
+///
+/// `generation` 隔离旧操作；`requiresLogout` 阻止凭据状态不确定时伪装成安全 signed-out。
+/// 新 QR 登录须校验并持久化成功才发布 `.signedIn`；恢复路径会重新验证既存凭据。
 public actor BiliAuthenticationService: AuthenticationServicing {
     private var loginSession: WebQRLoginSession
     private var authorizer: BiliCredentialRequestAuthorizer
@@ -38,6 +42,7 @@ public actor BiliAuthenticationService: AuthenticationServicing {
         self.additionalSessionInvalidators = additionalSessionInvalidators
     }
 
+    /// 从 Keychain 恢复后再次向登录态 endpoint 验证；临时网络失败不会删除凭据。
     public func restore() async -> AuthenticationState {
         generation &+= 1
         let operationGeneration = generation
@@ -115,6 +120,7 @@ public actor BiliAuthenticationService: AuthenticationServicing {
         return state
     }
 
+    /// 消费一次待提交凭据，在同一 QR generation 内完成远端验证与原子持久化。
     public func finalizeLogin() async -> AuthenticationState {
         guard state == .finalizing else { return state }
         let operationGeneration = generation
@@ -156,6 +162,9 @@ public actor BiliAuthenticationService: AuthenticationServicing {
         return state
     }
 
+    /// 先取消临时工作并删除本地凭据，再失效所有认证 session，最后发布退出结果。
+    ///
+    /// 删除 Keychain 失败时仍重建网络 session，但保持失败状态，不能声称本机已安全退出。
     public func logout() async -> AuthenticationState {
         generation &+= 1
         let activeSession = loginSession

--- a/Packages/BiliKitCore/Sources/BiliAuth/Credential/BiliCredentialRequestAuthorizer.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/Credential/BiliCredentialRequestAuthorizer.swift
@@ -11,6 +11,10 @@ public enum BiliRequestAuthorizationError: Error, Sendable, Equatable {
     case validationUnavailable
 }
 
+/// 从 Keychain 按需读取 Cookie，并只授权代码内精确列出的 Bilibili API 请求。
+///
+/// 调用方声明“需要认证”并不足够：scheme、host、port、method、path、query 与现有 Cookie
+/// header 都会再次验证。损坏或过期凭据会清除，媒体/CDN/loopback 请求无法通过此边界。
 public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable {
     private static let maximumResponseSize = 256 * 1_024
     private static let navigationValidationURL: URL = {
@@ -48,6 +52,7 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
         }
     }
 
+    /// 返回附带短生命周期 Cookie header 的新请求；原请求不会被原地共享或缓存。
     public func authorize(_ request: HTTPRequest) async throws -> HTTPRequest {
         guard Self.isAllowed(request) else {
             throw BiliRequestAuthorizationError.requestNotAllowed
@@ -102,6 +107,7 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
         transportInvalidator?()
     }
 
+    /// 验证已存凭据当前是否仍登录；明确失效会清除，验证不可用则保留并抛错。
     public func restoreLoginState() async throws -> Bool {
         let request = HTTPRequest(
             url: Self.navigationValidationURL,

--- a/Packages/BiliKitCore/Sources/BiliAuth/Credential/WebCredential.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/Credential/WebCredential.swift
@@ -24,6 +24,7 @@ struct WebCredentialCookie: Codable, Sendable, Equatable,
     var customMirror: Mirror { Mirror(self, children: [:], displayStyle: .struct) }
 }
 
+/// 经白名单、结构与大小验证的完整 Web Cookie 集合；描述与反射均不暴露值。
 struct WebCredential: Sendable, Equatable,
     CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable
 {
@@ -76,6 +77,7 @@ enum WebCredentialCodingError: Error, Sendable, Equatable {
     case unsupportedVersion(Int)
 }
 
+/// 为 Keychain payload 提供版本化编码，并在解码后重新验证全部 Cookie 约束。
 enum WebCredentialCodec {
     static let currentVersion = 1
 

--- a/Packages/BiliKitCore/Sources/BiliAuth/Credential/WebCredentialStore.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/Credential/WebCredentialStore.swift
@@ -14,6 +14,7 @@ enum WebCredentialStoreError: Error, Sendable, Equatable {
     case operationFailed(OSStatus)
 }
 
+/// Web 凭据的唯一持久化 adapter，使用不可同步、仅本机解锁时可读的 Data Protection Keychain。
 struct KeychainWebCredentialStore: WebCredentialStoring, Sendable {
     static let productionService = "com.shiinayane.BiliKitMac.web-auth"
     static let productionAccount = "web-credential"
@@ -50,6 +51,7 @@ struct KeychainWebCredentialStore: WebCredentialStoring, Sendable {
         }
     }
 
+    /// 新增或原子替换固定 service/account 下的单个版本化 credential item。
     func save(_ credential: WebCredential) throws {
         let encoded: Data
         do {

--- a/Packages/BiliKitCore/Sources/BiliAuth/WebQR/WebQRCode.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/WebQR/WebQRCode.swift
@@ -3,6 +3,7 @@ import CoreImage
 import CoreImage.CIFilterBuiltins
 import Foundation
 
+/// 封装不可公开读取的完整二维码 payload，只允许在内存中渲染或读取已审计的 host。
 public struct WebQRCode: Sendable, Equatable, CustomStringConvertible,
     CustomDebugStringConvertible, CustomReflectable
 {

--- a/Packages/BiliKitCore/Sources/BiliAuth/WebQR/WebQRLoginSession.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/WebQR/WebQRLoginSession.swift
@@ -1,6 +1,10 @@
 import BiliNetworking
 import Foundation
 
+/// 拥有一次 Web QR challenge、轮询序列与尚未持久化的候选凭据。
+///
+/// generation 隔离新旧二维码，poll ID 隔离同一二维码的并发轮询；取消或未知协议状态会
+/// 失败关闭并清除临时秘密。成功响应仍须登录态验证后才能写入 Keychain。
 public actor WebQRLoginSession {
     public static let productionBaseURL: URL = {
         guard let url = URL(string: "https://passport.bilibili.com") else {
@@ -194,6 +198,7 @@ public actor WebQRLoginSession {
         }
     }
 
+    /// 使 challenge、待验证凭据及所有旧轮询结果失效，但不修改已持久化凭据。
     public func cancel() {
         generation &+= 1
         latestPollID &+= 1
@@ -212,6 +217,7 @@ public actor WebQRLoginSession {
         return try await validate(pendingCredential)
     }
 
+    /// 一次性消费候选凭据，验证登录态与有效期后才提交 Keychain。
     public func validateAndStorePendingCredential() async throws -> Bool {
         let pendingCredential = try takePendingCredential()
         guard try await validate(pendingCredential) else { return false }

--- a/Packages/BiliKitCore/Sources/BiliAuth/WebQR/WebQRLoginState.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/WebQR/WebQRLoginState.swift
@@ -1,3 +1,4 @@
+/// QR adapter 的内部安全状态投影；描述不包含 key、URL、Cookie 或服务端正文。
 public enum WebQRLoginState: Sendable, Equatable, CustomStringConvertible {
     case signedOut
     case requestingQRCode
@@ -65,6 +66,7 @@ public enum WebQRLoginFailure: Error, Sendable, Equatable, CustomStringConvertib
     }
 }
 
+/// 只保留协议形状的脱敏观察，用于审计未知状态，不保存任何字段值。
 public struct WebQRStatusObservation: Sendable, Equatable,
     CustomStringConvertible, CustomDebugStringConvertible
 {

--- a/Packages/BiliKitCore/Sources/BiliAuthFeature/Authentication/AuthenticationQRCodeProviding.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuthFeature/Authentication/AuthenticationQRCodeProviding.swift
@@ -1,5 +1,8 @@
 import CoreGraphics
 
+/// Presentation 专用的二维码图像 port，使 Feature 无需取得完整 QR URL 或 challenge key。
+///
+/// `CGImage` 不进入 `BiliApplication`；具体认证 adapter 只在内存中渲染当前 challenge。
 public protocol AuthenticationQRCodeProviding: Sendable {
     func makeQRCodeImage(scale: Int) async throws -> CGImage?
 }

--- a/Packages/BiliKitCore/Sources/BiliAuthFeature/Authentication/AuthenticationViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuthFeature/Authentication/AuthenticationViewModel.swift
@@ -5,6 +5,10 @@ import Observation
 
 @MainActor
 @Observable
+/// 拥有恢复、登录、轮询与登出的单一 UI Task，并仅发布非秘密认证状态和二维码图像。
+///
+/// generation 拒绝旧操作写回；轮询同时受总时限与次数上限约束。Cookie、QR key 与完整 URL
+/// 始终留在 `BiliAuth` adapter，失败重试也保持原操作类型，避免把登出失败误当成登录失败。
 public final class AuthenticationViewModel {
     public private(set) var state: AuthenticationState = .signedOut
     public private(set) var qrCodeImage: CGImage?
@@ -132,6 +136,7 @@ public final class AuthenticationViewModel {
         logout()
     }
 
+    /// 在 sheet/窗口生命周期结束时取消临时登录工作，但不会把已登录状态当作可取消挑战。
     public func cancelTransientWork() {
         switch state {
         case .restoring, .requestingQRCode, .awaitingScan, .awaitingConfirmation,

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/BrowseScene/GuestBrowseViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/BrowseScene/GuestBrowseViewModel.swift
@@ -17,6 +17,10 @@ struct GuestFeedPresentation: Sendable, Equatable {
 
 @MainActor
 @Observable
+/// 拥有热门与最后一次搜索两份独立工作集，以及当前路由的请求 Task。
+///
+/// `generation + activeRequestIdentity` 共同阻止已取消或已切路由的结果写回；进入播放页时
+/// 普通 deactivate 会保留当前两份工作集，`reset` 则清空两者；不同请求会替换对应工作集。
 public final class GuestBrowseViewModel {
     public private(set) var state: GuestFeedState = .idle
     private(set) var activeRequestIdentity: GuestFeedRequest?
@@ -91,6 +95,7 @@ public final class GuestBrowseViewModel {
         refresh(request)
     }
 
+    /// 停止当前路由工作，但把规范化后的状态保存回对应工作集供返回时恢复。
     public func deactivateRoute() {
         generation += 1
         loadTask?.cancel()
@@ -103,6 +108,7 @@ public final class GuestBrowseViewModel {
         refreshError = nil
     }
 
+    /// 取消请求并丢弃两份内存工作集，适用于窗口关闭而非普通页面 push/pop。
     public func reset() {
         deactivateRoute()
         popularWorkset = FeedWorkset()

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsViewModel.swift
@@ -3,6 +3,9 @@ import Observation
 
 @MainActor
 @Observable
+/// 只保存用户可见的弹幕开关，并把视频 lifecycle 交给 presentation port。
+///
+/// 它不拥有 protobuf、分段缓存、时间线或 renderer；`reset` 必须停止整条会话而非只隐藏画面。
 public final class DanmakuControlsViewModel {
     public private(set) var isEnabled = true
     public private(set) var showsScrolling = true

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoViewModel.swift
@@ -16,6 +16,9 @@ public enum GuestVideoState: Sendable, Equatable {
 
 @MainActor
 @Observable
+/// 拥有单个视频准备意图，并把内容准备与播放器安装串成同一 generation。
+///
+/// 新视频、重试或 reset 都使旧任务失效；旧任务即使忽略取消，也不能覆盖当前状态。
 public final class GuestVideoViewModel {
     public private(set) var state: GuestVideoState = .idle
 
@@ -32,6 +35,7 @@ public final class GuestVideoViewModel {
         self.playback = playback
     }
 
+    /// 取代当前播放意图；已有非 idle 会话会先停止，避免两个 bridge/server 并存。
     public func loadVideo(_ bvid: String) {
         generation += 1
         let currentGeneration = generation
@@ -48,6 +52,7 @@ public final class GuestVideoViewModel {
         }
     }
 
+    /// 取消内容准备并停止播放 adapter，作为离开播放目的地的最终清理边界。
     public func reset() {
         generation += 1
         loadTask?.cancel()

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Subtitle/SubtitleViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Subtitle/SubtitleViewModel.swift
@@ -20,6 +20,10 @@ public enum SubtitleViewState: Sendable, Equatable {
 
 @MainActor
 @Observable
+/// 拥有当前视频的字幕目录、正文、时间线订阅与跨 identity reset 顺序。
+///
+/// 切换视频时先让串行 reset worker 清理上一 identity，再加载下一目录；这避免 A→B→A
+/// 中迟到的旧 A reset 清掉新 A。内容 generation 另行隔离切轨与网络迟到结果。
 public final class SubtitleViewModel {
     private struct LoadIntent {
         let identity: PlaybackItemIdentity
@@ -58,6 +62,7 @@ public final class SubtitleViewModel {
         resetTask?.cancel()
     }
 
+    /// 选择新的播放身份；目录可以预载，但默认不选择轨道，也不会请求正文。
     public func selectVideo(_ identity: PlaybackItemIdentity) {
         guard self.identity != identity else { return }
         let previousIdentity = self.identity
@@ -83,6 +88,7 @@ public final class SubtitleViewModel {
         startPendingLoadIfReady()
     }
 
+    /// 切换正文请求；传入 `nil` 明确关闭字幕并清空已加载 cue。
     public func selectTrack(_ trackID: String?) {
         guard let identity else { return }
         if let trackID, !tracks.contains(where: { $0.id == trackID }) {
@@ -129,6 +135,7 @@ public final class SubtitleViewModel {
         reset(preservingIdentityForRetry: false)
     }
 
+    /// 登出时清除已授权取得的数据，但保留 identity 供重新认证后显式 retry。
     public func suspendForAuthentication() {
         reset(preservingIdentityForRetry: true)
     }
@@ -237,6 +244,7 @@ public final class SubtitleViewModel {
         }
     }
 
+    /// 合并待清理 identity，并用单一 worker 保证 reset 与下一次目录加载不会交错。
     private func enqueueReset(for identity: PlaybackItemIdentity?) {
         if let identity, pendingResetIdentity == nil {
             pendingResetIdentity = identity

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoPlaybackView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoPlaybackView.swift
@@ -1,6 +1,10 @@
 import BiliApplication
 import SwiftUI
 
+/// 把视频准备状态连接到字幕与弹幕的播放 identity 生命周期。
+///
+/// 详情上下文一旦可用就选择同一 BVID/CID；状态回到 idle/loading/failed 时 identity 变为
+/// `nil`，由 `.task(id:)` 完整 reset 两条支线。网络任务仍由各 ViewModel 自己拥有。
 public struct VideoPlaybackView<PlayerContent: View>: View {
     private let model: GuestVideoViewModel
     private let subtitleModel: SubtitleViewModel

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuRenderer.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuRenderer.swift
@@ -5,6 +5,10 @@ import Foundation
 import QuartzCore
 
 @MainActor
+/// 有硬上限的 Core Animation 弹幕 backend，负责 layer identity、动画时钟与最终回收。
+///
+/// `renderEpoch + objectIdentity` 使旧动画 completion 无法删除同 ID 的新 layer；清屏、
+/// resize 和 stop 都会推进 epoch 并同步移除活动对象。
 public final class CoreAnimationDanmakuRenderer:
     DanmakuRenderingBackend
 {
@@ -130,6 +134,7 @@ public final class CoreAnimationDanmakuRenderer:
         removeAllEntries()
     }
 
+    /// 在保持当前 layer 局部时间连续的前提下暂停或调整动画速率。
     public func setPlaybackRate(_ rate: Double) {
         let newRate = rate.isFinite ? max(rate, 0) : 0
         guard Double(rootLayer.speed) != newRate else { return }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneAllocator.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneAllocator.swift
@@ -1,6 +1,9 @@
 import BiliModels
 import Foundation
 
+/// 在固定 surface 与活动数量上限内分配弹幕轨道，并阻止滚动弹幕追尾。
+///
+/// allocator 只使用媒体时间计算占用/过期；renderer completion 通过 `remove` 回收相同事件。
 public struct DanmakuLaneAllocator: Sendable {
     private struct ActivePlacement: Sendable {
         let placement: DanmakuLanePlacement

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentation.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentation.swift
@@ -15,6 +15,10 @@ public struct DanmakuPresentationUpdate: Sendable, Equatable {
 }
 
 @MainActor
+/// 调度会话写入 presentation 的资源生命周期边界。
+///
+/// `clearPresentation` 只清空当前画面并保留会话 identity；`stopPresentation` 还终止
+/// backend 动画时钟并丢弃 identity/discontinuity 状态。
 public protocol DanmakuPresentationSink: AnyObject {
     func apply(_ update: DanmakuPresentationUpdate)
     func clearPresentation()

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
@@ -28,6 +28,10 @@ public struct DanmakuRendererStatistics: Sendable, Equatable {
 }
 
 @MainActor
+/// 在调度 batch 与具体 renderer 之间执行 identity/generation 检查、lane 分配与容量治理。
+///
+/// surface owner ID 防止旧 `AVPlayerView` 的迟到 resize/detach 操作清空新宿主；换 identity、
+/// seek generation 或显式清屏都会同步清空 allocator 与 backend。
 public final class DanmakuPresentationController:
     DanmakuPresentationSink,
     DanmakuRenderingBackendDelegate
@@ -56,6 +60,7 @@ public final class DanmakuPresentationController:
         )
     }
 
+    /// 只呈现与快照 identity 和 discontinuity generation 完全匹配的 batch。
     public func apply(_ update: DanmakuPresentationUpdate) {
         guard let updateIdentity = update.snapshot.identity else {
             stopPresentation()

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuRenderingBackend.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuRenderingBackend.swift
@@ -37,6 +37,10 @@ public protocol DanmakuRenderingBackendDelegate: AnyObject {
 }
 
 @MainActor
+/// Renderer 的最小平台 port。
+///
+/// `clearAll` 只移除活动对象；`stop` 还把播放速率归零。尺寸变化允许实现清空无法安全
+/// 迁移的对象，因此 controller 必须同步重置 lane allocator。
 public protocol DanmakuRenderingBackend: AnyObject {
     var delegate: (any DanmakuRenderingBackendDelegate)? { get set }
 

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Scheduling/DanmakuScheduler.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Scheduling/DanmakuScheduler.swift
@@ -46,6 +46,7 @@ public struct DanmakuFilter: Sendable, Equatable {
     }
 }
 
+/// 某一播放 identity/generation 的增量呈现指令；`clearsExisting` 表示时间不再连续。
 public struct DanmakuBatch: Sendable, Equatable {
     public let identity: PlaybackItemIdentity
     public let discontinuityGeneration: UInt64
@@ -65,6 +66,10 @@ public struct DanmakuBatch: Sendable, Equatable {
     }
 }
 
+/// 以统一媒体时间线调度弹幕，并维护有界分段缓存与去重游标。
+///
+/// identity、discontinuity 或时间回跳会清除投递记录并先发清屏 batch；暂停和倍速直接使用
+/// timeline 快照，不创建独立 wall-clock timer。
 public struct DanmakuScheduler: Sendable {
     public static let segmentDurationSeconds = 360.0
     public static let maximumCachedSegments = 3
@@ -144,6 +149,7 @@ public struct DanmakuScheduler: Sendable {
         return indices
     }
 
+    /// 消费相邻快照之间首次出现的事件；不连续时只返回清屏指令，不补喷跨越区间。
     public mutating func consume(
         _ snapshot: PlaybackTimelineSnapshot
     ) -> DanmakuBatch? {

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Session/DanmakuSession.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Session/DanmakuSession.swift
@@ -10,6 +10,10 @@ public enum DanmakuSessionState: Sendable, Equatable {
 }
 
 @MainActor
+/// 弹幕数据、时间线订阅、分段加载与 presentation 的会话 owner。
+///
+/// 同时最多加载两个 segment，失败 segment 在当前 identity 内不自动重试；generation 阻止
+/// 切视频或 stop 后的迟到结果写回。`stop` 必须取消所有任务并清空 scheduler/presentation。
 public final class DanmakuSession: DanmakuPresentationControlling {
     public private(set) var state: DanmakuSessionState = .idle
 
@@ -46,6 +50,7 @@ public final class DanmakuSession: DanmakuPresentationControlling {
         }
     }
 
+    /// 提供调试/观察用的有界 batch 流；presentation sink 仍是生产呈现主路径。
     public func batches() -> AsyncStream<DanmakuBatch> {
         let id = UUID()
         let stream = AsyncStream<DanmakuBatch>.makeStream(
@@ -106,6 +111,7 @@ public final class DanmakuSession: DanmakuPresentationControlling {
         )
     }
 
+    /// 幂等结束整个会话，而不只是隐藏弹幕图层。
     public func stop() {
         presentationSink?.stopPresentation()
         generation &+= 1

--- a/Packages/BiliKitCore/Sources/BiliLibraryFeature/History/WatchHistoryView.swift
+++ b/Packages/BiliKitCore/Sources/BiliLibraryFeature/History/WatchHistoryView.swift
@@ -4,6 +4,10 @@ import BiliUI
 import Foundation
 import SwiftUI
 
+/// 将历史页面可见性连接到 ViewModel 的加载与路由停用语义。
+///
+/// `.task` 触发并等待模型当前请求；离开页面时 `deactivateRoute` 负责取消在途工作，
+/// 同时保留已经加载的条目供返回恢复。登出清理仍由窗口级 `reset` 边界负责。
 public struct WatchHistoryView: View {
     private let model: WatchHistoryViewModel
     @Binding private var scrollPosition: ScrollPosition

--- a/Packages/BiliKitCore/Sources/BiliLibraryFeature/History/WatchHistoryViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliLibraryFeature/History/WatchHistoryViewModel.swift
@@ -20,6 +20,9 @@ public enum WatchHistoryState: Sendable, Equatable {
 
 @MainActor
 @Observable
+/// 拥有当前登录会话的历史工作集、分页 continuation 与请求 generation。
+///
+/// `reset` 会清除个性化内容；普通路由停用只取消在途请求，并在分页中断时保留已显示条目。
 public final class WatchHistoryViewModel {
     public private(set) var state: WatchHistoryState = .idle
 
@@ -125,6 +128,7 @@ public final class WatchHistoryViewModel {
         }
     }
 
+    /// 取消请求并从内存删除全部个性化历史，供登出与窗口关闭调用。
     public func reset() {
         generation += 1
         task?.cancel()
@@ -137,6 +141,7 @@ public final class WatchHistoryViewModel {
         task = nil
     }
 
+    /// 停用页面请求而不抹掉已加载条目；迟到结果仍由 generation 拒绝。
     public func deactivateRoute() {
         generation += 1
         task?.cancel()

--- a/Packages/BiliKitCore/Sources/BiliNetworking/Authorization/HTTPRequestAuthorizing.swift
+++ b/Packages/BiliKitCore/Sources/BiliNetworking/Authorization/HTTPRequestAuthorizing.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+/// 为已经通过实现方精确 allowlist 的请求临时附加认证材料。
+///
+/// 协议不代表任意请求都有权获得凭据；实现必须同时验证目标、方法与 endpoint 语义。
 public protocol HTTPRequestAuthorizing: Sendable {
     func authorize(_ request: HTTPRequest) async throws -> HTTPRequest
 }

--- a/Packages/BiliKitCore/Sources/BiliNetworking/Range/HTTPRangeClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliNetworking/Range/HTTPRangeClient.swift
@@ -140,6 +140,10 @@ public enum HTTPRangeClientError: Error, Sendable, Equatable {
     case allCandidatesFailed([HTTPRangeAttempt])
 }
 
+/// 逐候选执行严格 HTTP Range 读取的无状态 client。
+///
+/// 成功必须同时满足公共 HTTPS、`206`、精确 `Content-Range` 与正文长度；取消立即传播，
+/// 不会伪装成候选失败后继续请求其他 CDN。
 public struct HTTPRangeClient: Sendable {
     private let transport: any HTTPTransport
     private let urlPolicy: PublicHTTPSURLPolicy
@@ -166,6 +170,10 @@ public struct HTTPRangeClient: Sendable {
         self.urlPolicy = urlPolicy
     }
 
+    /// 按顺序尝试来源并返回首个完全验证的响应。
+    ///
+    /// 失败记录包含候选 URL 与分类结果，但不保留响应正文或底层 Error 文本；因此不能直接
+    /// 把 `HTTPRangeAttempt` 当作可公开日志，调用方仍须按敏感远端 URL 处理。
     public func fetch(
         from candidateURLs: [URL],
         range: HTTPByteRange,

--- a/Packages/BiliKitCore/Sources/BiliNetworking/Transport/HTTPClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliNetworking/Transport/HTTPClient.swift
@@ -40,6 +40,7 @@ public struct HTTPResponse: Sendable, Equatable {
     }
 }
 
+/// 不包含业务或认证语义的 HTTP 传输边界，便于按用途注入独立 session。
 public protocol HTTPTransport: Sendable {
     func send(_ request: HTTPRequest) async throws -> HTTPResponse
 }
@@ -53,6 +54,7 @@ public enum HTTPClientError: Error, Sendable, Equatable {
     case unacceptableStatusCode(Int)
 }
 
+/// 只统一成功状态检查的轻量 client；来源、大小、Content-Type 与解码限制仍由调用方负责。
 public actor HTTPClient {
     private let transport: any HTTPTransport
 
@@ -72,6 +74,9 @@ public actor HTTPClient {
     }
 }
 
+/// `URLSession` adapter；实际 Cookie、缓存与重定向行为取决于注入的 session。
+///
+/// 默认 `.shared` 不提供认证、媒体或字幕所需的隔离保证；这些调用方必须注入用途专属配置。
 public final class URLSessionTransport: HTTPTransport, HTTPTransportInvalidating,
     @unchecked Sendable
 {

--- a/Packages/BiliKitCore/Sources/BiliNetworking/Transport/HTTPLogRedactor.swift
+++ b/Packages/BiliKitCore/Sources/BiliNetworking/Transport/HTTPLogRedactor.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// 在诊断输出前遮蔽已知敏感 query/header；它不是发送请求前的授权或来源校验器。
 public struct HTTPLogRedactor: Sendable {
     private let sensitiveQueryKeys: Set<String>
     private let sensitiveHeaderNames: Set<String>

--- a/Packages/BiliKitCore/Sources/BiliNetworking/Transport/PublicHTTPSURLPolicy.swift
+++ b/Packages/BiliKitCore/Sources/BiliNetworking/Transport/PublicHTTPSURLPolicy.swift
@@ -1,6 +1,10 @@
 import Darwin
 import Foundation
 
+/// 拒绝已知本地域名后缀、userinfo、非标准端口与 IP literal 的 URL 形状基线。
+///
+/// 它不解析 DNS，因而不能证明公共域名不会指向私网；具体媒体或字幕调用方仍需叠加
+/// 用途专属主机规则。
 public struct PublicHTTPSURLPolicy: Sendable {
     public init() {}
 

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Bridge/DASHToHLSBridge.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Bridge/DASHToHLSBridge.swift
@@ -9,6 +9,9 @@ public enum DASHToHLSBridgeError: Error, Sendable, Equatable {
     case missingCompleteMediaLength(representationID: Int)
 }
 
+/// 一次已启动的 loopback HLS 会话；其生命周期就是底层 server 的生命周期。
+///
+/// owner 必须在替换播放项或失败时调用 `stop`；`deinit` 只是最后一道幂等清理保障。
 public final class PreparedPlaybackAsset: @unchecked Sendable {
     public let url: URL
     private let server: LoopbackPlaybackServer
@@ -27,6 +30,9 @@ public final class PreparedPlaybackAsset: @unchecked Sendable {
     }
 }
 
+/// 把 DASH representation 的 SIDX/Range 语义转换为 AVPlayer 可消费的本机 HLS 会话。
+///
+/// Bridge 只构造内存 playlist 与按需代理，不下载完整媒体；任一步失败都会停止已启动 server。
 public struct DASHToHLSBridge: Sendable {
     private let rangeClient: HTTPRangeClient
     private let indexLoader: RepresentationIndexLoader
@@ -64,6 +70,7 @@ public struct DASHToHLSBridge: Sendable {
         )
     }
 
+    /// 并行解析各 representation，注册随机 loopback route，并返回会话 owner。
     public func prepare(
         videos: [MediaRepresentation],
         audio: MediaRepresentation,

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Bridge/HLSPlaylistBuilder.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Bridge/HLSPlaylistBuilder.swift
@@ -15,6 +15,9 @@ public enum HLSPlaylistBuilderError: Error, Sendable, Equatable {
     case unsafeURI
 }
 
+/// 将一个 representation 的已验证 SIDX 引用编码为内存 VOD media playlist。
+///
+/// 输入必须具有非空分段与正 timescale；输出只引用调用方提供的安全 URI，不持有网络资源。
 public struct HLSMediaPlaylistBuilder: Sendable {
     public init() {}
 
@@ -104,6 +107,9 @@ public struct HLSVideoVariant: Sendable, Equatable {
     }
 }
 
+/// 把一个或多个视频 variant 与单一音频 representation 组合成 AVPlayer 的 ABR master playlist。
+///
+/// Builder 从真实分段计算带宽并验证媒体类型、视频属性与可嵌入字符串，不决定 CDN 或会话生命周期。
 public struct HLSMasterPlaylistBuilder: Sendable {
     public init() {}
 

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Bridge/LoopbackPlaybackServer.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Bridge/LoopbackPlaybackServer.swift
@@ -69,6 +69,10 @@ private enum LoopbackRangeRequest {
     case unsatisfiable
 }
 
+/// 向 AVPlayer 暴露最小、会话隔离的 HTTP/1.1 HLS/Range surface。
+///
+/// Server 只绑定 `127.0.0.1`，要求随机 path 与精确 Host，并对远端媒体强制 Range。
+/// `stop` 会原子移除 listener、route、connection 与上游 Task，可安全重复调用。
 public final class LoopbackPlaybackServer: @unchecked Sendable {
     private static let maximumHeaderBytes = 16 * 1_024
 
@@ -96,6 +100,7 @@ public final class LoopbackPlaybackServer: @unchecked Sendable {
         stop()
     }
 
+    /// 启动并等待 listener 得到实际端口；调用方取消会同步撤销未完成的启动。
     public func start() async throws {
         if lock.withLock({ self.listener != nil && self.port != nil }) {
             return
@@ -168,6 +173,7 @@ public final class LoopbackPlaybackServer: @unchecked Sendable {
         }
     }
 
+    /// 把资源登记在本 session token 下；返回 URL 不泄露远端来源。
     public func register(
         _ resource: LoopbackPlaybackResource,
         at relativePath: String
@@ -194,6 +200,7 @@ public final class LoopbackPlaybackServer: @unchecked Sendable {
         )
     }
 
+    /// 关闭 listener、所有活动连接与远端 Range Task，并清空内存 route。
     public func stop() {
         let state = lock.withLock {
             () -> (

--- a/Packages/BiliKitCore/Sources/BiliPlayback/MediaIndex/RepresentationIndexLoader.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/MediaIndex/RepresentationIndexLoader.swift
@@ -18,6 +18,7 @@ public struct LoadedSegmentIndex: Sendable, Equatable {
     }
 }
 
+/// 从候选 CDN 严格读取并解析 SIDX，同时保留实际成功的来源供媒体代理复用。
 public struct RepresentationIndexLoader: Sendable {
     private let rangeClient: HTTPRangeClient
     private let parser: SIDXParser

--- a/Packages/BiliKitCore/Sources/BiliPlayback/MediaIndex/SIDXParser.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/MediaIndex/SIDXParser.swift
@@ -57,6 +57,9 @@ public enum SIDXParserError: Error, Sendable, Equatable {
     case unexpectedTrailingBytes(Int)
 }
 
+/// 解析独立的 ISO BMFF `sidx` box，并把相对引用换算为经过溢出检查的绝对字节范围。
+///
+/// 当前只接受直接媒体引用、v0/v1 与无尾随字节的完整 box；不支持的结构会失败关闭。
 public struct SIDXParser: Sendable {
     public init() {}
 

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
@@ -14,6 +14,10 @@ public enum AVPlayerEngineError: Error, Sendable, Equatable {
 }
 
 @MainActor
+/// AVPlayer、DASH→HLS 会话与统一播放时间线的唯一资源 owner。
+///
+/// 每次 load 用 UUID generation 取代旧准备流程；迟到 bridge/readiness 结果必须自毁而不能
+/// 安装到当前 player。`stop` 同时释放 item、任务、loopback server、observer 与时间线 identity。
 public final class AVPlayerEngine:
     PlaybackControlling,
     PlaybackTimelineProviding
@@ -62,6 +66,7 @@ public final class AVPlayerEngine:
         timeline.updates()
     }
 
+    /// 准备并安装一个新播放项目；调用方取消会沿 generation 边界清理本次全部资源。
     public func load(
         _ request: PlaybackRequest,
         identity: PlaybackItemIdentity
@@ -205,6 +210,7 @@ public final class AVPlayerEngine:
         try timeline.setRate(rate)
     }
 
+    /// 执行精确 seek，并只为一次用户 seek 发布一个 discontinuity generation。
     public func seek(to time: Duration) async throws {
         guard player.currentItem != nil else {
             throw AVPlayerEngineError.seekFailed
@@ -226,6 +232,7 @@ public final class AVPlayerEngine:
         timeline.explicitSeekCompleted(at: seconds)
     }
 
+    /// 幂等终止当前及在途播放，将唯一时间线恢复为 `.idle`。
     public func stop() {
         loadGeneration = UUID()
         loadTask?.cancel()

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
@@ -232,7 +232,7 @@ public final class AVPlayerEngine:
         timeline.explicitSeekCompleted(at: seconds)
     }
 
-    /// 幂等终止当前及在途播放，将唯一时间线恢复为 `.idle`。
+    /// 幂等终止当前及在途播放，将唯一时间线恢复为 `.idle` 状态。
     public func stop() {
         loadGeneration = UUID()
         loadTask?.cancel()

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerTimelineAdapter.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerTimelineAdapter.swift
@@ -4,6 +4,10 @@ import Foundation
 import os
 
 @MainActor
+/// 把 AVPlayer/KVO/notification 事件投影为平台无关、identity-safe 的播放时间线。
+///
+/// 所有 callback 都同时核对当前 `AVPlayerItem` 与 item token；observer bag 在替换、失败和
+/// clear 时统一释放，避免旧 item 继续推进字幕或弹幕。
 final class AVPlayerTimelineAdapter {
     var onEnded: (@MainActor () -> Void)?
     var onFailed: (@MainActor () -> Void)?
@@ -35,6 +39,7 @@ final class AVPlayerTimelineAdapter {
         failedToken = nil
     }
 
+    /// 为当前 item 安装位置、速率、状态、结束、失败与时间跳变观察，并替换旧观察集合。
     func installObservers(for item: AVPlayerItem) {
         observers.reset()
         guard let token else { return }


### PR DESCRIPTION
## 变化

- 为 App / Composition / Platform、Application ports 与 use cases，以及网络认证、播放、字幕、弹幕和 Feature 状态边界补全 Swift `///` 文档注释
- 重点说明职责、前置条件、状态与取消语义、identity / generation 隔离、副作用、失败方式和存在原因
- 保持简单 getter、直接转发、SwiftUI `body`、测试样板和可从签名直接读出的代码不做机械注释
- 共修改 55 个生产 Swift 文件，新增 253 行文档注释；没有生产逻辑、测试或生成文件变更

## 原因

大型项目中的跨层职责、资源所有权和异步生命周期不能仅依赖实现本身表达。补充 Quick Help 可读的契约说明，帮助人与 AI 在不冻结实现细节的前提下共同理解关键边界。

## 用户与开发者影响

运行时行为不变。开发者在 Xcode Quick Help 和源码阅读中可以更快确认认证隔离、播放 identity、字幕/弹幕同步、取消与清理等非显然契约。

## 审查

- 由独立 agent 审查注释质量与覆盖范围
- 根据审查意见完成第二轮修改，修正 8 处必须处理的问题并补齐遗漏边界
- 发布前再次确认 staged diff 只有 `///` 新增，无删除和非注释新增

## 验证

- `git diff --check`
- 纯注释新增检查通过
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer BILIKIT_COMPACT_LOGS=1 BILIKIT_DERIVED_DATA_PATH=<fresh DerivedData> sh Scripts/run-quality-gates.sh app`
  - static contracts passed
  - Swift package passed
  - app build-for-testing passed
  - app unit tests passed

## 未覆盖边界

本次没有运行真实登录、窗口生命周期或播放交互验证，因为改动只涉及注释；这些运行时行为仍需在相应生产逻辑变更时用真实证据验证。