### PR TITLE
feat(playback): 优化播放器手势与原生呈现

### DIFF
--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -87,7 +87,13 @@ struct AppEnvironment {
             PlayerHostView(
                 player: playerEngine.player,
                 danmakuRenderer: danmakuRenderer,
-                danmakuController: danmakuController
+                danmakuController: danmakuController,
+                beginMomentaryPlaybackRate: { [playerEngine] rate in
+                    try? playerEngine.beginMomentaryPlaybackRate(Double(rate))
+                },
+                endMomentaryPlaybackRate: { [playerEngine] sessionID in
+                    playerEngine.endMomentaryPlaybackRate(sessionID: sessionID)
+                }
             )
         )
     }

--- a/BiliKitMac/Platform/PlayerHostView.swift
+++ b/BiliKitMac/Platform/PlayerHostView.swift
@@ -10,12 +10,30 @@ struct PlayerHostView: View {
     let player: AVPlayer
     let danmakuRenderer: CoreAnimationDanmakuRenderer
     let danmakuController: DanmakuPresentationController
+    let beginMomentaryPlaybackRate: ((Float) -> UUID?)?
+    let endMomentaryPlaybackRate: ((UUID) -> Void)?
+
+    init(
+        player: AVPlayer,
+        danmakuRenderer: CoreAnimationDanmakuRenderer,
+        danmakuController: DanmakuPresentationController,
+        beginMomentaryPlaybackRate: ((Float) -> UUID?)? = nil,
+        endMomentaryPlaybackRate: ((UUID) -> Void)? = nil
+    ) {
+        self.player = player
+        self.danmakuRenderer = danmakuRenderer
+        self.danmakuController = danmakuController
+        self.beginMomentaryPlaybackRate = beginMomentaryPlaybackRate
+        self.endMomentaryPlaybackRate = endMomentaryPlaybackRate
+    }
 
     var body: some View {
         AVPlayerContainerView(
             player: player,
             renderer: danmakuRenderer,
-            controller: danmakuController
+            controller: danmakuController,
+            beginMomentaryPlaybackRate: beginMomentaryPlaybackRate,
+            endMomentaryPlaybackRate: endMomentaryPlaybackRate
         )
     }
 }
@@ -24,20 +42,31 @@ private struct AVPlayerContainerView: NSViewRepresentable {
     let player: AVPlayer
     let renderer: CoreAnimationDanmakuRenderer
     let controller: DanmakuPresentationController
+    let beginMomentaryPlaybackRate: ((Float) -> UUID?)?
+    let endMomentaryPlaybackRate: ((UUID) -> Void)?
 
     func makeNSView(context: Context) -> DanmakuPlayerView {
         let view = DanmakuPlayerView(
             renderer: renderer,
-            controller: controller
+            controller: controller,
+            beginMomentaryPlaybackRate: beginMomentaryPlaybackRate,
+            endMomentaryPlaybackRate: endMomentaryPlaybackRate
         )
         view.player = player
+        view.startObservingPlayerItemChanges()
         view.controlsStyle = .floating
+        view.showsFullScreenToggleButton = true
+        view.allowsPictureInPicturePlayback = true
         return view
     }
 
     func updateNSView(_ view: DanmakuPlayerView, context: Context) {
+        view.requestMomentaryPlaybackRate = beginMomentaryPlaybackRate
+        view.finishMomentaryPlaybackRate = endMomentaryPlaybackRate
         if view.player !== player {
+            view.cancelMomentaryPlaybackRate()
             view.player = player
+            view.startObservingPlayerItemChanges()
         }
     }
 
@@ -47,31 +76,201 @@ private struct AVPlayerContainerView: NSViewRepresentable {
         coordinator: ()
     ) {
         view.danmakuOverlay.detachSurface()
+        view.stopObservingFocusLoss()
+        view.stopObservingPlayerItemChanges()
+        view.cancelMomentaryPlaybackRate()
         view.player = nil
+    }
+}
+
+enum PlayerMomentaryRate: Float, Equatable, Sendable {
+    case slow = 0.5
+    case fast = 2
+
+    var label: String {
+        switch self {
+        case .slow: "0.5X"
+        case .fast: "2X"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .slow: "backward.fill"
+        case .fast: "forward.fill"
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch self {
+        case .slow: "临时播放速度 0.5 倍"
+        case .fast: "临时播放速度 2 倍"
+        }
+    }
+}
+
+enum PlayerMomentaryRateSessionPolicy {
+    static func shouldCancel(
+        hasActiveSession: Bool,
+        timeControlStatus: AVPlayer.TimeControlStatus
+    ) -> Bool {
+        hasActiveSession && timeControlStatus == .paused
+    }
+}
+
+private struct PlayerMomentaryRateBadge: View {
+    let rate: PlayerMomentaryRate
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: rate.symbolName)
+            Text(rate.label)
+                .monospacedDigit()
+        }
+        .font(.title3.weight(.semibold))
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .modifier(PlayerMomentaryRateBadgeBackground())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(rate.accessibilityLabel)
+        .accessibilityIdentifier("player.momentary-rate")
+    }
+}
+
+private struct PlayerMomentaryRateBadgeBackground: ViewModifier {
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(macOS 26.0, *) {
+            content.glassEffect(.regular, in: Capsule())
+        } else {
+            content
+                .background(.ultraThinMaterial, in: Capsule())
+                .overlay {
+                    Capsule()
+                        .stroke(.white.opacity(0.18), lineWidth: 0.5)
+                }
+        }
+    }
+}
+
+@MainActor
+private final class PlayerMomentaryRateBadgeHostingView:
+    NSHostingView<PlayerMomentaryRateBadge>
+{
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
     }
 }
 
 @MainActor
 private final class DanmakuPlayerView: AVPlayerView {
     let danmakuOverlay: DanmakuOverlayView
-    private let scrollCaptureView = PlayerScrollCaptureView()
+    private let scrollWheelCaptureView = PlayerScrollWheelCaptureView()
     private var installedDanmakuOverlay = false
+    private var momentaryRateSessionID: UUID?
+    private var momentaryRateItemIdentity: ObjectIdentifier?
+    private weak var observedPlayer: AVPlayer?
+    private var playerItemObservation: NSKeyValueObservation?
+    private var playerTimeControlObservation: NSKeyValueObservation?
+    private var appResignObserver: NSObjectProtocol?
+    private var windowResignObserver: NSObjectProtocol?
+    var requestMomentaryPlaybackRate: ((Float) -> UUID?)?
+    var finishMomentaryPlaybackRate: ((UUID) -> Void)?
 
     init(
         renderer: CoreAnimationDanmakuRenderer,
-        controller: DanmakuPresentationController
+        controller: DanmakuPresentationController,
+        beginMomentaryPlaybackRate: ((Float) -> UUID?)?,
+        endMomentaryPlaybackRate: ((UUID) -> Void)?
     ) {
         danmakuOverlay = DanmakuOverlayView(
             renderer: renderer,
             controller: controller
         )
+        requestMomentaryPlaybackRate = beginMomentaryPlaybackRate
+        finishMomentaryPlaybackRate = endMomentaryPlaybackRate
         super.init(frame: .zero)
+        scrollWheelCaptureView.isMomentaryRateAvailable = { [weak self] in
+            self?.canBeginMomentaryPlaybackRate == true
+        }
+        scrollWheelCaptureView.onMomentaryRateBegan = { [weak self] rate in
+            self?.beginMomentaryPlaybackRate(rate)
+        }
+        scrollWheelCaptureView.onMomentaryRateEnded = { [weak self] in
+            self?.endMomentaryPlaybackRate()
+        }
         installDanmakuOverlayIfNeeded()
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        if window !== newWindow {
+            stopObservingFocusLoss()
+            cancelMomentaryPlaybackRate()
+        }
+        super.viewWillMove(toWindow: newWindow)
     }
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         installDanmakuOverlayIfNeeded()
+        startObservingFocusLoss()
+    }
+
+    func cancelMomentaryPlaybackRate() {
+        scrollWheelCaptureView.cancelInputSession()
+        if momentaryRateSessionID != nil {
+            endMomentaryPlaybackRate()
+        }
+    }
+
+    func cancelMomentaryPlaybackRateIfItemChanged() {
+        guard let momentaryRateItemIdentity else { return }
+        guard let currentItem = player?.currentItem,
+            ObjectIdentifier(currentItem) == momentaryRateItemIdentity
+        else {
+            cancelMomentaryPlaybackRate()
+            return
+        }
+    }
+
+    func startObservingPlayerItemChanges() {
+        guard observedPlayer !== player else { return }
+        stopObservingPlayerItemChanges()
+        guard let player else { return }
+        observedPlayer = player
+        playerItemObservation = player.observe(\.currentItem, options: [.new]) {
+            [weak self] _, _ in
+            Task { @MainActor in
+                self?.cancelMomentaryPlaybackRateIfItemChanged()
+            }
+        }
+        playerTimeControlObservation = player.observe(
+            \.timeControlStatus,
+            options: [.new]
+        ) {
+            [weak self] _, change in
+            guard change.newValue == .paused else { return }
+            Task { @MainActor in
+                guard let self,
+                    PlayerMomentaryRateSessionPolicy.shouldCancel(
+                        hasActiveSession: self.momentaryRateSessionID != nil,
+                        timeControlStatus: self.player?.timeControlStatus
+                            ?? .paused
+                    )
+                else {
+                    return
+                }
+                self.cancelMomentaryPlaybackRate()
+            }
+        }
+    }
+
+    func stopObservingPlayerItemChanges() {
+        playerItemObservation?.invalidate()
+        playerItemObservation = nil
+        playerTimeControlObservation?.invalidate()
+        playerTimeControlObservation = nil
+        observedPlayer = nil
     }
 
     private func installDanmakuOverlayIfNeeded() {
@@ -81,21 +280,25 @@ private final class DanmakuPlayerView: AVPlayerView {
             return
         }
         installedDanmakuOverlay = true
-        scrollCaptureView.translatesAutoresizingMaskIntoConstraints = false
+        scrollWheelCaptureView.translatesAutoresizingMaskIntoConstraints = false
         danmakuOverlay.translatesAutoresizingMaskIntoConstraints = false
-        contentOverlayView.addSubview(scrollCaptureView)
         contentOverlayView.addSubview(danmakuOverlay)
+        contentOverlayView.addSubview(
+            scrollWheelCaptureView,
+            positioned: .above,
+            relativeTo: danmakuOverlay
+        )
         NSLayoutConstraint.activate([
-            scrollCaptureView.leadingAnchor.constraint(
+            scrollWheelCaptureView.leadingAnchor.constraint(
                 equalTo: contentOverlayView.leadingAnchor
             ),
-            scrollCaptureView.trailingAnchor.constraint(
+            scrollWheelCaptureView.trailingAnchor.constraint(
                 equalTo: contentOverlayView.trailingAnchor
             ),
-            scrollCaptureView.topAnchor.constraint(
+            scrollWheelCaptureView.topAnchor.constraint(
                 equalTo: contentOverlayView.topAnchor
             ),
-            scrollCaptureView.bottomAnchor.constraint(
+            scrollWheelCaptureView.bottomAnchor.constraint(
                 equalTo: contentOverlayView.bottomAnchor
             ),
             danmakuOverlay.leadingAnchor.constraint(
@@ -113,34 +316,241 @@ private final class DanmakuPlayerView: AVPlayerView {
         ])
     }
 
+    private var canBeginMomentaryPlaybackRate: Bool {
+        guard requestMomentaryPlaybackRate != nil,
+            finishMomentaryPlaybackRate != nil,
+            let player,
+            let item = player.currentItem
+        else {
+            return false
+        }
+        return item.status == .readyToPlay && player.rate > 0
+    }
+
+    private func beginMomentaryPlaybackRate(_ rate: PlayerMomentaryRate) {
+        guard let player,
+            let item = player.currentItem,
+            item.status == .readyToPlay,
+            player.rate > 0,
+            let sessionID = requestMomentaryPlaybackRate?(rate.rawValue)
+        else {
+            clearMomentaryPlaybackRate()
+            return
+        }
+        momentaryRateSessionID = sessionID
+        momentaryRateItemIdentity = ObjectIdentifier(item)
+        scrollWheelCaptureView.showMomentaryRateBadge(rate)
+    }
+
+    private func endMomentaryPlaybackRate() {
+        if let momentaryRateSessionID {
+            finishMomentaryPlaybackRate?(momentaryRateSessionID)
+        }
+        clearMomentaryPlaybackRate()
+    }
+
+    private func clearMomentaryPlaybackRate() {
+        momentaryRateSessionID = nil
+        momentaryRateItemIdentity = nil
+        scrollWheelCaptureView.clearMomentaryRateBadge()
+    }
+
+    private func startObservingFocusLoss() {
+        guard requestMomentaryPlaybackRate != nil,
+            finishMomentaryPlaybackRate != nil,
+            let window,
+            appResignObserver == nil,
+            windowResignObserver == nil
+        else {
+            return
+        }
+        appResignObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.cancelMomentaryPlaybackRate()
+            }
+        }
+        windowResignObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.cancelMomentaryPlaybackRate()
+            }
+        }
+    }
+
+    func stopObservingFocusLoss() {
+        if let appResignObserver {
+            NotificationCenter.default.removeObserver(appResignObserver)
+            self.appResignObserver = nil
+        }
+        if let windowResignObserver {
+            NotificationCenter.default.removeObserver(windowResignObserver)
+            self.windowResignObserver = nil
+        }
+    }
+
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         nil
     }
 }
 
-/// 安装在 AVKit 公开的 content overlay 中、位于原生控制条下方的透明滚轮命中层。
+/// 安装在 AVKit 公开 content overlay 中、位于原生控制条下方的透明滚轮命中层。
 ///
-/// 它不覆写点击、拖动、magnify、键盘或辅助功能方法；弹幕层仍保持 hitTest 为 nil。
+/// 只对 scroll-wheel 事件参与 hit testing；点击、拖动、magnify、键盘与辅助功能继续穿透。
+/// AVKit detached 全屏会携带 content overlay，因此同一 capture 可继续处理全屏横向倍速。
 @MainActor
-final class PlayerScrollCaptureView: NSView {
-    private var scrollWheelRouter = PlayerScrollWheelRouter()
-    private var pendingScrollWheelEvents: [NSEvent] = []
+final class PlayerScrollWheelCaptureView: NSView {
+    private lazy var surfaceCapture = PlayerScrollWheelSurfaceCapture(
+        anchorView: self,
+        dispatchToPlayer: { [weak self] event in
+            self?.dispatchScrollWheelToResponderChain(event)
+        }
+    )
+    private var windowResignObserver: NSObjectProtocol?
+    private var momentaryRateBadge: NSView?
+
+    var isMomentaryRateAvailable: () -> Bool {
+        get { surfaceCapture.isMomentaryRateAvailable }
+        set { surfaceCapture.isMomentaryRateAvailable = newValue }
+    }
+
+    var onMomentaryRateBegan: (PlayerMomentaryRate) -> Void {
+        get { surfaceCapture.onMomentaryRateBegan }
+        set { surfaceCapture.onMomentaryRateBegan = newValue }
+    }
+
+    var onMomentaryRateEnded: () -> Void {
+        get { surfaceCapture.onMomentaryRateEnded }
+        set { surfaceCapture.onMomentaryRateEnded = newValue }
+    }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         setAccessibilityElement(false)
     }
 
-    /// 只把纵向滚轮序列交给 AVPlayerView 之外的详情 ScrollView。
+    static func capturesEvent(ofType type: NSEvent.EventType?) -> Bool {
+        type == .scrollWheel
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        Self.capturesEvent(ofType: NSApp.currentEvent?.type) ? self : nil
+    }
+
     override func scrollWheel(with event: NSEvent) {
+        surfaceCapture.handleScrollWheel(event)
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        if window !== newWindow {
+            stopObservingWindowFocusLoss()
+            cancelInputSession()
+        }
+        super.viewWillMove(toWindow: newWindow)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard let window, windowResignObserver == nil else { return }
+        windowResignObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.cancelInputSession()
+            }
+        }
+    }
+
+    func cancelInputSession() {
+        surfaceCapture.cancelInputSession()
+    }
+
+    var hasMomentaryRateBadge: Bool {
+        momentaryRateBadge != nil
+    }
+
+    func showMomentaryRateBadge(_ rate: PlayerMomentaryRate) {
+        clearMomentaryRateBadge()
+        let badge = PlayerMomentaryRateBadgeHostingView(
+            rootView: PlayerMomentaryRateBadge(rate: rate)
+        )
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(badge)
+        NSLayoutConstraint.activate([
+            badge.centerXAnchor.constraint(equalTo: centerXAnchor),
+            badge.topAnchor.constraint(equalTo: topAnchor, constant: 20),
+        ])
+        momentaryRateBadge = badge
+    }
+
+    func clearMomentaryRateBadge() {
+        momentaryRateBadge?.removeFromSuperview()
+        momentaryRateBadge = nil
+    }
+
+    private func dispatchScrollWheelToResponderChain(_ event: NSEvent) {
+        super.scrollWheel(with: event)
+    }
+
+    private func stopObservingWindowFocusLoss() {
+        if let windowResignObserver {
+            NotificationCenter.default.removeObserver(windowResignObserver)
+            self.windowResignObserver = nil
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+}
+
+/// 由唯一 AVPlayerView content overlay surface 拥有的滚轮序列处理器。
+///
+/// 本类型不安装 event monitor，也不向 AVKit 私有子视图重放事件。
+@MainActor
+final class PlayerScrollWheelSurfaceCapture {
+    private weak var anchorView: NSView?
+    private let dispatchToPlayer: (NSEvent) -> Void
+    private var scrollWheelRouter = PlayerScrollWheelRouter()
+    private var horizontalRateGesture = PlayerHorizontalRateGestureState()
+    private var pendingScrollWheelEvents: [NSEvent] = []
+    var isMomentaryRateAvailable: () -> Bool = { false }
+    var onMomentaryRateBegan: (PlayerMomentaryRate) -> Void = { _ in }
+    var onMomentaryRateEnded: () -> Void = {}
+
+    init(
+        anchorView: NSView,
+        dispatchToPlayer: @escaping (NSEvent) -> Void = { _ in }
+    ) {
+        self.anchorView = anchorView
+        self.dispatchToPlayer = dispatchToPlayer
+    }
+
+    var hasDetailScrollViewAncestor: Bool {
+        detailScrollViewAncestor != nil
+    }
+
+    /// 纵向滚动交给详情页；播放中的精确横向手势用于临时倍速。
+    func handleScrollWheel(_ event: NSEvent) {
+        cancelAbandonedMomentaryRate(before: event)
         flushAbandonedPendingEvents(before: event)
         let route = scrollWheelRouter.route(
             deltaX: event.scrollingDeltaX,
             deltaY: event.scrollingDeltaY,
             phase: event.phase,
             momentumPhase: event.momentumPhase,
-            isPrecise: event.hasPreciseScrollingDeltas
+            isPrecise: event.hasPreciseScrollingDeltas,
+            allowsMomentaryRate: isMomentaryRateAvailable()
         )
         if route == .pending {
             pendingScrollWheelEvents.append(event)
@@ -152,22 +562,65 @@ final class PlayerScrollCaptureView: NSView {
         switch route {
         case .outerScroll:
             guard let scrollView = detailScrollViewAncestor else {
-                dispatchToPlayer(events)
+                dispatchToAVKit(events)
                 return
             }
             for event in events {
                 scrollView.scrollWheel(with: event)
             }
         case .player:
-            dispatchToPlayer(events)
+            dispatchToAVKit(events)
+        case .momentaryRate:
+            for event in events {
+                applyHorizontalRateAction(
+                    horizontalRateGesture.handle(
+                        deltaX: Self.deviceRelativeDeltaX(
+                            event.scrollingDeltaX,
+                            isDirectionInverted:
+                                event.isDirectionInvertedFromDevice
+                        ),
+                        phase: event.phase,
+                        momentumPhase: event.momentumPhase
+                    )
+                )
+            }
+        case .discard:
+            return
         case .pending:
             assertionFailure("Pending scroll events must return before dispatch")
         }
     }
 
+    func cancelInputSession() {
+        let action = horizontalRateGesture.cancel()
+        pendingScrollWheelEvents.removeAll(keepingCapacity: true)
+        scrollWheelRouter.cancelInputSession()
+        applyHorizontalRateAction(action)
+    }
+
+    static func deviceRelativeDeltaX(
+        _ deltaX: CGFloat,
+        isDirectionInverted: Bool
+    ) -> CGFloat {
+        isDirectionInverted ? -deltaX : deltaX
+    }
+
+    private func applyHorizontalRateAction(
+        _ action: PlayerHorizontalRateGestureState.Action
+    ) {
+        switch action {
+        case .none:
+            return
+        case .begin(let rate):
+            onMomentaryRateBegan(rate)
+        case .end:
+            onMomentaryRateEnded()
+        }
+    }
+
     /// 忽略 AVPlayerView 内部可能存在的滚动视图，只找播放器之外的详情容器。
     private var detailScrollViewAncestor: NSScrollView? {
-        var ancestor = superview
+        var ancestor = anchorView?.superview
         var passedPlayerView = false
         while let current = ancestor {
             if current is AVPlayerView {
@@ -182,9 +635,10 @@ final class PlayerScrollCaptureView: NSView {
         return nil
     }
 
-    private func dispatchToPlayer(_ events: [NSEvent]) {
+    private func dispatchToAVKit<Events: Sequence>(_ events: Events)
+    where Events.Element == NSEvent {
         for event in events {
-            super.scrollWheel(with: event)
+            dispatchToPlayer(event)
         }
     }
 
@@ -197,14 +651,74 @@ final class PlayerScrollCaptureView: NSView {
                 && !previousPhase.contains(.mayBegin))
         let leavesDirectGesture = event.phase.isEmpty
         guard startsNewGesture || leavesDirectGesture else { return }
-        dispatchToPlayer(pendingScrollWheelEvents)
+        dispatchToAVKit(pendingScrollWheelEvents)
         pendingScrollWheelEvents.removeAll(keepingCapacity: true)
+        applyHorizontalRateAction(horizontalRateGesture.cancel())
         scrollWheelRouter.reset()
     }
 
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        nil
+    private func cancelAbandonedMomentaryRate(before event: NSEvent) {
+        let previousPhase = pendingScrollWheelEvents.last?.phase ?? []
+        let startsNewGesture =
+            event.phase.contains(.mayBegin)
+            || (event.phase.contains(.began)
+                && !previousPhase.contains(.mayBegin))
+        let startsUnphasedInput =
+            event.phase.isEmpty && event.momentumPhase.isEmpty
+        guard startsNewGesture || startsUnphasedInput else { return }
+        applyHorizontalRateAction(horizontalRateGesture.cancel())
+    }
+}
+
+struct PlayerHorizontalRateGestureState {
+    enum Action: Equatable {
+        case none
+        case begin(PlayerMomentaryRate)
+        case end
+    }
+
+    static let activationThreshold: CGFloat = 30
+
+    private var accumulatedDeltaX: CGFloat = 0
+    private var activeRate: PlayerMomentaryRate?
+
+    mutating func handle(
+        deltaX: CGFloat,
+        phase: NSEvent.Phase,
+        momentumPhase: NSEvent.Phase
+    ) -> Action {
+        if phase.contains(.ended) || phase.contains(.cancelled) {
+            return cancel()
+        }
+
+        if !momentumPhase.isEmpty {
+            return cancel()
+        }
+
+        if phase.contains(.mayBegin) || phase.contains(.began) {
+            let action = cancel()
+            accumulatedDeltaX = deltaX
+            return action
+        }
+
+        accumulatedDeltaX += deltaX
+        guard activeRate == nil,
+            abs(accumulatedDeltaX) >= Self.activationThreshold
+        else {
+            return .none
+        }
+
+        let rate: PlayerMomentaryRate =
+            accumulatedDeltaX < 0 ? .fast : .slow
+        activeRate = rate
+        return .begin(rate)
+    }
+
+    mutating func cancel() -> Action {
+        let action: Action = activeRate == nil ? .none : .end
+        accumulatedDeltaX = 0
+        activeRate = nil
+        return action
     }
 }
 
@@ -212,6 +726,8 @@ struct PlayerScrollWheelRouter {
     enum Route: Equatable {
         case outerScroll
         case player
+        case momentaryRate
+        case discard
         case pending
     }
 
@@ -224,14 +740,27 @@ struct PlayerScrollWheelRouter {
     private var accumulatedDeltaX: CGFloat = 0
     private var accumulatedDeltaY: CGFloat = 0
     private var pendingSampleCount = 0
+    private var directGestureHasBegun = false
+    private var discardsCancelledGestureRemainder = false
 
     mutating func route(
         deltaX: CGFloat,
         deltaY: CGFloat,
         phase: NSEvent.Phase,
         momentumPhase: NSEvent.Phase,
-        isPrecise: Bool = true
+        isPrecise: Bool = true,
+        allowsMomentaryRate: Bool = false
     ) -> Route {
+        if discardsCancelledGestureRemainder {
+            let startsNewDirectGesture =
+                phase.contains(.mayBegin) || phase.contains(.began)
+            let startsUnphasedInput = phase.isEmpty && momentumPhase.isEmpty
+            guard startsNewDirectGesture || startsUnphasedInput else {
+                return .discard
+            }
+            discardsCancelledGestureRemainder = false
+        }
+
         if !momentumPhase.isEmpty {
             let route =
                 gestureRoute
@@ -252,6 +781,9 @@ struct PlayerScrollWheelRouter {
 
         if phase.contains(.began) || phase.contains(.mayBegin) {
             reset()
+            directGestureHasBegun = true
+        } else if !directGestureHasBegun {
+            return .player
         }
 
         if !isPrecise {
@@ -281,7 +813,9 @@ struct PlayerScrollWheelRouter {
             accumulatedDeltaX += deltaX
             accumulatedDeltaY += deltaY
             pendingSampleCount += 1
-            gestureRoute = accumulatedRoute()
+            gestureRoute = accumulatedRoute(
+                allowsMomentaryRate: allowsMomentaryRate
+            )
             if gestureRoute == nil,
                 phase.contains(.ended)
                     || phase.contains(.cancelled)
@@ -313,9 +847,18 @@ struct PlayerScrollWheelRouter {
         accumulatedDeltaX = 0
         accumulatedDeltaY = 0
         pendingSampleCount = 0
+        directGestureHasBegun = false
+        discardsCancelledGestureRemainder = false
     }
 
-    private func accumulatedRoute() -> Route? {
+    mutating func cancelInputSession() {
+        reset()
+        discardsCancelledGestureRemainder = true
+    }
+
+    private func accumulatedRoute(
+        allowsMomentaryRate: Bool
+    ) -> Route? {
         let horizontalMagnitude = abs(accumulatedDeltaX)
         let verticalMagnitude = abs(accumulatedDeltaY)
         let dominantMagnitude = max(horizontalMagnitude, verticalMagnitude)
@@ -325,7 +868,10 @@ struct PlayerScrollWheelRouter {
         else {
             return nil
         }
-        return verticalMagnitude > horizontalMagnitude ? .outerScroll : .player
+        if verticalMagnitude > horizontalMagnitude {
+            return .outerScroll
+        }
+        return allowsMomentaryRate ? .momentaryRate : .player
     }
 
     private func dominantRoute(deltaX: CGFloat, deltaY: CGFloat) -> Route {

--- a/BiliKitMac/Platform/PlayerHostView.swift
+++ b/BiliKitMac/Platform/PlayerHostView.swift
@@ -54,6 +54,7 @@ private struct AVPlayerContainerView: NSViewRepresentable {
 @MainActor
 private final class DanmakuPlayerView: AVPlayerView {
     let danmakuOverlay: DanmakuOverlayView
+    private let scrollCaptureView = PlayerScrollCaptureView()
     private var installedDanmakuOverlay = false
 
     init(
@@ -80,9 +81,23 @@ private final class DanmakuPlayerView: AVPlayerView {
             return
         }
         installedDanmakuOverlay = true
+        scrollCaptureView.translatesAutoresizingMaskIntoConstraints = false
         danmakuOverlay.translatesAutoresizingMaskIntoConstraints = false
+        contentOverlayView.addSubview(scrollCaptureView)
         contentOverlayView.addSubview(danmakuOverlay)
         NSLayoutConstraint.activate([
+            scrollCaptureView.leadingAnchor.constraint(
+                equalTo: contentOverlayView.leadingAnchor
+            ),
+            scrollCaptureView.trailingAnchor.constraint(
+                equalTo: contentOverlayView.trailingAnchor
+            ),
+            scrollCaptureView.topAnchor.constraint(
+                equalTo: contentOverlayView.topAnchor
+            ),
+            scrollCaptureView.bottomAnchor.constraint(
+                equalTo: contentOverlayView.bottomAnchor
+            ),
             danmakuOverlay.leadingAnchor.constraint(
                 equalTo: contentOverlayView.leadingAnchor
             ),
@@ -101,5 +116,229 @@ private final class DanmakuPlayerView: AVPlayerView {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         nil
+    }
+}
+
+/// 安装在 AVKit 公开的 content overlay 中、位于原生控制条下方的透明滚轮命中层。
+///
+/// 它不覆写点击、拖动、magnify、键盘或辅助功能方法；弹幕层仍保持 hitTest 为 nil。
+@MainActor
+final class PlayerScrollCaptureView: NSView {
+    private var scrollWheelRouter = PlayerScrollWheelRouter()
+    private var pendingScrollWheelEvents: [NSEvent] = []
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setAccessibilityElement(false)
+    }
+
+    /// 只把纵向滚轮序列交给 AVPlayerView 之外的详情 ScrollView。
+    override func scrollWheel(with event: NSEvent) {
+        flushAbandonedPendingEvents(before: event)
+        let route = scrollWheelRouter.route(
+            deltaX: event.scrollingDeltaX,
+            deltaY: event.scrollingDeltaY,
+            phase: event.phase,
+            momentumPhase: event.momentumPhase,
+            isPrecise: event.hasPreciseScrollingDeltas
+        )
+        if route == .pending {
+            pendingScrollWheelEvents.append(event)
+            return
+        }
+
+        let events = pendingScrollWheelEvents + [event]
+        pendingScrollWheelEvents.removeAll(keepingCapacity: true)
+        switch route {
+        case .outerScroll:
+            guard let scrollView = detailScrollViewAncestor else {
+                dispatchToPlayer(events)
+                return
+            }
+            for event in events {
+                scrollView.scrollWheel(with: event)
+            }
+        case .player:
+            dispatchToPlayer(events)
+        case .pending:
+            assertionFailure("Pending scroll events must return before dispatch")
+        }
+    }
+
+    /// 忽略 AVPlayerView 内部可能存在的滚动视图，只找播放器之外的详情容器。
+    private var detailScrollViewAncestor: NSScrollView? {
+        var ancestor = superview
+        var passedPlayerView = false
+        while let current = ancestor {
+            if current is AVPlayerView {
+                passedPlayerView = true
+            } else if passedPlayerView,
+                let scrollView = current as? NSScrollView
+            {
+                return scrollView
+            }
+            ancestor = current.superview
+        }
+        return nil
+    }
+
+    private func dispatchToPlayer(_ events: [NSEvent]) {
+        for event in events {
+            super.scrollWheel(with: event)
+        }
+    }
+
+    private func flushAbandonedPendingEvents(before event: NSEvent) {
+        guard !pendingScrollWheelEvents.isEmpty else { return }
+        let previousPhase = pendingScrollWheelEvents.last?.phase ?? []
+        let startsNewGesture =
+            event.phase.contains(.mayBegin)
+            || (event.phase.contains(.began)
+                && !previousPhase.contains(.mayBegin))
+        let leavesDirectGesture = event.phase.isEmpty
+        guard startsNewGesture || leavesDirectGesture else { return }
+        dispatchToPlayer(pendingScrollWheelEvents)
+        pendingScrollWheelEvents.removeAll(keepingCapacity: true)
+        scrollWheelRouter.reset()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+}
+
+struct PlayerScrollWheelRouter {
+    enum Route: Equatable {
+        case outerScroll
+        case player
+        case pending
+    }
+
+    private static let minimumAxisTravel: CGFloat = 4
+    private static let minimumAxisLead: CGFloat = 2
+    private static let maximumPendingSampleCount = 16
+
+    private var gestureRoute: Route?
+    private var completedGestureRoute: Route?
+    private var accumulatedDeltaX: CGFloat = 0
+    private var accumulatedDeltaY: CGFloat = 0
+    private var pendingSampleCount = 0
+
+    mutating func route(
+        deltaX: CGFloat,
+        deltaY: CGFloat,
+        phase: NSEvent.Phase,
+        momentumPhase: NSEvent.Phase,
+        isPrecise: Bool = true
+    ) -> Route {
+        if !momentumPhase.isEmpty {
+            let route =
+                gestureRoute
+                ?? completedGestureRoute
+                ?? dominantRoute(deltaX: deltaX, deltaY: deltaY)
+            if momentumPhase.contains(.ended)
+                || momentumPhase.contains(.cancelled)
+            {
+                gestureRoute = nil
+                completedGestureRoute = nil
+            }
+            return route
+        }
+
+        if phase.isEmpty {
+            return dominantRoute(deltaX: deltaX, deltaY: deltaY)
+        }
+
+        if phase.contains(.began) || phase.contains(.mayBegin) {
+            reset()
+        }
+
+        if !isPrecise {
+            if gestureRoute == nil {
+                gestureRoute = unambiguousRoute(
+                    deltaX: deltaX,
+                    deltaY: deltaY
+                )
+            }
+            if gestureRoute == nil,
+                phase.contains(.ended) || phase.contains(.cancelled)
+            {
+                gestureRoute = .player
+            }
+            let route = gestureRoute ?? .pending
+            if phase.contains(.ended) {
+                completedGestureRoute = route
+                resetDirectGesture()
+            } else if phase.contains(.cancelled) {
+                completedGestureRoute = nil
+                resetDirectGesture()
+            }
+            return route
+        }
+
+        if gestureRoute == nil {
+            accumulatedDeltaX += deltaX
+            accumulatedDeltaY += deltaY
+            pendingSampleCount += 1
+            gestureRoute = accumulatedRoute()
+            if gestureRoute == nil,
+                phase.contains(.ended)
+                    || phase.contains(.cancelled)
+                    || pendingSampleCount >= Self.maximumPendingSampleCount
+            {
+                gestureRoute = .player
+            }
+        }
+
+        let route = gestureRoute ?? .pending
+        if phase.contains(.ended) {
+            completedGestureRoute = gestureRoute
+            resetDirectGesture()
+        } else if phase.contains(.cancelled) {
+            completedGestureRoute = nil
+            resetDirectGesture()
+        }
+        return route
+    }
+
+    mutating func reset() {
+        gestureRoute = nil
+        completedGestureRoute = nil
+        resetDirectGesture()
+    }
+
+    private mutating func resetDirectGesture() {
+        gestureRoute = nil
+        accumulatedDeltaX = 0
+        accumulatedDeltaY = 0
+        pendingSampleCount = 0
+    }
+
+    private func accumulatedRoute() -> Route? {
+        let horizontalMagnitude = abs(accumulatedDeltaX)
+        let verticalMagnitude = abs(accumulatedDeltaY)
+        let dominantMagnitude = max(horizontalMagnitude, verticalMagnitude)
+        let axisLead = abs(horizontalMagnitude - verticalMagnitude)
+        guard dominantMagnitude >= Self.minimumAxisTravel,
+            axisLead >= Self.minimumAxisLead
+        else {
+            return nil
+        }
+        return verticalMagnitude > horizontalMagnitude ? .outerScroll : .player
+    }
+
+    private func dominantRoute(deltaX: CGFloat, deltaY: CGFloat) -> Route {
+        unambiguousRoute(deltaX: deltaX, deltaY: deltaY) ?? .player
+    }
+
+    private func unambiguousRoute(
+        deltaX: CGFloat,
+        deltaY: CGFloat
+    ) -> Route? {
+        let horizontalMagnitude = abs(deltaX)
+        let verticalMagnitude = abs(deltaY)
+        guard horizontalMagnitude != verticalMagnitude else { return nil }
+        return verticalMagnitude > horizontalMagnitude ? .outerScroll : .player
     }
 }

--- a/BiliKitMac/Platform/PlayerHostView.swift
+++ b/BiliKitMac/Platform/PlayerHostView.swift
@@ -140,16 +140,24 @@ private struct PlayerMomentaryRateBadge: View {
 private struct PlayerMomentaryRateBadgeBackground: ViewModifier {
     @ViewBuilder
     func body(content: Content) -> some View {
-        if #available(macOS 26.0, *) {
-            content.glassEffect(.regular, in: Capsule())
-        } else {
-            content
-                .background(.ultraThinMaterial, in: Capsule())
-                .overlay {
-                    Capsule()
-                        .stroke(.white.opacity(0.18), lineWidth: 0.5)
-                }
-        }
+        #if compiler(>=6.2)
+            if #available(macOS 26.0, *) {
+                content.glassEffect(.regular, in: Capsule())
+            } else {
+                fallbackBackground(content)
+            }
+        #else
+            fallbackBackground(content)
+        #endif
+    }
+
+    private func fallbackBackground(_ content: Content) -> some View {
+        content
+            .background(.ultraThinMaterial, in: Capsule())
+            .overlay {
+                Capsule()
+                    .stroke(.white.opacity(0.18), lineWidth: 0.5)
+            }
     }
 }
 

--- a/BiliKitMacTests/PlayerHostViewIdentityTests.swift
+++ b/BiliKitMacTests/PlayerHostViewIdentityTests.swift
@@ -11,7 +11,7 @@ import Testing
 struct PlayerHostViewIdentityTests {
     @Test(.timeLimit(.minutes(1)))
     @MainActor
-    func contentOverlayCaptureRoutesVerticalWheelToEnclosingSwiftUIScrollView()
+    func playerSurfaceCaptureRoutesVerticalWheelWithoutLocalMonitor()
         async throws
     {
         let renderer = CoreAnimationDanmakuRenderer()
@@ -49,13 +49,31 @@ struct PlayerHostViewIdentityTests {
                 in: hostingView
             )
         )
+        #expect(playerView.showsFullScreenToggleButton)
+        #expect(playerView.allowsPictureInPicturePlayback)
         let scrollCaptureView = try #require(
             firstView(
-                ofType: PlayerScrollCaptureView.self,
+                ofType: PlayerScrollWheelCaptureView.self,
                 in: playerView
             )
         )
         #expect(scrollCaptureView.superview === playerView.contentOverlayView)
+        let danmakuOverlay = try #require(
+            firstView(
+                ofType: DanmakuOverlayView.self,
+                in: playerView
+            )
+        )
+        let overlaySubviews = try #require(
+            playerView.contentOverlayView?.subviews
+        )
+        let danmakuIndex = try #require(
+            overlaySubviews.firstIndex { $0 === danmakuOverlay }
+        )
+        let captureIndex = try #require(
+            overlaySubviews.firstIndex { $0 === scrollCaptureView }
+        )
+        #expect(captureIndex > danmakuIndex)
         #expect(!scrollCaptureView.isAccessibilityElement())
         let scrollView = try #require(
             firstAncestor(ofType: NSScrollView.self, from: playerView)
@@ -73,17 +91,7 @@ struct PlayerHostViewIdentityTests {
         let event = try makeScrollWheelEvent(deltaX: 0, deltaY: -80)
         #expect(event.hasPreciseScrollingDeltas)
 
-        let videoPoint = NSPoint(
-            x: playerView.bounds.midX,
-            y: playerView.bounds.height * 0.75
-        )
-        let eventTarget = try #require(
-            playerView.hitTest(
-                playerView.convert(videoPoint, to: playerView.superview)
-            )
-        )
-        #expect(eventTarget === scrollCaptureView)
-        eventTarget.scrollWheel(with: event)
+        scrollCaptureView.scrollWheel(with: event)
 
         #expect(
             await waitUntil(in: hostingView) {
@@ -93,11 +101,53 @@ struct PlayerHostViewIdentityTests {
 
         let scrolledOrigin = scrollView.contentView.bounds.origin
         let horizontalEvent = try makeScrollWheelEvent(deltaX: -80, deltaY: 0)
-        eventTarget.scrollWheel(with: horizontalEvent)
+        scrollCaptureView.scrollWheel(with: horizontalEvent)
         hostingView.layoutSubtreeIfNeeded()
         #expect(scrollView.contentView.bounds.origin == scrolledOrigin)
 
         window.contentView = NSView()
+    }
+
+    @Test
+    @MainActor
+    func contentOverlayCaptureOnlyParticipatesInScrollWheelHitTesting() {
+        #expect(
+            PlayerScrollWheelCaptureView.capturesEvent(
+                ofType: .scrollWheel
+            )
+        )
+        #expect(
+            !PlayerScrollWheelCaptureView.capturesEvent(
+                ofType: .leftMouseDown
+            )
+        )
+        #expect(
+            !PlayerScrollWheelCaptureView.capturesEvent(
+                ofType: .magnify
+            )
+        )
+        #expect(!PlayerScrollWheelCaptureView.capturesEvent(ofType: nil))
+    }
+
+    @Test
+    @MainActor
+    func contentOverlayCaptureOwnsExactlyOneMomentaryRateBadge() {
+        let capture = PlayerScrollWheelCaptureView(
+            frame: NSRect(x: 0, y: 0, width: 800, height: 450)
+        )
+
+        #expect(!capture.hasMomentaryRateBadge)
+        capture.showMomentaryRateBadge(.fast)
+        #expect(capture.hasMomentaryRateBadge)
+        #expect(capture.subviews.count == 1)
+
+        capture.showMomentaryRateBadge(.slow)
+        #expect(capture.hasMomentaryRateBadge)
+        #expect(capture.subviews.count == 1)
+
+        capture.clearMomentaryRateBadge()
+        #expect(!capture.hasMomentaryRateBadge)
+        #expect(capture.subviews.isEmpty)
     }
 
     @Test
@@ -320,6 +370,282 @@ struct PlayerHostViewIdentityTests {
         )
     }
 
+    @Test
+    func momentaryRateBadgeUsesNativeSymbolsAndRequestedLabels() {
+        #expect(PlayerMomentaryRate.fast.label == "2X")
+        #expect(PlayerMomentaryRate.fast.symbolName == "forward.fill")
+        #expect(PlayerMomentaryRate.slow.label == "0.5X")
+        #expect(PlayerMomentaryRate.slow.symbolName == "backward.fill")
+    }
+
+    @Test
+    func ordinaryBufferingDoesNotCancelTheScrollInputSession() {
+        #expect(
+            !PlayerMomentaryRateSessionPolicy.shouldCancel(
+                hasActiveSession: false,
+                timeControlStatus: .paused
+            )
+        )
+        #expect(
+            PlayerMomentaryRateSessionPolicy.shouldCancel(
+                hasActiveSession: true,
+                timeControlStatus: .paused
+            )
+        )
+        #expect(
+            !PlayerMomentaryRateSessionPolicy.shouldCancel(
+                hasActiveSession: true,
+                timeControlStatus: .waitingToPlayAtSpecifiedRate
+            )
+        )
+        #expect(
+            !PlayerMomentaryRateSessionPolicy.shouldCancel(
+                hasActiveSession: true,
+                timeControlStatus: .playing
+            )
+        )
+    }
+
+    @Test
+    @MainActor
+    func preciseHorizontalGestureCanReserveWholeSequenceForMomentaryRate() {
+        var router = PlayerScrollWheelRouter()
+        #expect(
+            router.route(
+                deltaX: 0.2,
+                deltaY: 0.1,
+                phase: .began,
+                momentumPhase: [],
+                allowsMomentaryRate: true
+            ) == .pending
+        )
+        #expect(
+            router.route(
+                deltaX: 8,
+                deltaY: 0.2,
+                phase: .changed,
+                momentumPhase: [],
+                allowsMomentaryRate: true
+            ) == .momentaryRate
+        )
+        #expect(
+            router.route(
+                deltaX: 0,
+                deltaY: -30,
+                phase: .changed,
+                momentumPhase: [],
+                allowsMomentaryRate: true
+            ) == .momentaryRate
+        )
+        #expect(
+            router.route(
+                deltaX: 0,
+                deltaY: 0,
+                phase: .ended,
+                momentumPhase: [],
+                allowsMomentaryRate: true
+            ) == .momentaryRate
+        )
+        #expect(
+            router.route(
+                deltaX: 12,
+                deltaY: 0,
+                phase: [],
+                momentumPhase: .began,
+                allowsMomentaryRate: true
+            ) == .momentaryRate
+        )
+        #expect(
+            router.route(
+                deltaX: 0,
+                deltaY: 0,
+                phase: [],
+                momentumPhase: .ended,
+                allowsMomentaryRate: true
+            ) == .momentaryRate
+        )
+    }
+
+    @Test
+    @MainActor
+    func unphasedAndNonPreciseHorizontalWheelRemainNative() {
+        var unphasedRouter = PlayerScrollWheelRouter()
+        #expect(
+            unphasedRouter.route(
+                deltaX: 40,
+                deltaY: 0,
+                phase: [],
+                momentumPhase: [],
+                allowsMomentaryRate: true
+            ) == .player
+        )
+
+        var nonPreciseRouter = PlayerScrollWheelRouter()
+        #expect(
+            nonPreciseRouter.route(
+                deltaX: 40,
+                deltaY: 0,
+                phase: .began,
+                momentumPhase: [],
+                isPrecise: false,
+                allowsMomentaryRate: true
+            ) == .player
+        )
+    }
+
+    @Test
+    @MainActor
+    func horizontalRateGestureActivatesAfterThresholdAndEndsBeforeMomentum() {
+        var gesture = PlayerHorizontalRateGestureState()
+        #expect(
+            gesture.handle(
+                deltaX: -1,
+                phase: .began,
+                momentumPhase: []
+            ) == .none
+        )
+        #expect(
+            gesture.handle(
+                deltaX: -20,
+                phase: .changed,
+                momentumPhase: []
+            ) == .none
+        )
+        #expect(
+            gesture.handle(
+                deltaX: -10,
+                phase: .changed,
+                momentumPhase: []
+            ) == .begin(.fast)
+        )
+        #expect(
+            gesture.handle(
+                deltaX: 12,
+                phase: .changed,
+                momentumPhase: []
+            ) == .none
+        )
+        #expect(
+            gesture.handle(
+                deltaX: 0,
+                phase: .ended,
+                momentumPhase: []
+            ) == .end
+        )
+        #expect(
+            gesture.handle(
+                deltaX: 18,
+                phase: [],
+                momentumPhase: .began
+            ) == .none
+        )
+    }
+
+    @Test
+    @MainActor
+    func horizontalRateGestureUsesOppositeDirectionForSlowRate() {
+        var gesture = PlayerHorizontalRateGestureState()
+        _ = gesture.handle(
+            deltaX: 4,
+            phase: .began,
+            momentumPhase: []
+        )
+        #expect(
+            gesture.handle(
+                deltaX: 26,
+                phase: .changed,
+                momentumPhase: []
+            ) == .begin(.slow)
+        )
+        #expect(gesture.cancel() == .end)
+    }
+
+    @Test
+    @MainActor
+    func deviceRelativeHorizontalDeltaIgnoresNaturalScrollingPreference() {
+        #expect(
+            PlayerScrollWheelSurfaceCapture.deviceRelativeDeltaX(
+                20,
+                isDirectionInverted: true
+            ) == -20
+        )
+        #expect(
+            PlayerScrollWheelSurfaceCapture.deviceRelativeDeltaX(
+                -20,
+                isDirectionInverted: false
+            ) == -20
+        )
+    }
+
+    @Test
+    @MainActor
+    func horizontalRateGestureEndsWhenMomentumArrivesWithoutDirectEnd() {
+        var gesture = PlayerHorizontalRateGestureState()
+        _ = gesture.handle(
+            deltaX: -30,
+            phase: .began,
+            momentumPhase: []
+        )
+        _ = gesture.handle(
+            deltaX: -1,
+            phase: .changed,
+            momentumPhase: []
+        )
+
+        #expect(
+            gesture.handle(
+                deltaX: -12,
+                phase: [],
+                momentumPhase: .began
+            ) == .end
+        )
+    }
+
+    @Test
+    @MainActor
+    func scrollWheelRouterQuarantinesCancelledGestureRemainder() {
+        var router = PlayerScrollWheelRouter()
+        #expect(
+            router.route(
+                deltaX: -12,
+                deltaY: 0,
+                phase: .began,
+                momentumPhase: [],
+                allowsMomentaryRate: true
+            ) == .momentaryRate
+        )
+
+        router.cancelInputSession()
+
+        #expect(
+            router.route(
+                deltaX: -40,
+                deltaY: 0,
+                phase: .changed,
+                momentumPhase: [],
+                allowsMomentaryRate: true
+            ) == .discard
+        )
+        #expect(
+            router.route(
+                deltaX: -30,
+                deltaY: 0,
+                phase: [],
+                momentumPhase: .began,
+                allowsMomentaryRate: true
+            ) == .discard
+        )
+        #expect(
+            router.route(
+                deltaX: 0,
+                deltaY: 8,
+                phase: .began,
+                momentumPhase: [],
+                allowsMomentaryRate: true
+            ) == .outerScroll
+        )
+    }
+
     @Test(.timeLimit(.minutes(1)))
     @MainActor
     func realAVPlayerViewIdentitySurvivesUpdatesAndDetachesOnRemoval()
@@ -505,9 +831,7 @@ private struct PlayerHostScrollRoutingHarness: View {
                     player: player,
                     danmakuRenderer: renderer,
                     danmakuController: controller
-                ) {
-                    EmptyView()
-                }
+                )
                 .frame(height: 300)
                 Color.clear.frame(height: 900)
             }

--- a/BiliKitMacTests/PlayerHostViewIdentityTests.swift
+++ b/BiliKitMacTests/PlayerHostViewIdentityTests.swift
@@ -11,6 +11,317 @@ import Testing
 struct PlayerHostViewIdentityTests {
     @Test(.timeLimit(.minutes(1)))
     @MainActor
+    func contentOverlayCaptureRoutesVerticalWheelToEnclosingSwiftUIScrollView()
+        async throws
+    {
+        let renderer = CoreAnimationDanmakuRenderer()
+        let controller = DanmakuPresentationController(
+            backend: renderer,
+            configuration: Self.emptyDanmakuConfiguration
+        )
+        let hostingView = NSHostingView(
+            rootView: PlayerHostScrollRoutingHarness(
+                player: AVPlayer(),
+                renderer: renderer,
+                controller: controller
+            )
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = hostingView
+        hostingView.layoutSubtreeIfNeeded()
+
+        #expect(
+            await waitUntil(in: hostingView) {
+                self.firstView(
+                    ofType: AVPlayerView.self,
+                    in: hostingView
+                ) != nil
+            }
+        )
+        let playerView = try #require(
+            firstView(
+                ofType: AVPlayerView.self,
+                in: hostingView
+            )
+        )
+        let scrollCaptureView = try #require(
+            firstView(
+                ofType: PlayerScrollCaptureView.self,
+                in: playerView
+            )
+        )
+        #expect(scrollCaptureView.superview === playerView.contentOverlayView)
+        #expect(!scrollCaptureView.isAccessibilityElement())
+        let scrollView = try #require(
+            firstAncestor(ofType: NSScrollView.self, from: playerView)
+        )
+        #expect(
+            await waitUntil(in: hostingView) {
+                guard let documentView = scrollView.documentView else {
+                    return false
+                }
+                return documentView.bounds.height
+                    > scrollView.contentView.bounds.height
+            }
+        )
+        let initialOrigin = scrollView.contentView.bounds.origin
+        let event = try makeScrollWheelEvent(deltaX: 0, deltaY: -80)
+        #expect(event.hasPreciseScrollingDeltas)
+
+        let videoPoint = NSPoint(
+            x: playerView.bounds.midX,
+            y: playerView.bounds.height * 0.75
+        )
+        let eventTarget = try #require(
+            playerView.hitTest(
+                playerView.convert(videoPoint, to: playerView.superview)
+            )
+        )
+        #expect(eventTarget === scrollCaptureView)
+        eventTarget.scrollWheel(with: event)
+
+        #expect(
+            await waitUntil(in: hostingView) {
+                scrollView.contentView.bounds.origin.y > initialOrigin.y
+            }
+        )
+
+        let scrolledOrigin = scrollView.contentView.bounds.origin
+        let horizontalEvent = try makeScrollWheelEvent(deltaX: -80, deltaY: 0)
+        eventTarget.scrollWheel(with: horizontalEvent)
+        hostingView.layoutSubtreeIfNeeded()
+        #expect(scrollView.contentView.bounds.origin == scrolledOrigin)
+
+        window.contentView = NSView()
+    }
+
+    @Test
+    @MainActor
+    func scrollWheelRouterLocksDominantAxisThroughMomentum() {
+        var verticalRouter = PlayerScrollWheelRouter()
+        #expect(
+            verticalRouter.route(
+                deltaX: 2,
+                deltaY: -12,
+                phase: .began,
+                momentumPhase: []
+            ) == .outerScroll
+        )
+        #expect(
+            verticalRouter.route(
+                deltaX: -20,
+                deltaY: -1,
+                phase: .changed,
+                momentumPhase: []
+            ) == .outerScroll
+        )
+        #expect(
+            verticalRouter.route(
+                deltaX: 0,
+                deltaY: 0,
+                phase: .ended,
+                momentumPhase: []
+            ) == .outerScroll
+        )
+        #expect(
+            verticalRouter.route(
+                deltaX: -8,
+                deltaY: -1,
+                phase: [],
+                momentumPhase: .began
+            ) == .outerScroll
+        )
+        #expect(
+            verticalRouter.route(
+                deltaX: 0,
+                deltaY: 0,
+                phase: [],
+                momentumPhase: .ended
+            ) == .outerScroll
+        )
+
+        var horizontalRouter = PlayerScrollWheelRouter()
+        #expect(
+            horizontalRouter.route(
+                deltaX: -12,
+                deltaY: -2,
+                phase: .began,
+                momentumPhase: []
+            ) == .player
+        )
+        #expect(
+            horizontalRouter.route(
+                deltaX: -1,
+                deltaY: -20,
+                phase: .changed,
+                momentumPhase: []
+            ) == .player
+        )
+        #expect(
+            horizontalRouter.route(
+                deltaX: 0,
+                deltaY: 0,
+                phase: .ended,
+                momentumPhase: []
+            ) == .player
+        )
+        #expect(
+            horizontalRouter.route(
+                deltaX: -1,
+                deltaY: -8,
+                phase: [],
+                momentumPhase: .ended
+            ) == .player
+        )
+    }
+
+    @Test
+    @MainActor
+    func scrollWheelRouterWaitsPastInitialNoiseBeforeLockingAxis() {
+        var verticalRouter = PlayerScrollWheelRouter()
+        #expect(
+            verticalRouter.route(
+                deltaX: 0.2,
+                deltaY: 0.1,
+                phase: .began,
+                momentumPhase: []
+            ) == .pending
+        )
+        #expect(
+            verticalRouter.route(
+                deltaX: 0.2,
+                deltaY: 12,
+                phase: .changed,
+                momentumPhase: []
+            ) == .outerScroll
+        )
+
+        var horizontalRouter = PlayerScrollWheelRouter()
+        #expect(
+            horizontalRouter.route(
+                deltaX: 0.1,
+                deltaY: 0.2,
+                phase: .mayBegin,
+                momentumPhase: []
+            ) == .pending
+        )
+        #expect(
+            horizontalRouter.route(
+                deltaX: 12,
+                deltaY: 0.2,
+                phase: .changed,
+                momentumPhase: []
+            ) == .player
+        )
+
+        var ambiguousRouter = PlayerScrollWheelRouter()
+        #expect(
+            ambiguousRouter.route(
+                deltaX: 1,
+                deltaY: 1,
+                phase: .began,
+                momentumPhase: []
+            ) == .pending
+        )
+        #expect(
+            ambiguousRouter.route(
+                deltaX: 0,
+                deltaY: 0,
+                phase: .cancelled,
+                momentumPhase: []
+            ) == .player
+        )
+    }
+
+    @Test
+    @MainActor
+    func unphasedScrollWheelUsesStrictDominantAxis() {
+        var router = PlayerScrollWheelRouter()
+        #expect(
+            router.route(
+                deltaX: 0,
+                deltaY: -1,
+                phase: [],
+                momentumPhase: []
+            ) == .outerScroll
+        )
+        #expect(
+            router.route(
+                deltaX: -4,
+                deltaY: -9,
+                phase: [],
+                momentumPhase: []
+            ) == .outerScroll
+        )
+        #expect(
+            router.route(
+                deltaX: -9,
+                deltaY: -4,
+                phase: [],
+                momentumPhase: []
+            ) == .player
+        )
+        #expect(
+            router.route(
+                deltaX: -5,
+                deltaY: -5,
+                phase: [],
+                momentumPhase: []
+            ) == .player
+        )
+        #expect(
+            router.route(
+                deltaX: 0,
+                deltaY: 0,
+                phase: [],
+                momentumPhase: []
+            ) == .player
+        )
+        #expect(
+            router.route(
+                deltaX: 0,
+                deltaY: -1,
+                phase: .began,
+                momentumPhase: [],
+                isPrecise: false
+            ) == .outerScroll
+        )
+        #expect(
+            router.route(
+                deltaX: -20,
+                deltaY: -1,
+                phase: .changed,
+                momentumPhase: [],
+                isPrecise: false
+            ) == .outerScroll
+        )
+        #expect(
+            router.route(
+                deltaX: 0,
+                deltaY: 0,
+                phase: .ended,
+                momentumPhase: [],
+                isPrecise: false
+            ) == .outerScroll
+        )
+        #expect(
+            router.route(
+                deltaX: -8,
+                deltaY: -1,
+                phase: [],
+                momentumPhase: .ended,
+                isPrecise: false
+            ) == .outerScroll
+        )
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
     func realAVPlayerViewIdentitySurvivesUpdatesAndDetachesOnRemoval()
         async throws
     {
@@ -110,8 +421,56 @@ struct PlayerHostViewIdentityTests {
     }
 
     @MainActor
-    private func waitUntil(
-        in hostingView: NSHostingView<PlayerHostHarness>,
+    private func firstView<ViewType: NSView>(
+        ofType type: ViewType.Type,
+        in root: NSView
+    ) -> ViewType? {
+        if let match = root as? ViewType {
+            return match
+        }
+        for child in root.subviews {
+            if let match = firstView(ofType: type, in: child) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    @MainActor
+    private func firstAncestor<ViewType: NSView>(
+        ofType type: ViewType.Type,
+        from view: NSView
+    ) -> ViewType? {
+        var ancestor = view.superview
+        while let current = ancestor {
+            if let match = current as? ViewType {
+                return match
+            }
+            ancestor = current.superview
+        }
+        return nil
+    }
+
+    private func makeScrollWheelEvent(
+        deltaX: Int32,
+        deltaY: Int32
+    ) throws -> NSEvent {
+        let event = try #require(
+            CGEvent(
+                scrollWheelEvent2Source: nil,
+                units: .pixel,
+                wheelCount: 2,
+                wheel1: deltaY,
+                wheel2: deltaX,
+                wheel3: 0
+            )
+        )
+        return try #require(NSEvent(cgEvent: event))
+    }
+
+    @MainActor
+    private func waitUntil<Content: View>(
+        in hostingView: NSHostingView<Content>,
         _ condition: @MainActor () -> Bool
     ) async -> Bool {
         let clock = ContinuousClock()
@@ -132,6 +491,28 @@ struct PlayerHostViewIdentityTests {
         maximumActiveCount: DanmakuLaneConfiguration.hardMaximumActiveCount,
         displayAreaFraction: 1
     )
+}
+
+private struct PlayerHostScrollRoutingHarness: View {
+    let player: AVPlayer
+    let renderer: CoreAnimationDanmakuRenderer
+    let controller: DanmakuPresentationController
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                PlayerHostView(
+                    player: player,
+                    danmakuRenderer: renderer,
+                    danmakuController: controller
+                ) {
+                    EmptyView()
+                }
+                .frame(height: 300)
+                Color.clear.frame(height: 900)
+            }
+        }
+    }
 }
 
 @MainActor

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
@@ -162,6 +162,7 @@ public final class AVPlayerEngine:
         readinessTask = nil
         preparedAsset?.stop()
         preparedAsset = nil
+        player.pause()
         player.replaceCurrentItem(with: nil)
         let pendingSubtitleReset = enqueueSubtitleReset()
         timeline.begin(identity: identity)
@@ -276,6 +277,16 @@ public final class AVPlayerEngine:
 
     public func setRate(_ rate: Double) throws {
         try timeline.setRate(rate)
+    }
+
+    /// 临时改变当前播放速率，但不覆盖用户选择的永久速率。
+    public func beginMomentaryPlaybackRate(_ rate: Double) throws -> UUID? {
+        try timeline.beginMomentaryRate(rate)
+    }
+
+    /// 结束仍匹配的临时速率会话；过期会话不会影响新的播放项目或用户改速。
+    public func endMomentaryPlaybackRate(sessionID: UUID) {
+        timeline.endMomentaryRate(sessionID: sessionID)
     }
 
     /// 执行精确 seek，并只为一次用户 seek 发布一个 discontinuity generation。

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerTimelineAdapter.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerTimelineAdapter.swift
@@ -3,12 +3,46 @@ import BiliApplication
 import Foundation
 import os
 
+enum MomentaryRateRestorationAction: Equatable {
+    case none
+    case setCurrentRate
+    case resumeAtDefaultRate
+}
+
+enum MomentaryRateRestorationPolicy {
+    static func action(
+        timeControlStatus: AVPlayer.TimeControlStatus,
+        currentRate: Float,
+        momentaryRate: Float
+    ) -> MomentaryRateRestorationAction {
+        let stillUsesMomentaryRate =
+            abs(currentRate - momentaryRate) < 0.01
+        switch timeControlStatus {
+        case .paused:
+            return .none
+        case .playing:
+            return stillUsesMomentaryRate ? .setCurrentRate : .none
+        case .waitingToPlayAtSpecifiedRate:
+            return currentRate == 0 || stillUsesMomentaryRate
+                ? .resumeAtDefaultRate : .none
+        @unknown default:
+            return .none
+        }
+    }
+}
+
 @MainActor
 /// 把 AVPlayer/KVO/notification 事件投影为平台无关、identity-safe 的播放时间线。
 ///
 /// 所有 callback 都同时核对当前 `AVPlayerItem` 与 item token；observer bag 在替换、失败和
 /// clear 时统一释放，避免旧 item 继续推进字幕或弹幕。
 final class AVPlayerTimelineAdapter {
+    private struct MomentaryRateSession {
+        let id: UUID
+        let item: AVPlayerItem
+        let rate: Float
+    }
+
     var onEnded: (@MainActor () -> Void)?
     var onFailed: (@MainActor () -> Void)?
 
@@ -21,6 +55,7 @@ final class AVPlayerTimelineAdapter {
     private let observers = PlayerTimelineObserverBag()
     private var token: PlaybackTimelineItemToken?
     private var failedToken: PlaybackTimelineItemToken?
+    private var momentaryRateSession: MomentaryRateSession?
     private var pendingExplicitSeekPosition: Double?
 
     init(player: AVPlayer) {
@@ -34,6 +69,7 @@ final class AVPlayerTimelineAdapter {
     }
 
     func begin(identity: PlaybackItemIdentity) {
+        momentaryRateSession = nil
         observers.reset()
         pendingExplicitSeekPosition = nil
         token = store.beginItem(identity: identity)
@@ -121,6 +157,7 @@ final class AVPlayerTimelineAdapter {
                     rate: 0,
                     state: .ended
                 )
+                self.momentaryRateSession = nil
                 self.onEnded?()
             }
         }
@@ -195,6 +232,7 @@ final class AVPlayerTimelineAdapter {
     }
 
     func markFailed() {
+        momentaryRateSession = nil
         observers.reset()
         guard let token else { return }
         failedToken = token
@@ -215,6 +253,7 @@ final class AVPlayerTimelineAdapter {
 
     func pause() {
         guard let token else { return }
+        momentaryRateSession = nil
         player.pause()
         store.update(token: token, rate: 0, state: .paused)
     }
@@ -223,10 +262,67 @@ final class AVPlayerTimelineAdapter {
         guard rate.isFinite, (0.25...4).contains(rate) else {
             throw AVPlayerEngineError.invalidPlaybackRate
         }
+        momentaryRateSession = nil
         player.defaultRate = Float(rate)
         guard player.rate > 0, let token else { return }
         player.rate = Float(rate)
         store.update(token: token, rate: rate, state: .playing)
+    }
+
+    func beginMomentaryRate(_ rate: Double) throws -> UUID? {
+        guard rate.isFinite, (0.25...4).contains(rate) else {
+            throw AVPlayerEngineError.invalidPlaybackRate
+        }
+        guard let token,
+            let item = player.currentItem,
+            player.rate > 0
+        else {
+            return nil
+        }
+
+        let session = MomentaryRateSession(
+            id: UUID(),
+            item: item,
+            rate: Float(rate)
+        )
+        momentaryRateSession = session
+        player.rate = session.rate
+        store.update(token: token, rate: rate, state: .playing)
+        return session.id
+    }
+
+    func endMomentaryRate(sessionID: UUID) {
+        guard let session = momentaryRateSession,
+            session.id == sessionID
+        else {
+            return
+        }
+        momentaryRateSession = nil
+
+        guard player.currentItem === session.item, let token
+        else {
+            return
+        }
+        let restorationAction = MomentaryRateRestorationPolicy.action(
+            timeControlStatus: player.timeControlStatus,
+            currentRate: player.rate,
+            momentaryRate: session.rate
+        )
+        switch restorationAction {
+        case .none:
+            return
+        case .setCurrentRate:
+            player.rate = player.defaultRate
+        case .resumeAtDefaultRate:
+            player.play()
+        }
+        let restoredState: PlaybackTimelineState =
+            player.timeControlStatus == .playing ? .playing : .buffering
+        store.update(
+            token: token,
+            rate: Double(player.defaultRate),
+            state: restoredState
+        )
     }
 
     func prepareExplicitSeek(to positionSeconds: Double) {
@@ -246,6 +342,7 @@ final class AVPlayerTimelineAdapter {
     }
 
     func clear() {
+        momentaryRateSession = nil
         observers.reset()
         pendingExplicitSeekPosition = nil
         store.clear(token: token)
@@ -264,6 +361,7 @@ final class AVPlayerTimelineAdapter {
         else { return }
 
         failedToken = token
+        momentaryRateSession = nil
         observers.reset()
         store.markFailed(token: token)
         onFailed?()

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
@@ -1854,6 +1854,38 @@ struct LoopbackPlaybackServerTests {
     }
 
     @Test
+    func momentaryRateRestorationPreservesPauseAndRecoversBuffering() {
+        #expect(
+            MomentaryRateRestorationPolicy.action(
+                timeControlStatus: .paused,
+                currentRate: 0,
+                momentaryRate: 2
+            ) == .none
+        )
+        #expect(
+            MomentaryRateRestorationPolicy.action(
+                timeControlStatus: .playing,
+                currentRate: 2,
+                momentaryRate: 2
+            ) == .setCurrentRate
+        )
+        #expect(
+            MomentaryRateRestorationPolicy.action(
+                timeControlStatus: .waitingToPlayAtSpecifiedRate,
+                currentRate: 0,
+                momentaryRate: 2
+            ) == .resumeAtDefaultRate
+        )
+        #expect(
+            MomentaryRateRestorationPolicy.action(
+                timeControlStatus: .waitingToPlayAtSpecifiedRate,
+                currentRate: 1.5,
+                momentaryRate: 2
+            ) == .none
+        )
+    }
+
+    @Test
     @MainActor
     func engineFreezesNativeCatalogDefaultsOffAndSerializesResetAcrossABA()
         async throws
@@ -2221,16 +2253,41 @@ struct LoopbackPlaybackServerTests {
         #expect(engine.currentTimelineSnapshot.identity == identity)
         #expect(engine.currentTimelineSnapshot.state == .ready)
 
-        try engine.setRate(2)
+        try engine.setRate(1.25)
         engine.play()
         try await waitUntilPlaybackTime(engine.player, reaches: 0.15)
         #expect(engine.currentTimelineSnapshot.positionSeconds > 0)
         #expect(engine.currentTimelineSnapshot.rate > 1)
         #expect(engine.currentTimelineSnapshot.state == .playing)
 
+        let normalMomentarySession = try #require(
+            try engine.beginMomentaryPlaybackRate(2)
+        )
+        #expect(abs(engine.player.rate - 2) < 0.01)
+        engine.endMomentaryPlaybackRate(
+            sessionID: normalMomentarySession
+        )
+        #expect(abs(engine.player.rate - 1.25) < 0.01)
+
+        let pausedMomentarySession = try #require(
+            try engine.beginMomentaryPlaybackRate(0.5)
+        )
         engine.pause()
+        engine.endMomentaryPlaybackRate(
+            sessionID: pausedMomentarySession
+        )
         #expect(engine.currentTimelineSnapshot.rate == 0)
         #expect(engine.currentTimelineSnapshot.state == .paused)
+        engine.play()
+        #expect(abs(engine.player.rate - 1.25) < 0.01)
+
+        let userOverrideSession = try #require(
+            try engine.beginMomentaryPlaybackRate(2)
+        )
+        try engine.setRate(1.5)
+        engine.endMomentaryPlaybackRate(sessionID: userOverrideSession)
+        #expect(abs(engine.player.rate - 1.5) < 0.01)
+        try engine.setRate(1.25)
 
         try await engine.seek(to: .seconds(0.7))
         #expect(engine.currentTimelineSnapshot.positionSeconds >= 0.65)
@@ -2247,7 +2304,11 @@ struct LoopbackPlaybackServerTests {
             bvid: "BV1TimelineReplacement",
             cid: 900_002
         )
+        let staleMomentarySession = try #require(
+            try engine.beginMomentaryPlaybackRate(2)
+        )
         try await engine.load(request, identity: replacementIdentity)
+        engine.endMomentaryPlaybackRate(sessionID: staleMomentarySession)
         #expect(engine.player.currentItem !== firstItem)
         NotificationCenter.default.post(
             name: AVPlayerItem.failedToPlayToEndTimeNotification,
@@ -2256,10 +2317,16 @@ struct LoopbackPlaybackServerTests {
         await Task { @MainActor in }.value
         #expect(engine.currentTimelineSnapshot.identity == replacementIdentity)
         #expect(engine.currentTimelineSnapshot.state == .ready)
+        engine.play()
+        #expect(abs(engine.player.rate - 1.25) < 0.01)
 
         let seekGeneration = engine.currentTimelineSnapshot
             .discontinuityGeneration
+        let stoppedMomentarySession = try #require(
+            try engine.beginMomentaryPlaybackRate(0.5)
+        )
         engine.stop()
+        engine.endMomentaryPlaybackRate(sessionID: stoppedMomentarySession)
         #expect(engine.player.currentItem == nil)
         #expect(engine.currentTimelineSnapshot.identity == nil)
         #expect(engine.currentTimelineSnapshot.state == .idle)

--- a/docs/validation/M5.0-playback-context-sidebar-2026-08-07.md
+++ b/docs/validation/M5.0-playback-context-sidebar-2026-08-07.md
@@ -146,3 +146,6 @@ actionable 问题，也未发现第二个 player／host、导航扩张或 scope 
 - 860×620 不是本阶段验收尺寸，旧 test-only `setContentSize` 也不证明用户可达；
 - Intel、其他 macOS 版本和远端 CI 未由本地验证覆盖；
 - 评论能力和横向相关推荐仍属于后续独立阶段。
+
+后续播放器 surface 输入路由、临时倍速、detached fullscreen 与画中画的实现和失败路线见
+[`M5.0-player-input-fullscreen-pip-2026-08-07.md`](./M5.0-player-input-fullscreen-pip-2026-08-07.md)。

--- a/docs/validation/M5.0-player-input-fullscreen-pip-2026-08-07.md
+++ b/docs/validation/M5.0-player-input-fullscreen-pip-2026-08-07.md
@@ -1,0 +1,228 @@
+# M5.0 播放器输入、全屏与画中画验证记录（2026-08-07）
+
+## 状态与用途
+
+本记录保存一次从“播放器区域内纵向滚动详情页”逐步收口到横向临时倍速、全屏一致性与
+原生画中画的实现证据和失败路线。它用于防止后续再次依赖错误的 responder chain、误测
+旧 App，或把 AVKit 原生行为误判为产品实现。
+
+当前生产结果已经通过本地 App gate，并由用户在签名开发版、真实远端播放和真实触控板上
+确认以下行为：
+
+- 指针位于视频区域时，纵向双指滚动可以滚动外层详情页；
+- 播放中横向双指手势分别提供临时 `2X`／`0.5X`，松开后恢复原速；
+- 详情页与 AVKit detached fullscreen 使用相同的手势和提示层；
+- 提示位于弹幕之上、AVKit 原生控制条之下；
+- 原生全屏按钮和原生画中画可用，退出后仍回到同一个播放器宿主。
+
+这不是对所有鼠标、触控板设置、macOS 版本或辅助技术的完整兼容性声明。当前实现和测试
+仍应以代码与质量 Gate 为准，本文只记录 2026-08-07 的决策与证据。
+
+## 最终交互契约
+
+| 输入／状态 | 结果 |
+| --- | --- |
+| 有明确纵向主轴的滚轮或触控板序列 | 交给播放器外层的详情 `NSScrollView` |
+| 播放中、有 phase 且有 precise delta 的横向触控板序列 | 达到阈值后临时 `2X`／`0.5X`，结束时恢复 |
+| 无 phase 的传统滚轮、非 precise 横向输入或倍速不可用 | 保留 AVPlayerView 原路径 |
+| 斜向输入 | 缓冲初始噪声后按累计主轴锁定，整段序列只交给一个 owner |
+| momentum | 沿用已完成的路由；临时倍速在 momentum 前结束 |
+| 点击、双击、拖动、magnify、键盘和辅助功能 | 透明捕获层返回 `nil`，继续使用 AVKit 原行为 |
+| 全屏 | AVKit 携带同一个 `contentOverlayView`，不建立第二个 player host |
+| 画中画 | 使用 AVKit 原生 PiP；当前不暂停详情播放器中的弹幕呈现 |
+
+横向方向先用 `NSEvent.isDirectionInvertedFromDevice` 归一化，因此产品的物理滑动方向不应
+随系统“自然滚动”偏好翻转。只有确认为纵向主轴的序列才允许越过 AVKit；横向、模糊或
+无法安全归属的序列不会被解释为 seek。
+
+## 最终视图层级
+
+```text
+DanmakuPlayerView : AVPlayerView
+├─ AVKit video content
+├─ contentOverlayView
+│  ├─ DanmakuOverlayView
+│  │  └─ CoreAnimationDanmakuRenderer.rootLayer
+│  └─ PlayerScrollWheelCaptureView（显式位于弹幕之上）
+│     └─ PlayerMomentaryRateBadgeHostingView（仅激活期间存在）
+└─ AVKit native controls
+```
+
+`contentOverlayView` 是 AVKit 用于把自定义内容放在视频和原生控制之间的公开 API。弹幕、
+滚轮捕获层和临时倍速提示统一由这个 surface 承载；`DanmakuOverlayView.hitTest` 继续始终
+返回 `nil`。捕获层只在当前 AppKit event 是 `.scrollWheel` 时参与 hit testing，因此把它
+放在弹幕上方不会遮挡控制条、点击或拖动。
+
+## 踩过的坑与结论
+
+### 1. 键盘长按不是可靠入口
+
+最初尝试用长按左右方向键触发临时倍速。真实运行中先出现系统提示音，随后按键落到
+AVPlayerView 的原生逐帧行为：播放按钮持有焦点时，方向键本来就由 AVKit 处理。给
+`AVPlayerView` 强行争夺 first responder、使用 SwiftUI focus，或安装更宽范围的键盘
+monitor，都会与 AVKit 的播放／暂停、逐帧和辅助功能 responder 竞争。
+
+调试还曾同时运行两个相同 Bundle Identifier 的 App：旧二进制在前台，新二进制在后台。
+这让若干轮人工结果看似证明“准入条件失败”，实际测试的根本不是新实现。后续真实 App
+验证必须按完整 executable path 和 PID 确认唯一进程，不能只按 App 名或 Bundle ID 激活。
+
+最终裁决：不保留键盘倍速 workaround，不安装全局或局部 keyboard event monitor；标准
+方向键、Space 和 J/K/L 继续由 AVPlayerView 原生处理。
+
+### 2. 重写外层 AVPlayerView 只对详情页有效
+
+在普通详情页中，事件可以命中 `DanmakuPlayerView`，因此 subclass 的 `scrollWheel` 或
+挂在外层 host 上的提示看似有效。进入全屏后，AVKit 会创建 detached fullscreen window
+和新的内容容器；它不会承诺把整个 `DanmakuPlayerView` 外壳原样放入全屏 responder
+chain。真实调试证明全屏事件可以绕过 subclass override。
+
+AVKit 会携带公开的 `contentOverlayView` 进入 detached fullscreen。将透明捕获层迁到该
+surface 后，详情页和全屏第一次共用相同的事件入口。实现不依赖调试时看到的 AVKit 私有
+类名，也不调用私有 API。
+
+### 3. 把横向事件原样交还 AVKit 不等于临时倍速
+
+AVPlayerView 的横向触控板行为会随播放／暂停、原生控制状态和手势阶段表现为扫描、暂停或
+seek；长距离滑动中还可能从暂停式扫描转为 seek。它是合理的原生播放器行为，但不能作为
+确定性的“按住 2X／0.5X”产品入口。
+
+最终将播放中的 precise、phase-bearing 横向序列完整保留给临时倍速状态机；其他横向输入
+仍交给 AVKit。这样没有把同一序列的一半交给倍速、另一半交给原生 seek。
+
+### 4. 第一个 delta 不能直接永久锁轴
+
+真实触控板常以很小的斜向噪声开始。例如首个样本略偏横向，后续才出现明确纵向移动。
+若第一个非等轴样本立即锁定，详情滚动和横向手势都会随机失败。
+
+路由器因此累计 precise delta，在达到明确位移阈值或样本上限后锁轴；pending 样本最终
+批量交给同一个接收者。`mayBegin → began → changed → ended/cancelled → momentum` 必须作为
+一段连续输入管理。non-precise 但带 phase 的输入也必须锁定；只有无 phase 的传统滚轮才
+允许逐 tick 判轴。
+
+### 5. 外层 ScrollView 不一定存在
+
+全屏重挂载或未来复用 host 时，捕获层的 responder chain 不一定包含详情 `NSScrollView`。
+仅检查 `nextResponder != nil` 会把纵向事件送进一个没有详情 scroll owner 的链并吞掉。
+
+当前实现只在确认穿过 AVPlayerView 后找到外层 `NSScrollView` 时转交纵向序列；找不到时
+回退 AVKit 原路径。
+
+### 6. 生命周期取消必须隔离旧手势尾流
+
+window/app resign、host 重挂载、item 替换或播放停止时，系统不保证总能送达原序列的
+`ended/cancelled`。只结束倍速、不重置 router，会让旧 rate 或 pending 样本污染下一次
+输入；只 reset router 又会把旧 `.changed`／momentum 尾流送给 AVKit，可能作用于新 item。
+
+当前取消顺序为：结束临时 rate、清 pending、重置输入 session，并进入 quarantine。
+quarantine 丢弃旧 changed/ended/cancelled/momentum，直到新的 mayBegin/began 或明确无 phase
+新输入才解锁。
+
+### 7. 临时 `player.rate` 不能污染永久速度
+
+直接写 `AVPlayer.rate` 会触发时间线 rate observation。若 observation 把临时 `2`／`0.5`
+记成永久偏好，而手势期间又发生 item 替换、结束、失败或 clear，下一条视频可能继承临时
+速度。
+
+最终由 playback engine/timeline 拥有 temporary-rate session token：永久偏好使用
+`defaultRate`，临时会话只改变有效 `rate`；匹配临时会话的 observation 不回写永久偏好。
+load、stop、pause、setRate、item end/failure 和 clear 都能清理 session，旧 token 不能恢复
+或覆盖新 item。
+
+### 8. UI badge 与播放 session 必须同步取消
+
+只弱持有旧 `AVPlayerItem` 会在 item 释放后失去比较依据，造成引擎已取消临时倍速、提示却
+仍留在画面。异步把 rate 回写 SwiftUI Binding 还会产生 sibling Task 顺序竞态：旧 begin
+可能晚于 end 落地，或旧 end 覆盖新 begin。
+
+最终不再通过页面级 SwiftUI state/Binding 桥接提示。`PlayerScrollWheelCaptureView` 直接在
+主线程拥有一个 badge hosting view；item identity 使用 `ObjectIdentifier`，播放器与焦点
+观察在执行取消前重新检查当前状态。
+
+### 9. 同在 contentOverlayView 仍可能层级错误
+
+把提示迁入 `contentOverlayView` 后，最初先插入捕获层、后插入弹幕。提示虽然是捕获层的
+子视图，但整个捕获 subtree 仍位于弹幕 sibling 下方，因此提示被密集弹幕覆盖。
+
+最终先安装弹幕，再使用 AppKit 的明确相对定位把捕获层放在弹幕之上；测试锁定两个 sibling
+的相对顺序。不能只测试“badge 存在”，还要测试它所在 subtree 的 z-order。
+
+### 10. AVPlayerView 的可选原生按钮默认不会自动出现
+
+`.floating` 控制样式并不意味着所有原生能力都会显示。`showsFullScreenToggleButton` 和
+`allowsPictureInPicturePlayback` 默认都不会替产品自动打开。全屏曾因遗漏显式开关而被误判
+为双击或事件捕获问题。
+
+当前显式开启：
+
+- `showsFullScreenToggleButton = true`；
+- `allowsPictureInPicturePlayback = true`。
+
+没有开启逐帧按钮、分享按钮、时间码或自定义 action menu。画中画继续使用同一个
+AVPlayer，不创建第二个 host。系统 PiP 不承诺显示 `contentOverlayView` 的弹幕；当前进入
+PiP 后详情播放器的弹幕呈现继续运行，以换取退出 PiP 时自然连续。只有实测出现明显资源
+问题时，才考虑暂停弹幕呈现并按当前播放时间恢复，不能暂停播放引擎或重建 renderer。
+
+## 被否决的 workaround
+
+- 全局 `NSEvent` monitor；
+- 为键盘倍速强制抢占 AVPlayerView first responder；
+- 把滚轮解释为 seek；
+- 向 AVKit 私有子视图重放事件；
+- 依赖 AVKit 私有 class、selector 或 view hierarchy；
+- 为详情页与全屏分别维护两套捕获层或提示状态；
+- 新建第二个 `AVPlayerView`／player host；
+- 自制播放器控制条代替 AVKit；
+- 用大量 XCUITest 模拟系统滚轮 routing 并把它当成真实触控板证据。
+
+## 自动化与人工证据
+
+验证环境为 Xcode 26.6（17F113）、macOS arm64 签名开发版。最高适用
+`sh Scripts/run-quality-gates.sh app` 在最终改动上通过，覆盖：
+
+- axis 初始噪声、斜向累计判定、phase/momentum 和 non-precise 序列；
+- natural scrolling 的横向方向归一；
+- 临时倍速阈值、结束、item replacement、stop、pause、用户改速与旧 token 隔离；
+- failure/clear 路径有源码清理守卫，但没有在临时 session 激活时分别触发的专门断言；
+- 生命周期 cancel 后的 stale changed/momentum quarantine；
+- 外层详情 ScrollView 的真实宿主路由；无详情 scroll ancestor 回退目前只有源码守卫和
+  全屏人工路径，没有独立宿主断言；
+- capture 只参与 scroll-wheel hit testing；
+- 唯一 badge ownership、badge/danmaku 相对层级；
+- 全屏与画中画开关，以及真实 AVPlayerView identity/dismantle 连续性。
+
+用户在多轮签名 App 观察中确认：
+
+- 详情页纵向滚动和左右临时倍速；
+- 播放器控制条仍可使用；
+- 全屏入口、全屏左右临时倍速和提示位置；
+- 提示不再被弹幕遮挡；
+- 画中画进入／退出正常，弹幕继续呈现可接受。
+
+自动测试不能替代这些触控板与 AVKit detached window 观察；反过来，一次人工成功也不能
+替代 router、rate owner 和资源清理测试。
+
+## 仍未关闭的边界
+
+- 尚未分别以“自然滚动”开／关做两次真人方向复核；当前只有纯函数测试覆盖归一化；
+- VoiceOver、Full Keyboard Access、Reduce Motion 和较大文字未因本轮完成而自动关闭；
+- 画中画期间继续运行弹幕的 CPU/GPU 成本未测量；没有症状前不增加暂停／恢复分支；
+- 不同触控板硬件、传统鼠标、Intel 和其他 macOS 版本没有本轮真实矩阵；
+- AVKit 内部控件与 detached fullscreen 结构不是公开稳定契约；实现只能依赖
+  `contentOverlayView`、公开 customization property 和标准 responder 行为。
+
+## 后续修改前检查表
+
+1. 确认测试的 executable 完整路径和 PID，排除同 Bundle ID 的旧进程。
+2. 保持唯一 `PlayerHostView`／`AVPlayerView`／`AVPlayer`，不要为全屏或 PiP 建第二套 surface。
+3. 自定义视频覆盖内容优先放在公开 `contentOverlayView`，并显式测试 sibling z-order。
+4. 新输入只能扩展现有 router/session owner；不能增加全局 monitor 或跨 responder 重放。
+5. 临时播放状态由 engine/timeline 拥有，UI 只显示 session 结果。
+6. 修改 event routing、rate lifecycle 或 overlay hierarchy 后运行 App gate，并使用签名 App
+   完成一次真实触控板的详情／全屏／PiP 往返。
+
+## 公开 API 参考
+
+- Apple [`AVPlayerView`](https://developer.apple.com/documentation/avkit/avplayerview)
+- Apple [`contentOverlayView`](https://developer.apple.com/documentation/avkit/avplayerview/contentoverlayview)
+- Apple [`showsFullScreenToggleButton`](https://developer.apple.com/documentation/avkit/avplayerview/showsfullscreentogglebutton)
+- Apple [`allowsPictureInPicturePlayback`](https://developer.apple.com/documentation/avkit/avplayerview/allowspictureinpictureplayback)


### PR DESCRIPTION
## 变化

- 将播放器区域内的纵向滚轮与触控板输入转交给详情页外层 `ScrollView`
- 对精确滚动、斜向输入、phase/momentum、自然滚动方向和生命周期中断进行轴锁与状态隔离
- 将横向触控板手势用于按住生效的临时倍速：右向 2X、左向 0.5X，结束后恢复原播放状态
- 在 AVPlayerView 的公开 `contentOverlayView` 中显示原生优先的倍速提示，并保证其位于弹幕上方
- 显式启用 AVKit 原生全屏按钮和画中画，不创建第二个播放器 host，也不替换原生控制条
- 补充播放器输入、倍速生命周期、host 连续性测试以及本轮调研和验证记录

## 原因

AVPlayerView 会优先接收视频表面的滚动输入，导致指针位于播放器上方时详情页无法纵向滚动。早期键盘长按方案还会与 AVKit 的焦点和暂停态逐帧快捷键竞争；全屏期间，覆盖在 SwiftUI/外层视图中的输入层也会随 AVKit 重挂载而失效。

本实现将输入捕获限制在公开的 `contentOverlayView`，只在 `scrollWheel` 命中时参与事件路由，并由单一状态机决定整段手势的接收方。点击、拖动、magnify、键盘、字幕菜单、进度、音量、全屏和辅助功能仍沿用 AVKit 原路径。

## 用户影响

- 指针停留在视频上时，可直接纵向滚动详情页
- 左右双指滑动可临时进入 0.5X / 2X，松开后恢复
- 详情页和原生全屏使用同一套输入与提示层
- 原生全屏与画中画入口可用
- 弹幕继续播放且不参与命中测试；画中画期间不额外改变弹幕策略

## 验证

- 三路独立只读审查：输入路由、倍速生命周期/辅助功能、旧 spike 清理，均未发现 P0–P3
- `sh Scripts/run-quality-gates.sh app` 在全新 DerivedData 中通过
- Apple Development 签名构建通过 `codesign --verify --deep --strict`
- 真实 App 与触控板观察通过：
  - 详情页纵向滚动
  - 左向 0.5X、右向 2X
  - 斜向轴判定与松手恢复
  - 原生控制条 hover/拖动
  - 全屏内横向临时倍速及提示层级
  - 全屏按钮与画中画
  - 原生字幕和倍速控件未受影响

## 未覆盖边界

- VoiceOver、Full Keyboard Access 与 Reduce Motion 尚未逐项真人复核
- 不同触控板硬件、两种“自然滚动”设置及其他 macOS 版本仍需补充观察
- 画中画期间弹幕继续运行；本 PR 不引入暂停弹幕的额外策略