### PR TITLE
feat(video): 接入真实相关推荐

### DIFF
--- a/BiliKitMac/App/AppShellView.swift
+++ b/BiliKitMac/App/AppShellView.swift
@@ -66,7 +66,9 @@ struct AppShellView: View {
                             model: videoModel,
                             danmakuModel: danmakuModel,
                             playerContent: playerContent,
-                            onRetry: navigationCoordinator.retryPlayback
+                            onRetry: navigationCoordinator.retryPlayback,
+                            onSelectRelatedVideo:
+                                navigationCoordinator.openPlayback
                         )
                     }
             }
@@ -165,12 +167,14 @@ private struct PlaybackDestinationView: View {
     let danmakuModel: DanmakuControlsViewModel
     let playerContent: AnyView
     let onRetry: () -> Void
+    let onSelectRelatedVideo: (String) -> Void
 
     var body: some View {
         VideoPlaybackView(
             model: model,
             danmakuModel: danmakuModel,
-            onRetry: onRetry
+            onRetry: onRetry,
+            onSelectRelatedVideo: onSelectRelatedVideo
         ) {
             playerContent
         }

--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -21,6 +21,7 @@ struct AppEnvironment {
     private let playerEngine: AVPlayerEngine
     let playbackPreferencesController: PlaybackPreferencesController
     private let guestContentRepository: any GuestContentRepository
+    private let relatedVideoRepository: any RelatedVideoRepository
     private let historyRepository: any WatchHistoryRepository
     private let danmakuSession: DanmakuSession
     private let danmakuController: DanmakuPresentationController
@@ -30,6 +31,7 @@ struct AppEnvironment {
 
     init(
         guestContentRepository: any GuestContentRepository,
+        relatedVideoRepository: any RelatedVideoRepository,
         historyRepository: any WatchHistoryRepository,
         danmakuRepository: any DanmakuSegmentRepository,
         playerEngine: AVPlayerEngine,
@@ -42,6 +44,7 @@ struct AppEnvironment {
             "AVPlayerEngine must own native subtitle presentation"
         )
         self.guestContentRepository = guestContentRepository
+        self.relatedVideoRepository = relatedVideoRepository
         self.historyRepository = historyRepository
         self.playerEngine = playerEngine
         self.playbackPreferencesController = playbackPreferencesController
@@ -74,7 +77,10 @@ struct AppEnvironment {
     func makeVideoViewModel() -> GuestVideoViewModel {
         GuestVideoViewModel(
             useCase: GuestVideoUseCase(repository: guestContentRepository),
-            playback: playerEngine
+            playback: playerEngine,
+            relatedVideoUseCase: RelatedVideoUseCase(
+                repository: relatedVideoRepository
+            )
         )
     }
 
@@ -146,8 +152,10 @@ struct AppEnvironment {
             player: player,
             subtitleUseCase: SubtitleUseCase(repository: subtitleRepository)
         )
+        let guestRepository = BiliGuestRepository(client: api)
         return AppEnvironment(
-            guestContentRepository: BiliGuestRepository(client: api),
+            guestContentRepository: guestRepository,
+            relatedVideoRepository: guestRepository,
             historyRepository: BiliWatchHistoryRepository(client: api),
             danmakuRepository: BiliDanmakuRepository(client: api),
             playerEngine: playerEngine,

--- a/BiliKitMacTests/VideoDetailLifecycleTests.swift
+++ b/BiliKitMacTests/VideoDetailLifecycleTests.swift
@@ -112,10 +112,14 @@ struct VideoDetailLifecycleTests {
             first: first,
             replacement: replacement
         )
+        let relatedRepository = RelatedLifecycleRepository()
         let player = ControlledReplacementPlayback()
         let videoModel = GuestVideoViewModel(
             useCase: GuestVideoUseCase(repository: repository),
-            playback: player
+            playback: player,
+            relatedVideoUseCase: RelatedVideoUseCase(
+                repository: relatedRepository
+            )
         )
         let presentation = RecordingPresentation()
         let danmakuModel = DanmakuControlsViewModel(
@@ -193,6 +197,29 @@ struct VideoDetailLifecycleTests {
         let playerViewIdentity = ObjectIdentifier(playerView)
         #expect(playerView.player === hostedPlayer)
         let stopCountBeforeReplacement = presentation.stopCount
+
+        #expect(
+            await waitUntilAsync {
+                await relatedRepository.firstRequestHasStarted()
+            }
+        )
+        await relatedRepository.releaseFirstRequest()
+        await videoModel.waitForCurrentRelatedVideoTask()
+        hostingView.layoutSubtreeIfNeeded()
+        #expect(
+            videoModel.relatedVideoState
+                == .loaded(
+                    bvid: first.bvid,
+                    videos: [relatedRepository.fixture]
+                )
+        )
+        #expect(player.loadedIdentities == [first.identity])
+        #expect(playerSurface.createdIdentities == [surfaceIdentity])
+        #expect(playerSurface.dismantledIdentities.isEmpty)
+        #expect(
+            playerViews(in: hostingView).first.map(ObjectIdentifier.init)
+                == Optional(playerViewIdentity)
+        )
 
         coordinator.openPlayback(replacement.bvid)
         #expect(
@@ -614,6 +641,37 @@ private actor ReplacementLifecycleRepository: GuestContentRepository {
         for bvid: String
     ) -> VideoDetailLifecycleFixture {
         bvid == first.bvid ? first : replacement
+    }
+}
+
+private actor RelatedLifecycleRepository: RelatedVideoRepository {
+    nonisolated let fixture = RelatedVideo(
+        bvid: "BV1RelatedA1",
+        title: "相关推荐",
+        coverURL: nil,
+        ownerName: "测试作者",
+        viewCount: 100,
+        danmakuCount: 10,
+        durationSeconds: 120
+    )
+    private var didStartFirstRequest = false
+    private var firstRequest: CheckedContinuation<[RelatedVideo], Never>?
+
+    func relatedVideos(to bvid: String) async throws -> [RelatedVideo] {
+        guard !didStartFirstRequest else { return [] }
+        didStartFirstRequest = true
+        return await withCheckedContinuation { continuation in
+            firstRequest = continuation
+        }
+    }
+
+    func firstRequestHasStarted() -> Bool {
+        didStartFirstRequest && firstRequest != nil
+    }
+
+    func releaseFirstRequest() {
+        firstRequest?.resume(returning: [fixture])
+        firstRequest = nil
     }
 }
 

--- a/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliGuestRepository.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliGuestRepository.swift
@@ -1,7 +1,7 @@
 import BiliApplication
 import BiliModels
 
-public struct BiliGuestRepository: GuestContentRepository {
+public struct BiliGuestRepository: GuestContentRepository, RelatedVideoRepository {
     private let client: BiliAPIClient
 
     public init(client: BiliAPIClient) {
@@ -29,6 +29,12 @@ public struct BiliGuestRepository: GuestContentRepository {
     public func pages(for bvid: String) async throws -> [VideoPage] {
         try await mapError {
             try await client.pages(for: bvid)
+        }
+    }
+
+    public func relatedVideos(to bvid: String) async throws -> [RelatedVideo] {
+        try await mapError {
+            try await client.relatedVideos(to: bvid)
         }
     }
 

--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
@@ -113,6 +113,19 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
         return detail
     }
 
+    /// 匿名读取相关推荐；该路径永不请求认证授权器。
+    public func relatedVideos(to bvid: String) async throws -> [RelatedVideo] {
+        guard Self.isValidBVID(bvid) else {
+            throw BiliAPIError.invalidRequest
+        }
+        let payload: [RelatedVideoPayload] = try await get(
+            path: "/x/web-interface/archive/related",
+            queryItems: [URLQueryItem(name: "bvid", value: bvid)],
+            referer: Self.videoReferer(bvid)
+        )
+        return try payload.map { try $0.model() }
+    }
+
     public func pages(for bvid: String) async throws -> [VideoPage] {
         guard Self.isValidBVID(bvid) else {
             throw BiliAPIError.invalidRequest

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/VideoEndpointPayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/VideoEndpointPayloads.swift
@@ -31,6 +31,50 @@ struct PopularVideoPayload: Decodable, Sendable {
     }
 }
 
+struct RelatedVideoPayload: Decodable, Sendable {
+    let bvid: String?
+    let title: String?
+    let pic: String?
+    let owner: RelatedVideoOwnerPayload?
+    let stat: RelatedVideoStatisticsPayload?
+    let duration: Int?
+
+    func model() throws -> RelatedVideo {
+        guard let bvid,
+            let title,
+            let owner,
+            let stat,
+            bvid.hasPrefix("BV"),
+            bvid.count == 12,
+            !title.isEmpty,
+            !owner.name.isEmpty,
+            stat.view >= 0,
+            stat.danmaku >= 0,
+            duration.map({ $0 >= 0 }) ?? true
+        else {
+            throw BiliAPIError.decodingFailed
+        }
+        return RelatedVideo(
+            bvid: bvid,
+            title: title,
+            coverURL: pic.flatMap(WebImageURL.parse),
+            ownerName: owner.name,
+            viewCount: stat.view,
+            danmakuCount: stat.danmaku,
+            durationSeconds: duration
+        )
+    }
+}
+
+struct RelatedVideoOwnerPayload: Decodable, Sendable {
+    let name: String
+}
+
+struct RelatedVideoStatisticsPayload: Decodable, Sendable {
+    let view: Int64
+    let danmaku: Int64
+}
+
 struct OwnerPayload: Decodable, Sendable {
     let mid: Int64
     let name: String

--- a/Packages/BiliKitCore/Sources/BiliAPIProbe/main.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPIProbe/main.swift
@@ -9,6 +9,8 @@ struct BiliAPIProbe {
             switch try Configuration(arguments: CommandLine.arguments).mode {
             case .search(let keyword, let page):
                 try await runSearch(keyword: keyword, page: page)
+            case .related:
+                try await runRelated()
             case .m4Contract(let bvid, let cid):
                 try await M4ContractProbe().run(bvid: bvid, cid: cid)
             }
@@ -25,6 +27,16 @@ struct BiliAPIProbe {
             )
             exit(EXIT_FAILURE)
         }
+    }
+
+    private static func runRelated() async throws {
+        let client = BiliAPIClient(transport: SearchProbeTransport())
+        guard let sample = try await client.popular(pageSize: 1).videos.first
+        else {
+            throw ProbeError.emptyResponse
+        }
+        let videos = try await client.relatedVideos(to: sample.bvid)
+        print("related: count=\(videos.count) production-decoder=ready")
     }
 
     private static func runSearch(keyword: String, page: Int) async throws {
@@ -191,6 +203,7 @@ private enum ProbeError: String, Error {
 private struct Configuration {
     enum Mode {
         case search(keyword: String, page: Int)
+        case related
         case m4Contract(bvid: String, cid: Int64)
     }
 
@@ -205,6 +218,8 @@ private struct Configuration {
         }
         let values = try SecureProbeInput.load(path: arguments[1])
         switch values["mode"] {
+        case "related":
+            mode = .related
         case "m4-contract":
             guard
                 let bvid = values["bvid"],

--- a/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestContracts.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestContracts.swift
@@ -18,3 +18,8 @@ public protocol GuestContentRepository: Sendable {
     func pages(for bvid: String) async throws -> [VideoPage]
     func playback(for bvid: String, cid: Int64) async throws -> VideoPlayback
 }
+
+/// 当前视频相关推荐所需的独立匿名只读 port。
+public protocol RelatedVideoRepository: Sendable {
+    func relatedVideos(to bvid: String) async throws -> [RelatedVideo]
+}

--- a/Packages/BiliKitCore/Sources/BiliApplication/Guest/RelatedVideoUseCase.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Guest/RelatedVideoUseCase.swift
@@ -1,0 +1,21 @@
+import BiliModels
+
+public struct RelatedVideoUseCase: Sendable {
+    private let repository: any RelatedVideoRepository
+
+    public init(repository: any RelatedVideoRepository) {
+        self.repository = repository
+    }
+
+    public func relatedVideos(to bvid: String) async throws -> [RelatedVideo] {
+        guard !bvid.isEmpty else {
+            throw GuestApplicationError.invalidRequest
+        }
+        let videos = try await repository.relatedVideos(to: bvid)
+        try Task.checkCancellation()
+        var seenBVIDs: Set<String> = []
+        return videos.filter { video in
+            video.bvid != bvid && seenBVIDs.insert(video.bvid).inserted
+        }
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoDetailView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoDetailView.swift
@@ -7,6 +7,9 @@ struct GuestVideoDetailView<PlayerContent: View>: View {
     let context: GuestVideoContext
     let isPreparingPlayback: Bool
     let danmakuModel: DanmakuControlsViewModel
+    let relatedVideoState: RelatedVideoState
+    let onSelectRelatedVideo: (String) -> Void
+    let onRetryRelatedVideos: () -> Void
     let playerContent: () -> PlayerContent
 
     var body: some View {
@@ -23,6 +26,16 @@ struct GuestVideoDetailView<PlayerContent: View>: View {
 
                 Divider()
                 DanmakuControlsView(model: danmakuModel)
+
+                RelatedVideoShelf(
+                    state: shelfState,
+                    onSelect: onSelectRelatedVideo,
+                    onRetry: onRetryRelatedVideos
+                )
+                .padding(
+                    .horizontal,
+                    -PlaybackPageLayout.horizontalContentPadding
+                )
             }
             .padding(
                 .horizontal,
@@ -33,6 +46,33 @@ struct GuestVideoDetailView<PlayerContent: View>: View {
                 PlaybackPageLayout.verticalContentPadding
             )
             .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var shelfState: RelatedVideoShelfState {
+        switch relatedVideoState {
+        case .idle, .loading:
+            .loading
+        case .loaded(let bvid, let videos) where bvid == context.detail.bvid:
+            .loaded(
+                videos.map {
+                    RelatedVideoShelfItem(
+                        bvid: $0.bvid,
+                        title: $0.title,
+                        coverURL: $0.coverURL,
+                        ownerName: $0.ownerName,
+                        viewCount: $0.viewCount,
+                        danmakuCount: $0.danmakuCount,
+                        durationSeconds: $0.durationSeconds
+                    )
+                }
+            )
+        case .empty(let bvid) where bvid == context.detail.bvid:
+            .empty
+        case .failed(let bvid, _) where bvid == context.detail.bvid:
+            .failure
+        case .loaded, .empty, .failed:
+            .loading
         }
     }
 

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoViewModel.swift
@@ -21,6 +21,14 @@ public enum GuestVideoState: Sendable, Equatable {
     )
 }
 
+public enum RelatedVideoState: Sendable, Equatable {
+    case idle
+    case loading(bvid: String)
+    case loaded(bvid: String, videos: [RelatedVideo])
+    case empty(bvid: String)
+    case failed(bvid: String, error: GuestApplicationError)
+}
+
 @MainActor
 @Observable
 /// 拥有单个视频准备意图，并把内容准备与播放器安装串成同一 generation。
@@ -28,6 +36,7 @@ public enum GuestVideoState: Sendable, Equatable {
 /// 新视频、重试或 reset 都使旧任务失效；旧任务即使忽略取消，也不能覆盖当前状态。
 public final class GuestVideoViewModel {
     public private(set) var state: GuestVideoState = .idle
+    public private(set) var relatedVideoState: RelatedVideoState = .idle
     /// 供播放主区与上下文 Sidebar 共享的最近有效详情。
     ///
     /// 新视频加载或失败期间保留旧值，使同一个播放 surface 不因短暂状态拆除；取得新
@@ -40,17 +49,22 @@ public final class GuestVideoViewModel {
 
     @ObservationIgnored private let useCase: GuestVideoUseCase
     @ObservationIgnored private let playback: any PlaybackControlling
+    @ObservationIgnored private let relatedVideoUseCase: RelatedVideoUseCase?
     @ObservationIgnored private var loadTask: Task<Void, Never>?
+    @ObservationIgnored private var relatedVideoTask: Task<Void, Never>?
     @ObservationIgnored private var playbackFailureTask: Task<Void, Never>?
     @ObservationIgnored private var playbackIntent: PlaybackLoadIntent?
     @ObservationIgnored private var generation = 0
+    @ObservationIgnored private var relatedVideoGeneration = 0
 
     public init(
         useCase: GuestVideoUseCase,
-        playback: any PlaybackControlling
+        playback: any PlaybackControlling,
+        relatedVideoUseCase: RelatedVideoUseCase? = nil
     ) {
         self.useCase = useCase
         self.playback = playback
+        self.relatedVideoUseCase = relatedVideoUseCase
         playbackFailureTask = Task { [weak self, playback] in
             for await event in playback.playbackFailureEvents() {
                 guard !Task.isCancelled else { return }
@@ -61,6 +75,7 @@ public final class GuestVideoViewModel {
 
     deinit {
         loadTask?.cancel()
+        relatedVideoTask?.cancel()
         playbackFailureTask?.cancel()
     }
 
@@ -76,6 +91,7 @@ public final class GuestVideoViewModel {
         presentedPlaybackIdentity = nil
         playbackIntent = nil
         state = .loading(bvid: bvid)
+        loadRelatedVideos(for: bvid)
         loadTask = Task { [weak self] in
             await self?.performLoad(
                 bvid: bvid,
@@ -132,11 +148,20 @@ public final class GuestVideoViewModel {
         }
     }
 
+    public func retryRelatedVideos() {
+        guard case .failed(let bvid, _) = relatedVideoState else { return }
+        loadRelatedVideos(for: bvid)
+    }
+
     /// 取消内容准备并停止播放 adapter，作为离开播放目的地的最终清理边界。
     public func reset() {
         generation += 1
+        relatedVideoGeneration += 1
         loadTask?.cancel()
         loadTask = nil
+        relatedVideoTask?.cancel()
+        relatedVideoTask = nil
+        relatedVideoState = .idle
         presentedContext = nil
         requestedPlaybackIdentity = nil
         presentedPlaybackIdentity = nil
@@ -151,6 +176,63 @@ public final class GuestVideoViewModel {
 
     func taskSnapshotForTesting() -> Task<Void, Never>? {
         loadTask
+    }
+
+    public func waitForCurrentRelatedVideoTask() async {
+        await relatedVideoTask?.value
+    }
+
+    func relatedVideoTaskSnapshotForTesting() -> Task<Void, Never>? {
+        relatedVideoTask
+    }
+
+    private func loadRelatedVideos(for bvid: String) {
+        relatedVideoGeneration += 1
+        let currentGeneration = relatedVideoGeneration
+        relatedVideoTask?.cancel()
+        guard let relatedVideoUseCase else {
+            relatedVideoState = .empty(bvid: bvid)
+            relatedVideoTask = nil
+            return
+        }
+        relatedVideoState = .loading(bvid: bvid)
+        relatedVideoTask = Task { [weak self] in
+            do {
+                let videos = try await relatedVideoUseCase.relatedVideos(
+                    to: bvid
+                )
+                try Task.checkCancellation()
+                guard let self,
+                    self.relatedVideoGeneration == currentGeneration
+                else { return }
+                self.relatedVideoState =
+                    videos.isEmpty
+                    ? .empty(bvid: bvid)
+                    : .loaded(bvid: bvid, videos: videos)
+                self.relatedVideoTask = nil
+            } catch is CancellationError {
+                guard let self,
+                    self.relatedVideoGeneration == currentGeneration
+                else { return }
+                self.relatedVideoState = .idle
+                self.relatedVideoTask = nil
+            } catch let error as GuestApplicationError {
+                guard let self,
+                    self.relatedVideoGeneration == currentGeneration
+                else { return }
+                self.relatedVideoState = .failed(bvid: bvid, error: error)
+                self.relatedVideoTask = nil
+            } catch {
+                guard let self,
+                    self.relatedVideoGeneration == currentGeneration
+                else { return }
+                self.relatedVideoState = .failed(
+                    bvid: bvid,
+                    error: .unavailable
+                )
+                self.relatedVideoTask = nil
+            }
+        }
     }
 
     private func performLoad(

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/RelatedVideoShelf.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/RelatedVideoShelf.swift
@@ -1,0 +1,428 @@
+import BiliUI
+import Foundation
+import SwiftUI
+
+struct RelatedVideoShelfItem: Identifiable, Equatable, Sendable {
+    let bvid: String
+    let title: String
+    let coverURL: URL?
+    let ownerName: String
+    let viewCount: Int64
+    let danmakuCount: Int64
+    let durationSeconds: Int?
+
+    var id: String { bvid }
+}
+
+enum RelatedVideoShelfState: Equatable, Sendable {
+    case loading
+    case loaded([RelatedVideoShelfItem])
+    case empty
+    case failure
+
+    var itemCount: Int {
+        if case .loaded(let items) = self {
+            return items.count
+        }
+        return 0
+    }
+}
+
+/// 播放详情下方的横向相关推荐 shelf。
+///
+/// 只接收稳定展示状态与 BVID 选择意图；滚动分页、hover 控件和 Reduce Motion
+/// 封装在视图内，不拥有推荐请求、导航路径、播放器或认证生命周期。
+struct RelatedVideoShelf: View {
+    private static let cardWidth: CGFloat = 224
+    private static let cardSpacing: CGFloat = 16
+    private static let contentPadding: CGFloat = 40
+
+    let state: RelatedVideoShelfState
+    let onSelect: (String) -> Void
+    let onRetry: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @ScaledMetric(relativeTo: .body) private var shelfHeight: CGFloat = 232
+    @State private var isHovered = false
+    @State private var viewportWidth: CGFloat = 0
+    @State private var visibleItemIDs: [String] = []
+    @FocusState private var focusedPageDirection: RecommendationShelfPageDirection?
+    @FocusState private var focusedItemID: String?
+
+    init(
+        state: RelatedVideoShelfState,
+        onSelect: @escaping (String) -> Void,
+        onRetry: @escaping () -> Void
+    ) {
+        self.state = state
+        self.onSelect = onSelect
+        self.onRetry = onRetry
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+                .padding(.horizontal, Self.contentPadding)
+
+            content
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityIdentifier("related-videos.shelf")
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Text("相关推荐")
+                .font(.title3.weight(.semibold))
+
+            Text("继续观看")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch state {
+        case .loading:
+            loadingShelf
+        case .loaded(let items) where items.isEmpty:
+            unavailableShelf
+        case .loaded(let items):
+            loadedShelf(items)
+        case .empty:
+            unavailableShelf
+        case .failure:
+            failureShelf
+        }
+    }
+
+    private func loadedShelf(
+        _ items: [RelatedVideoShelfItem]
+    ) -> some View {
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal) {
+                LazyHStack(alignment: .top, spacing: Self.cardSpacing) {
+                    ForEach(items) { item in
+                        card(item)
+                            .id(item.id)
+                    }
+                }
+                .scrollTargetLayout()
+            }
+            .contentMargins(
+                .horizontal,
+                Self.contentPadding,
+                for: .scrollContent
+            )
+            .scrollIndicators(.hidden)
+            .scrollTargetBehavior(.viewAligned)
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                geometry.containerSize.width
+            } action: { _, width in
+                viewportWidth = width
+            }
+            .onScrollTargetVisibilityChange(
+                idType: String.self,
+                threshold: 0.5
+            ) { identifiers in
+                visibleItemIDs = identifiers
+            }
+            .overlay {
+                pageControls(items, proxy: proxy)
+            }
+            .onHover { hovered in
+                withAnimation(reduceMotion ? nil : .easeOut(duration: 0.15)) {
+                    isHovered = hovered
+                }
+            }
+            .onChange(of: focusedItemID) { _, itemID in
+                guard let itemID else { return }
+                if reduceMotion {
+                    proxy.scrollTo(itemID, anchor: .center)
+                } else {
+                    withAnimation(.easeOut(duration: 0.18)) {
+                        proxy.scrollTo(itemID, anchor: .center)
+                    }
+                }
+            }
+            .frame(height: shelfHeight)
+            .accessibilityLabel("横向相关推荐")
+            .accessibilityIdentifier("related-videos.scroll")
+        }
+    }
+
+    private func card(_ item: RelatedVideoShelfItem) -> some View {
+        Button {
+            onSelect(item.bvid)
+        } label: {
+            RelatedVideoCard(
+                item: item,
+                isFocused: focusedItemID == item.id
+            )
+            .frame(width: Self.cardWidth)
+        }
+        .buttonStyle(VideoCardButtonStyle())
+        .focused($focusedItemID, equals: item.id)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(item.accessibilityLabel)
+        .accessibilityHint("播放并替换当前视频")
+        .accessibilityIdentifier("related-videos.card.\(item.bvid)")
+    }
+
+    private var loadingShelf: some View {
+        ScrollView(.horizontal) {
+            HStack(alignment: .top, spacing: Self.cardSpacing) {
+                ForEach(0..<4, id: \.self) { _ in
+                    VStack(alignment: .leading, spacing: 10) {
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(.quaternary)
+                            .aspectRatio(16.0 / 9.0, contentMode: .fit)
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(.quaternary)
+                            .frame(height: 18)
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(.quinary)
+                            .frame(width: 110, height: 14)
+                    }
+                    .frame(width: Self.cardWidth)
+                }
+            }
+        }
+        .contentMargins(
+            .horizontal,
+            Self.contentPadding,
+            for: .scrollContent
+        )
+        .scrollDisabled(true)
+        .scrollIndicators(.hidden)
+        .frame(height: shelfHeight, alignment: .topLeading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("正在加载相关推荐")
+    }
+
+    private var failureShelf: some View {
+        VStack(spacing: 10) {
+            Label("相关推荐加载失败", systemImage: "exclamationmark.triangle")
+                .font(.headline)
+            Button("重试", action: onRetry)
+                .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, minHeight: 180)
+        .accessibilityIdentifier("related-videos.failure")
+    }
+
+    private var unavailableShelf: some View {
+        ContentUnavailableView(
+            "暂无相关推荐",
+            systemImage: "rectangle.stack"
+        )
+        .frame(maxWidth: .infinity, minHeight: 180)
+    }
+
+    private func pageControls(
+        _ items: [RelatedVideoShelfItem],
+        proxy: ScrollViewProxy
+    ) -> some View {
+        HStack {
+            if pageTarget(.backward, in: items) != nil {
+                pageButton(.backward, items: items, proxy: proxy)
+            }
+
+            Spacer(minLength: 0)
+
+            if pageTarget(.forward, in: items) != nil {
+                pageButton(.forward, items: items, proxy: proxy)
+            }
+        }
+        .safeAreaPadding(.horizontal, 12)
+        .opacity(showsPageControls ? 1 : 0)
+        .allowsHitTesting(showsPageControls)
+    }
+
+    private var showsPageControls: Bool {
+        isHovered || focusedItemID != nil || focusedPageDirection != nil
+    }
+
+    private func pageButton(
+        _ direction: RecommendationShelfPageDirection,
+        items: [RelatedVideoShelfItem],
+        proxy: ScrollViewProxy
+    ) -> some View {
+        Button {
+            guard let target = pageTarget(direction, in: items) else { return }
+            if reduceMotion {
+                proxy.scrollTo(items[target].id, anchor: .leading)
+            } else {
+                withAnimation(.easeInOut(duration: 0.32)) {
+                    proxy.scrollTo(items[target].id, anchor: .leading)
+                }
+            }
+        } label: {
+            Image(systemName: direction.symbol)
+                .font(.headline.weight(.semibold))
+                .frame(width: 34, height: 44)
+                .contentShape(.capsule)
+        }
+        .buttonStyle(.plain)
+        .background(.regularMaterial, in: Capsule())
+        .overlay {
+            Capsule()
+                .stroke(.separator.opacity(0.55), lineWidth: 0.5)
+        }
+        .shadow(color: .black.opacity(0.18), radius: 5, y: 2)
+        .help(direction.accessibilityLabel)
+        .accessibilityLabel(direction.accessibilityLabel)
+        .focused($focusedPageDirection, equals: direction)
+    }
+
+    private func pageTarget(
+        _ direction: RecommendationShelfPageDirection,
+        in items: [RelatedVideoShelfItem]
+    ) -> Int? {
+        let indexByID = Dictionary(
+            uniqueKeysWithValues: items.enumerated().map { ($1.id, $0) }
+        )
+        let visibleIndices = visibleItemIDs.compactMap { indexByID[$0] }
+        return RelatedVideoShelfPaging(
+            itemCount: items.count,
+            cardWidth: Self.cardWidth,
+            cardSpacing: Self.cardSpacing,
+            contentPadding: Self.contentPadding
+        ).targetIndex(
+            visibleIndices: visibleIndices,
+            containerWidth: viewportWidth,
+            direction: direction
+        )
+    }
+}
+
+private struct RelatedVideoCard: View {
+    let item: RelatedVideoShelfItem
+    let isFocused: Bool
+
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+
+    var body: some View {
+        VideoCard(
+            coverURL: item.coverURL,
+            avatarURL: nil,
+            showsAvatar: false,
+            title: item.title,
+            coverMetrics: [
+                VideoCardMetric(
+                    item.viewCountText,
+                    systemImage: "play.fill"
+                ),
+                VideoCardMetric(
+                    item.danmakuCountText,
+                    systemImage: "text.bubble.fill"
+                ),
+            ],
+            coverTrailingText: item.durationText,
+            footerLeadingText: item.ownerName
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(
+                    Color.accentColor,
+                    lineWidth: colorSchemeContrast == .increased ? 3 : 2
+                )
+                .opacity(isFocused ? 1 : 0)
+        }
+    }
+}
+
+extension RelatedVideoShelfItem {
+    fileprivate var viewCountText: String {
+        VideoMetadataFormatting.compactCount(viewCount)
+    }
+
+    fileprivate var danmakuCountText: String {
+        VideoMetadataFormatting.compactCount(danmakuCount)
+    }
+
+    fileprivate var durationText: String? {
+        durationSeconds.map {
+            VideoDurationFormatting.string(seconds: $0)
+        }
+    }
+
+    fileprivate var accessibilityLabel: String {
+        var components = [
+            title,
+            ownerName,
+            "\(viewCountText)播放",
+            "\(danmakuCountText)弹幕",
+        ]
+        if let durationText {
+            components.append("时长\(durationText)")
+        }
+        return components.joined(separator: "，")
+    }
+}
+
+enum RecommendationShelfPageDirection: Hashable {
+    case backward
+    case forward
+
+    var symbol: String {
+        switch self {
+        case .backward: "chevron.left"
+        case .forward: "chevron.right"
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch self {
+        case .backward: "上一排相关推荐"
+        case .forward: "下一排相关推荐"
+        }
+    }
+}
+
+struct RelatedVideoShelfPaging {
+    let itemCount: Int
+    let cardWidth: CGFloat
+    let cardSpacing: CGFloat
+    let contentPadding: CGFloat
+
+    func targetIndex(
+        visibleIndices: [Int],
+        containerWidth: CGFloat,
+        direction: RecommendationShelfPageDirection
+    ) -> Int? {
+        guard itemCount > 0 else { return nil }
+
+        let visibleIndices = visibleIndices.filter {
+            (0..<itemCount).contains($0)
+        }
+        let firstVisibleIndex = visibleIndices.min() ?? 0
+        let lastVisibleIndex = visibleIndices.max() ?? 0
+        let availableWidth = max(
+            cardWidth,
+            containerWidth - contentPadding * 2
+        )
+        let pageCapacity = max(
+            1,
+            Int(
+                floor(
+                    (availableWidth + cardSpacing)
+                        / (cardWidth + cardSpacing)
+                )
+            )
+        )
+
+        switch direction {
+        case .backward:
+            guard firstVisibleIndex > 0 else { return nil }
+            return max(0, firstVisibleIndex - pageCapacity)
+        case .forward:
+            let finalIndex = itemCount - 1
+            guard lastVisibleIndex < finalIndex else { return nil }
+            return min(finalIndex, firstVisibleIndex + pageCapacity)
+        }
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoPlaybackView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoPlaybackView.swift
@@ -9,17 +9,20 @@ public struct VideoPlaybackView<PlayerContent: View>: View {
     private let model: GuestVideoViewModel
     private let danmakuModel: DanmakuControlsViewModel
     private let onRetry: () -> Void
+    private let onSelectRelatedVideo: (String) -> Void
     private let playerContent: () -> PlayerContent
 
     public init(
         model: GuestVideoViewModel,
         danmakuModel: DanmakuControlsViewModel,
         onRetry: @escaping () -> Void,
+        onSelectRelatedVideo: @escaping (String) -> Void = { _ in },
         @ViewBuilder playerContent: @escaping () -> PlayerContent
     ) {
         self.model = model
         self.danmakuModel = danmakuModel
         self.onRetry = onRetry
+        self.onSelectRelatedVideo = onSelectRelatedVideo
         self.playerContent = playerContent
     }
 
@@ -32,6 +35,9 @@ public struct VideoPlaybackView<PlayerContent: View>: View {
                         context: currentContext,
                         isPreparingPlayback: showsPlaybackActivity,
                         danmakuModel: danmakuModel,
+                        relatedVideoState: model.relatedVideoState,
+                        onSelectRelatedVideo: onSelectRelatedVideo,
+                        onRetryRelatedVideos: model.retryRelatedVideos,
                         playerContent: playerContent
                     )
                     .disabled(blocksRetainedContext)

--- a/Packages/BiliKitCore/Sources/BiliModels/Video/VideoModels.swift
+++ b/Packages/BiliKitCore/Sources/BiliModels/Video/VideoModels.swift
@@ -66,6 +66,36 @@ public struct PopularPage: Sendable, Equatable {
     }
 }
 
+public struct RelatedVideo: Identifiable, Sendable, Equatable {
+    public var id: String { bvid }
+
+    public let bvid: String
+    public let title: String
+    public let coverURL: URL?
+    public let ownerName: String
+    public let viewCount: Int64
+    public let danmakuCount: Int64
+    public let durationSeconds: Int?
+
+    public init(
+        bvid: String,
+        title: String,
+        coverURL: URL?,
+        ownerName: String,
+        viewCount: Int64,
+        danmakuCount: Int64,
+        durationSeconds: Int?
+    ) {
+        self.bvid = bvid
+        self.title = title
+        self.coverURL = coverURL
+        self.ownerName = ownerName
+        self.viewCount = viewCount
+        self.danmakuCount = danmakuCount
+        self.durationSeconds = durationSeconds
+    }
+}
+
 public struct VideoDetail: Identifiable, Sendable, Equatable {
     public var id: String { bvid }
 

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
@@ -66,6 +66,69 @@ struct BiliAPIClientTests {
     }
 
     @Test
+    func relatedVideosUseAnonymousRequestAndDecodeShelfFields() async throws {
+        let transport = RecordingTransport(
+            responses: [try fixtureResponse("related")]
+        )
+        let authorizer = RecordingRequestAuthorizer()
+        let client = BiliAPIClient(
+            transport: transport,
+            requestAuthorizer: authorizer
+        )
+
+        let videos = try await client.relatedVideos(to: "BV1FixtureA1")
+
+        #expect(videos.map(\.bvid) == ["BV1RelatedA1", "BV1RelatedB2"])
+        #expect(videos[0].ownerName == "相关作者甲")
+        #expect(videos[0].viewCount == 22_222)
+        #expect(videos[0].durationSeconds == 222)
+        #expect(videos[1].durationSeconds == nil)
+        let request = try #require(await transport.capturedRequests().first)
+        #expect(request.url.path == "/x/web-interface/archive/related")
+        #expect(
+            URLComponents(url: request.url, resolvingAgainstBaseURL: false)?
+                .queryItems == [URLQueryItem(name: "bvid", value: "BV1FixtureA1")]
+        )
+        #expect(request.headers["Cookie"] == nil)
+        #expect(await authorizer.capturedPaths().isEmpty)
+    }
+
+    @Test
+    func relatedVideosRejectMissingInteractiveFields() async {
+        let response = HTTPResponse(
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"],
+            body: Data(
+                #"{"code":0,"data":[{"bvid":"BV1RelatedA1","title":"","owner":{"name":"作者"},"stat":{"view":1,"danmaku":2}}]}"#
+                    .utf8
+            )
+        )
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [response])
+        )
+
+        await #expect(throws: BiliAPIError.decodingFailed) {
+            try await client.relatedVideos(to: "BV1FixtureA1")
+        }
+    }
+
+    @Test
+    func relatedVideosAcceptEmptyResponse() async throws {
+        let response = HTTPResponse(
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"],
+            body: Data(#"{"code":0,"data":[]}"#.utf8)
+        )
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [response])
+        )
+
+        let videos = try await client.relatedVideos(to: "BV1FixtureA1")
+
+        #expect(videos.isEmpty)
+    }
+
+    @Test
     func searchUsesWBIAndNormalizesEndpointQuirks() async throws {
         let transport = RecordingTransport(
             responses: [

--- a/Packages/BiliKitCore/Tests/BiliAPITests/Fixtures/related.json
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/Fixtures/related.json
@@ -1,0 +1,21 @@
+{
+  "code": 0,
+  "message": "0",
+  "data": [
+    {
+      "bvid": "BV1RelatedA1",
+      "title": "合成相关推荐 A",
+      "pic": "//image.example.invalid/related-a.jpg",
+      "owner": { "name": "相关作者甲" },
+      "stat": { "view": 22222, "danmaku": 222 },
+      "duration": 222
+    },
+    {
+      "bvid": "BV1RelatedB2",
+      "title": "合成相关推荐 B",
+      "pic": null,
+      "owner": { "name": "相关作者乙" },
+      "stat": { "view": 33333, "danmaku": 333 }
+    }
+  ]
+}

--- a/Packages/BiliKitCore/Tests/BiliApplicationTests/RelatedVideoUseCaseTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliApplicationTests/RelatedVideoUseCaseTests.swift
@@ -1,0 +1,55 @@
+import BiliApplication
+import BiliModels
+import Testing
+
+struct RelatedVideoUseCaseTests {
+    @Test
+    func removesCurrentVideoAndDuplicatesWithoutChangingRemoteOrder() async throws {
+        let current = RelatedVideo.fixture(bvid: "BV1CurrentAA1")
+        let first = RelatedVideo.fixture(bvid: "BV1RelatedA1")
+        let second = RelatedVideo.fixture(bvid: "BV1RelatedB2")
+        let useCase = RelatedVideoUseCase(
+            repository: RelatedVideoRepositoryStub(
+                videos: [current, first, first, second]
+            )
+        )
+
+        let videos = try await useCase.relatedVideos(to: current.bvid)
+
+        #expect(videos == [first, second])
+    }
+
+    @Test
+    func currentVideoOnlyBecomesEmptyResult() async throws {
+        let current = RelatedVideo.fixture(bvid: "BV1CurrentAA1")
+        let useCase = RelatedVideoUseCase(
+            repository: RelatedVideoRepositoryStub(videos: [current])
+        )
+
+        let videos = try await useCase.relatedVideos(to: current.bvid)
+
+        #expect(videos.isEmpty)
+    }
+}
+
+private struct RelatedVideoRepositoryStub: RelatedVideoRepository {
+    let videos: [RelatedVideo]
+
+    func relatedVideos(to bvid: String) async throws -> [RelatedVideo] {
+        videos
+    }
+}
+
+extension RelatedVideo {
+    fileprivate static func fixture(bvid: String) -> RelatedVideo {
+        RelatedVideo(
+            bvid: bvid,
+            title: "合成推荐",
+            coverURL: nil,
+            ownerName: "测试作者",
+            viewCount: 10,
+            danmakuCount: 1,
+            durationSeconds: 120
+        )
+    }
+}

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
@@ -555,6 +555,143 @@ struct GuestBrowseAndVideoViewModelTests {
         #expect(player.loadedIdentities.map(\.cid) == [900_001, 900_001])
         #expect(player.stopCallCount == 2)
     }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func relatedVideoABARejectsOldSameBVIDResult() async throws {
+        let fixture = GuestFixtures()
+        let relatedRepository = RelatedVideoABARepositoryStub()
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(
+                repository: GuestRepositoryStub(fixtures: fixture)
+            ),
+            playback: RecordingPlayerEngine(),
+            relatedVideoUseCase: RelatedVideoUseCase(
+                repository: relatedRepository
+            )
+        )
+
+        model.loadVideo("BV1RelatedAA")
+        try await relatedRepository.waitForRequestCount(1)
+        let oldA = try #require(model.relatedVideoTaskSnapshotForTesting())
+        model.loadVideo("BV1RelatedBB")
+        try await relatedRepository.waitForRequestCount(2)
+        model.loadVideo("BV1RelatedAA")
+        try await relatedRepository.waitForRequestCount(3)
+
+        let newResult = RelatedVideo.testFixture(bvid: "BV1CurrentAA1")
+        await relatedRepository.releaseRequest(2, videos: [newResult])
+        await model.waitForCurrentRelatedVideoTask()
+        #expect(
+            model.relatedVideoState
+                == .loaded(bvid: "BV1RelatedAA", videos: [newResult])
+        )
+
+        await relatedRepository.releaseRequest(
+            0,
+            videos: [.testFixture(bvid: "BV1StaleAAA1")]
+        )
+        await oldA.value
+        await relatedRepository.releaseRequest(1, videos: [])
+
+        #expect(
+            model.relatedVideoState
+                == .loaded(bvid: "BV1RelatedAA", videos: [newResult])
+        )
+    }
+
+    @Test
+    @MainActor
+    func relatedVideoFailureRetriesWithoutReloadingPlayback() async {
+        let fixture = GuestFixtures()
+        let relatedRepository = RetryingRelatedVideoRepositoryStub()
+        let player = RecordingPlayerEngine()
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(
+                repository: GuestRepositoryStub(fixtures: fixture)
+            ),
+            playback: player,
+            relatedVideoUseCase: RelatedVideoUseCase(
+                repository: relatedRepository
+            )
+        )
+
+        model.loadVideo(fixture.bvid)
+        await model.waitForCurrentTask()
+        await model.waitForCurrentRelatedVideoTask()
+        #expect(
+            model.relatedVideoState
+                == .failed(bvid: fixture.bvid, error: .transportFailure)
+        )
+
+        model.retryRelatedVideos()
+        await model.waitForCurrentRelatedVideoTask()
+
+        #expect(
+            model.relatedVideoState
+                == .loaded(
+                    bvid: fixture.bvid,
+                    videos: [.testFixture(bvid: "BV1RetryVid1")]
+                )
+        )
+        #expect(player.loadedPlaybacks.count == 1)
+        #expect(await relatedRepository.callCount == 2)
+    }
+}
+
+private actor RelatedVideoABARepositoryStub: RelatedVideoRepository {
+    private var continuations: [CheckedContinuation<[RelatedVideo], Never>?] = []
+    private var requestWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func relatedVideos(to bvid: String) async throws -> [RelatedVideo] {
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+            let waiters = requestWaiters
+            requestWaiters.removeAll()
+            for waiter in waiters {
+                waiter.resume()
+            }
+        }
+    }
+
+    func waitForRequestCount(_ count: Int) async throws {
+        while continuations.count < count {
+            await withCheckedContinuation { continuation in
+                requestWaiters.append(continuation)
+            }
+        }
+    }
+
+    func releaseRequest(_ index: Int, videos: [RelatedVideo]) {
+        continuations[index]?.resume(returning: videos)
+        continuations[index] = nil
+    }
+}
+
+private actor RetryingRelatedVideoRepositoryStub: RelatedVideoRepository {
+    private(set) var callCount = 0
+
+    func relatedVideos(to bvid: String) async throws -> [RelatedVideo] {
+        callCount += 1
+        guard callCount > 1 else {
+            throw GuestApplicationError.transportFailure
+        }
+        return [.testFixture(bvid: "BV1RetryVid1")]
+    }
+}
+
+extension RelatedVideo {
+    fileprivate static func testFixture(bvid: String) -> RelatedVideo {
+        RelatedVideo(
+            bvid: bvid,
+            title: "合成相关推荐",
+            coverURL: nil,
+            ownerName: "测试作者",
+            viewCount: 100,
+            danmakuCount: 10,
+            durationSeconds: 120
+        )
+    }
 }
 
 private actor WorksetRepositoryStub: GuestContentRepository {

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/RelatedVideoShelfTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/RelatedVideoShelfTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+
+@testable import BiliBrowseFeature
+
+struct RelatedVideoShelfTests {
+    @Test
+    func itemIdentityIsTheReplacementBVID() {
+        let item = RelatedVideoShelfItem(
+            bvid: "BV1Related",
+            title: "示例推荐",
+            coverURL: URL(string: "https://example.com/cover.webp"),
+            ownerName: "示例 UP 主",
+            viewCount: 123_456,
+            danmakuCount: 7_890,
+            durationSeconds: 754
+        )
+
+        #expect(item.id == "BV1Related")
+        #expect(RelatedVideoShelfState.loaded([item]).itemCount == 1)
+        #expect(RelatedVideoShelfState.loading.itemCount == 0)
+        #expect(RelatedVideoShelfState.empty.itemCount == 0)
+        #expect(RelatedVideoShelfState.failure.itemCount == 0)
+    }
+
+    @Test
+    func pagingAdvancesByTheVisibleCardCapacity() {
+        let paging = RelatedVideoShelfPaging(
+            itemCount: 8,
+            cardWidth: 224,
+            cardSpacing: 16,
+            contentPadding: 40
+        )
+
+        #expect(
+            paging.targetIndex(
+                visibleIndices: [0, 1, 2],
+                containerWidth: 784,
+                direction: .forward
+            ) == 3
+        )
+        #expect(
+            paging.targetIndex(
+                visibleIndices: [3, 4, 5],
+                containerWidth: 784,
+                direction: .forward
+            ) == 6
+        )
+        #expect(
+            paging.targetIndex(
+                visibleIndices: [5, 6, 7],
+                containerWidth: 784,
+                direction: .backward
+            ) == 2
+        )
+        #expect(
+            paging.targetIndex(
+                visibleIndices: [0, 1, 2],
+                containerWidth: 784,
+                direction: .backward
+            ) == nil
+        )
+        #expect(
+            paging.targetIndex(
+                visibleIndices: [5, 6, 7],
+                containerWidth: 784,
+                direction: .forward
+            ) == nil
+        )
+    }
+
+    @Test
+    func pagingStillMovesOneCardWhenTheViewportIsNarrow() {
+        let paging = RelatedVideoShelfPaging(
+            itemCount: 3,
+            cardWidth: 224,
+            cardSpacing: 16,
+            contentPadding: 40
+        )
+
+        #expect(
+            paging.targetIndex(
+                visibleIndices: [0],
+                containerWidth: 260,
+                direction: .forward
+            ) == 1
+        )
+    }
+}


### PR DESCRIPTION
## 变化

- 生产化既有 `RelatedVideoShelf` / `RelatedVideoCard`，不重做卡片视觉。
- 接入匿名 `GET /x/web-interface/archive/related?bvid=...`。
- 建立 endpoint DTO → BiliModels → BiliApplication use case/port → BiliAPI adapter → Feature state → App composition 链路。
- 将真实推荐状态接入当前视频 detail 下方，覆盖 loading、empty、failure 和 retry。
- 点击推荐时在同一窗口、同一 NavigationStack 深度和单一 player host 中替换 BVID；A→B→C 不产生嵌套播放页面。
- 用 request identity / generation 隔离旧详情、分 P、媒体、字幕、弹幕和推荐结果，并保留返回后的来源上下文。

## 原因与用户影响

相关推荐是当前观看流程的自然延伸。此次接入让用户可以在不离开当前窗口上下文的情况下继续浏览真实视频，同时避免切换视频时出现旧结果覆盖、新旧播放宿主并存或返回来源丢失。

## 认证与安全边界

- 推荐 endpoint 使用独立匿名请求，不调用认证 authorizer，不携带 BiliKit Cookie。
- DTO 仅存在于 BiliAPI；Application 与 Feature 不接触 endpoint 字段。
- 图片 URL 继续受现有公共 HTTPS 边界约束。
- 不加入自动播放、无限循环、评论、首页推荐或写操作。

## 验证

- 在该分支精确运行 `sh Scripts/run-quality-gates.sh app`：static、Swift Package、App build-for-testing、App unit tests 全部通过。
- 覆盖 endpoint 映射、缺失字段、空结果、失败/retry、请求隔离、A→B replacement、Back 与 player continuity。
- 实施阶段经过 API/安全、生命周期和 UI/测试独立审查，已关闭发现项后无 P0–P3。

## 未覆盖边界

- 真实 endpoint 验证仍是当前时点的单样本，不能保证 B 站长期 schema 稳定。
- 自动化证据不能替代所有真实 CDN、网络波动和完整辅助功能人工验证。