### PR TITLE
feat(ui): 统一加载与布局连续性

### DIFF
--- a/BiliKitMacTests/VideoDetailLifecycleTests.swift
+++ b/BiliKitMacTests/VideoDetailLifecycleTests.swift
@@ -181,6 +181,24 @@ struct VideoDetailLifecycleTests {
 
         coordinator.openPlayback(first.bvid)
         #expect(
+            await waitUntilAsync {
+                guard
+                    case .loading(let bvid) = videoModel.state,
+                    bvid == first.bvid
+                else {
+                    return false
+                }
+                return await repository.firstRequestHasStarted()
+            }
+        )
+        hostingView.layoutSubtreeIfNeeded()
+        let initialDetailScrollView = try #require(
+            verticallyScrollableViews(in: hostingView).first
+        )
+        #expect(verticallyScrollableViews(in: hostingView).count == 1)
+
+        await repository.releaseFirstRequest()
+        #expect(
             await waitUntil {
                 guard case .ready(let context) = videoModel.state else {
                     return false
@@ -195,7 +213,18 @@ struct VideoDetailLifecycleTests {
         let surfaceIdentity = playerSurface.createdIdentities[0]
         let playerView = try #require(playerViews(in: hostingView).first)
         let playerViewIdentity = ObjectIdentifier(playerView)
+        let detailScrollView = try #require(
+            firstAncestor(ofType: NSScrollView.self, from: playerView)
+        )
+        #expect(detailScrollView === initialDetailScrollView)
         #expect(playerView.player === hostedPlayer)
+        #expect(
+            await waitUntil {
+                self.verticallyScrollableViews(in: hostingView).map(
+                    ObjectIdentifier.init
+                ) == [ObjectIdentifier(detailScrollView)]
+            }
+        )
         let stopCountBeforeReplacement = presentation.stopCount
 
         #expect(
@@ -220,6 +249,13 @@ struct VideoDetailLifecycleTests {
             playerViews(in: hostingView).first.map(ObjectIdentifier.init)
                 == Optional(playerViewIdentity)
         )
+        #expect(
+            verticallyScrollableViews(in: hostingView).map(
+                ObjectIdentifier.init
+            ) == [ObjectIdentifier(detailScrollView)]
+        )
+        let replacementViewportOrigin = scrollToBottom(detailScrollView)
+        #expect(replacementViewportOrigin.y > 0)
 
         coordinator.openPlayback(replacement.bvid)
         #expect(
@@ -245,6 +281,18 @@ struct VideoDetailLifecycleTests {
             playerViews(in: hostingView).first.map(ObjectIdentifier.init)
                 == Optional(playerViewIdentity)
         )
+        hostingView.layoutSubtreeIfNeeded()
+        #expect(
+            verticallyScrollableViews(in: hostingView).map(
+                ObjectIdentifier.init
+            ) == [ObjectIdentifier(detailScrollView)]
+        )
+        #expect(
+            abs(
+                detailScrollView.contentView.bounds.origin.y
+                    - replacementViewportOrigin.y
+            ) < 2
+        )
 
         await repository.failReplacementRequest()
         await videoModel.waitForCurrentTask()
@@ -261,6 +309,11 @@ struct VideoDetailLifecycleTests {
         )
         #expect(playerSurface.createdIdentities == [surfaceIdentity])
         #expect(playerSurface.dismantledIdentities.isEmpty)
+        #expect(
+            verticallyScrollableViews(in: hostingView).map(
+                ObjectIdentifier.init
+            ) == [ObjectIdentifier(detailScrollView)]
+        )
         #expect(
             playerViews(in: hostingView).first.map(ObjectIdentifier.init)
                 == Optional(playerViewIdentity)
@@ -288,6 +341,11 @@ struct VideoDetailLifecycleTests {
         )
         #expect(playerSurface.createdIdentities == [surfaceIdentity])
         #expect(playerSurface.dismantledIdentities.isEmpty)
+        #expect(
+            verticallyScrollableViews(in: hostingView).map(
+                ObjectIdentifier.init
+            ) == [ObjectIdentifier(detailScrollView)]
+        )
         #expect(
             playerViews(in: hostingView).first.map(ObjectIdentifier.init)
                 == Optional(playerViewIdentity)
@@ -323,6 +381,11 @@ struct VideoDetailLifecycleTests {
         )
         #expect(playerSurface.createdIdentities == [surfaceIdentity])
         #expect(player.stopCallCount == 3)
+        #expect(
+            !verticallyScrollableViews(in: hostingView).contains {
+                $0 === detailScrollView
+            }
+        )
         #expect(
             presentation.startedIdentities == [
                 first.identity,
@@ -460,6 +523,54 @@ struct VideoDetailLifecycleTests {
     }
 
     @MainActor
+    private func verticallyScrollableViews(in root: NSView) -> [NSScrollView] {
+        var matches: [NSScrollView] = []
+        if let scrollView = root as? NSScrollView,
+            let documentView = scrollView.documentView,
+            documentView.bounds.height > scrollView.contentView.bounds.height
+        {
+            matches.append(scrollView)
+        }
+        for child in root.subviews {
+            matches.append(contentsOf: verticallyScrollableViews(in: child))
+        }
+        return matches
+    }
+
+    @MainActor
+    private func firstAncestor<ViewType: NSView>(
+        ofType type: ViewType.Type,
+        from view: NSView
+    ) -> ViewType? {
+        var ancestor = view.superview
+        while let current = ancestor {
+            if let match = current as? ViewType {
+                return match
+            }
+            ancestor = current.superview
+        }
+        return nil
+    }
+
+    @MainActor
+    private func scrollToBottom(_ scrollView: NSScrollView) -> NSPoint {
+        guard let documentView = scrollView.documentView else {
+            return scrollView.contentView.bounds.origin
+        }
+        let origin = NSPoint(
+            x: scrollView.contentView.bounds.origin.x,
+            y: max(
+                0,
+                documentView.bounds.maxY
+                    - scrollView.contentView.bounds.height
+            )
+        )
+        scrollView.contentView.scroll(to: origin)
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        return scrollView.contentView.bounds.origin
+    }
+
+    @MainActor
     private func waitUntil(
         _ condition: @MainActor () -> Bool
     ) async -> Bool {
@@ -578,8 +689,11 @@ private actor VideoDetailLifecycleRepository: GuestContentRepository {
 private actor ReplacementLifecycleRepository: GuestContentRepository {
     let first: VideoDetailLifecycleFixture
     let replacement: VideoDetailLifecycleFixture
+    private var blocksFirst = true
     private var blocksReplacement = true
+    private var firstRequestStarted = false
     private var replacementRequestStarted = false
+    private var blockedFirstRequest: CheckedContinuation<Void, Never>?
     private var blockedRequest: CheckedContinuation<Void, any Error>?
 
     init(
@@ -605,6 +719,12 @@ private actor ReplacementLifecycleRepository: GuestContentRepository {
     }
 
     func videoDetail(for bvid: String) async throws -> VideoDetail {
+        if bvid == first.bvid, blocksFirst {
+            await withCheckedContinuation { continuation in
+                blockedFirstRequest = continuation
+                firstRequestStarted = true
+            }
+        }
         if bvid == replacement.bvid, blocksReplacement {
             try await withCheckedThrowingContinuation { continuation in
                 blockedRequest = continuation
@@ -612,6 +732,16 @@ private actor ReplacementLifecycleRepository: GuestContentRepository {
             }
         }
         return fixture(for: bvid).detail
+    }
+
+    func firstRequestHasStarted() -> Bool {
+        firstRequestStarted
+    }
+
+    func releaseFirstRequest() {
+        blocksFirst = false
+        blockedFirstRequest?.resume()
+        blockedFirstRequest = nil
     }
 
     func pages(for bvid: String) async throws -> [VideoPage] {

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/Feed/PopularFeedView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/Feed/PopularFeedView.swift
@@ -4,6 +4,7 @@ import BiliUI
 import SwiftUI
 
 public struct PopularFeedView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let model: GuestBrowseViewModel
     private let request: GuestFeedRequest
     @Binding private var scrollPosition: ScrollPosition
@@ -22,9 +23,20 @@ public struct PopularFeedView: View {
         self.onSelect = onSelect
     }
 
-    @ViewBuilder
     public var body: some View {
         let presentation = model.presentation(for: request)
+        ZStack {
+            content(for: presentation)
+                .transition(.opacity)
+        }
+        .animation(
+            LoadingStateTransition.animation(reduceMotion: reduceMotion),
+            value: visualPhase(for: presentation.state)
+        )
+    }
+
+    @ViewBuilder
+    private func content(for presentation: GuestFeedPresentation) -> some View {
         switch presentation.state {
         case .idle, .loading:
             VideoCardGridSkeleton(loadingLabel: "正在加载热门视频")
@@ -55,9 +67,25 @@ public struct PopularFeedView: View {
                 .accessibilityIdentifier("feed.transitioning")
         }
     }
+
+    private func visualPhase(for state: GuestFeedState) -> LoadingVisualPhase {
+        switch state {
+        case .idle, .loading:
+            .loading
+        case .loaded(.popular(let page)) where page.videos.isEmpty:
+            .empty
+        case .loaded(.popular(_)):
+            .content
+        case .failed(request: .popular(_, _), error: _):
+            .failure
+        default:
+            .transitioning
+        }
+    }
 }
 
 private struct PopularGrid: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let model: GuestBrowseViewModel
     let page: PopularPage
     @Binding var scrollPosition: ScrollPosition
@@ -116,7 +144,15 @@ private struct PopularGrid: View {
                 await model.waitForCurrentTask()
             }
             .overlay(alignment: .top) {
-                refreshStatus
+                ZStack {
+                    refreshStatus
+                }
+                .animation(
+                    LoadingStateTransition.animation(
+                        reduceMotion: reduceMotion
+                    ),
+                    value: refreshVisualPhase
+                )
             }
         }
     }
@@ -130,12 +166,21 @@ private struct PopularGrid: View {
                 .padding(8)
                 .background(.regularMaterial, in: Capsule())
                 .accessibilityLabel("正在刷新热门视频")
+                .transition(.opacity)
         } else if let error = presentation.refreshError {
             Text(error.guestMessage)
                 .font(.caption)
                 .padding(8)
                 .background(.regularMaterial, in: Capsule())
                 .accessibilityIdentifier("feed.refresh-failure")
+                .transition(.opacity)
         }
+    }
+
+    private var refreshVisualPhase: LoadingVisualPhase {
+        let presentation = model.presentation(for: request)
+        if presentation.isRefreshing { return .loading }
+        if presentation.refreshError != nil { return .failure }
+        return .idle
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/Feed/PopularFeedView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/Feed/PopularFeedView.swift
@@ -27,8 +27,7 @@ public struct PopularFeedView: View {
         let presentation = model.presentation(for: request)
         switch presentation.state {
         case .idle, .loading:
-            ProgressView("正在加载热门视频…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            VideoCardGridSkeleton(loadingLabel: "正在加载热门视频")
                 .accessibilityIdentifier("feed.loading")
         case .loaded(.popular(let page)) where page.videos.isEmpty:
             ContentUnavailableView(
@@ -52,8 +51,7 @@ public struct PopularFeedView: View {
             )
             .accessibilityIdentifier("feed.failure")
         default:
-            ProgressView("正在切换到热门视频…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            VideoCardGridSkeleton(loadingLabel: "正在切换到热门视频")
                 .accessibilityIdentifier("feed.transitioning")
         }
     }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/Search/VideoSearchView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/Search/VideoSearchView.swift
@@ -44,8 +44,7 @@ public struct VideoSearchView: View {
         switch presentation.state {
         case .idle, .loading:
             let query = request.searchQuery ?? ""
-            ProgressView("正在搜索“\(query)”…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            SearchResultsSkeleton(query: query)
                 .accessibilityIdentifier("search.loading")
         case .loaded(.search(let query, let page)) where page.videos.isEmpty:
             ContentUnavailableView.search(text: query)
@@ -90,6 +89,28 @@ public struct VideoSearchView: View {
             description: Text("输入关键词后按下 Return 或点击搜索。")
         )
         .accessibilityIdentifier("search.prompt")
+    }
+}
+
+private struct SearchResultsSkeleton: View {
+    let query: String
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("“\(query)”")
+                Spacer()
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.quinary)
+                    .frame(width: 96, height: 12)
+                    .accessibilityHidden(true)
+            }
+            .font(.caption)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            VideoCardGridSkeleton(loadingLabel: "正在搜索“\(query)”")
+        }
     }
 }
 

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/Search/VideoSearchView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/Search/VideoSearchView.swift
@@ -4,6 +4,7 @@ import BiliUI
 import SwiftUI
 
 public struct VideoSearchView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let model: GuestBrowseViewModel
     private let submittedSearchQuery: String?
     @Binding private var scrollPosition: ScrollPosition
@@ -22,7 +23,34 @@ public struct VideoSearchView: View {
     }
 
     public var body: some View {
-        results
+        ZStack {
+            results
+                .transition(.opacity)
+        }
+        .animation(
+            LoadingStateTransition.animation(reduceMotion: reduceMotion),
+            value: visualPhase
+        )
+    }
+
+    private var visualPhase: LoadingVisualPhase {
+        guard let submittedSearchQuery else { return .idle }
+        let request = GuestFeedRequest.search(
+            query: submittedSearchQuery,
+            page: 1
+        )
+        switch model.presentation(for: request).state {
+        case .idle, .loading:
+            return .loading
+        case .loaded(.search(_, let page)) where page.videos.isEmpty:
+            return .empty
+        case .loaded(.search(_, _)):
+            return .content
+        case .failed(request: .search(_, _), error: _):
+            return .failure
+        default:
+            return .transitioning
+        }
     }
 
     @ViewBuilder
@@ -122,6 +150,7 @@ extension GuestFeedRequest {
 }
 
 private struct SearchResultsGrid: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let model: GuestBrowseViewModel
     let query: String
     let page: SearchPage
@@ -180,7 +209,15 @@ private struct SearchResultsGrid: View {
                 await model.waitForCurrentTask()
             }
             .overlay(alignment: .top) {
-                refreshStatus
+                ZStack {
+                    refreshStatus
+                }
+                .animation(
+                    LoadingStateTransition.animation(
+                        reduceMotion: reduceMotion
+                    ),
+                    value: refreshVisualPhase
+                )
             }
         }
     }
@@ -194,12 +231,21 @@ private struct SearchResultsGrid: View {
                 .padding(8)
                 .background(.regularMaterial, in: Capsule())
                 .accessibilityLabel("正在刷新搜索结果")
+                .transition(.opacity)
         } else if let error = presentation.refreshError {
             Text(error.guestMessage)
                 .font(.caption)
                 .padding(8)
                 .background(.regularMaterial, in: Capsule())
                 .accessibilityIdentifier("search.refresh-failure")
+                .transition(.opacity)
         }
+    }
+
+    private var refreshVisualPhase: LoadingVisualPhase {
+        let presentation = model.presentation(for: request)
+        if presentation.isRefreshing { return .loading }
+        if presentation.refreshError != nil { return .failure }
+        return .idle
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoDetailView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoDetailView.swift
@@ -4,6 +4,7 @@ import Foundation
 import SwiftUI
 
 struct GuestVideoDetailView<PlayerContent: View>: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let context: GuestVideoContext
     let isPreparingPlayback: Bool
     let danmakuModel: DanmakuControlsViewModel
@@ -128,14 +129,21 @@ struct GuestVideoDetailView<PlayerContent: View>: View {
                 .accessibilityIdentifier("player.host")
 
             if isPreparingPlayback {
-                Rectangle()
-                    .fill(.black.opacity(0.45))
-                ProgressView("正在准备播放…")
-                    .controlSize(.large)
-                    .font(.title3)
-                    .foregroundStyle(.white)
+                ZStack {
+                    Rectangle()
+                        .fill(.black.opacity(0.45))
+                    ProgressView("正在准备播放…")
+                        .controlSize(.large)
+                        .font(.title3)
+                        .foregroundStyle(.white)
+                }
+                .transition(.opacity)
             }
         }
+        .animation(
+            LoadingStateTransition.animation(reduceMotion: reduceMotion),
+            value: isPreparingPlayback
+        )
         .aspectRatio(
             PlaybackPageLayout.playerAspectRatio,
             contentMode: .fit

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoDetailView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoDetailView.swift
@@ -20,33 +20,18 @@ struct GuestVideoDetailView<PlayerContent: View>: View {
     }
 
     private var mainContent: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                metadata
-                player
-
-                Divider()
-                DanmakuControlsView(model: danmakuModel)
-
-                RelatedVideoShelf(
-                    state: shelfState,
-                    onSelect: onSelectRelatedVideo,
-                    onRetry: onRetryRelatedVideos
-                )
-                .padding(
-                    .horizontal,
-                    -PlaybackPageLayout.horizontalContentPadding
-                )
-            }
-            .padding(
-                .horizontal,
-                PlaybackPageLayout.horizontalContentPadding
+        PlaybackDetailLayout {
+            metadata
+        } player: {
+            player
+        } controls: {
+            DanmakuControlsView(model: danmakuModel)
+        } related: {
+            RelatedVideoShelf(
+                state: shelfState,
+                onSelect: onSelectRelatedVideo,
+                onRetry: onRetryRelatedVideos
             )
-            .padding(
-                .vertical,
-                PlaybackPageLayout.verticalContentPadding
-            )
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
@@ -157,5 +142,6 @@ struct GuestVideoDetailView<PlayerContent: View>: View {
 enum PlaybackPageLayout {
     static let horizontalContentPadding: CGFloat = 40
     static let verticalContentPadding: CGFloat = 24
+    static let sectionSpacing: CGFloat = 18
     static let playerAspectRatio: CGFloat = 16.0 / 9.0
 }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/PlaybackContextSidebar.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/PlaybackContextSidebar.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// `presentedContext` 让 Sidebar 与主区共享最近有效内容；替换视频的 loading／failed
 /// 状态会遮挡旧内容并从辅助树隐藏，避免把上一视频误读成当前上下文。
 public struct PlaybackContextSidebar: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let model: GuestVideoViewModel
     private let onRetry: () -> Void
     @State private var isSummaryExpanded = true
@@ -32,11 +33,17 @@ public struct PlaybackContextSidebar: View {
                         .accessibilityHidden(blocksPresentedContext)
 
                     presentedContextOverlay
+                        .transition(.opacity)
                 }
             } else {
                 emptyState
+                    .transition(.opacity)
             }
         }
+        .animation(
+            LoadingStateTransition.animation(reduceMotion: reduceMotion),
+            value: visualPhase
+        )
         .navigationTitle("观看辅助")
         .accessibilityIdentifier("sidebar.playback-context")
     }
@@ -243,6 +250,30 @@ public struct PlaybackContextSidebar: View {
             true
         case .idle, .loadingPage, .preparingPlayback, .ready, .failedPage:
             false
+        }
+    }
+
+    private var visualPhase: LoadingVisualPhase {
+        if model.presentedContext != nil {
+            switch model.state {
+            case .loading:
+                return .replacementLoading
+            case .failed:
+                return .failure
+            case .idle, .loadingPage, .preparingPlayback, .ready, .failedPage:
+                return .content
+            }
+        }
+
+        switch model.state {
+        case .idle:
+            return .idle
+        case .loading, .loadingPage, .preparingPlayback:
+            return .loading
+        case .failed, .failedPage:
+            return .failure
+        case .ready:
+            return .content
         }
     }
 

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/PlaybackContextSidebar.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/PlaybackContextSidebar.swift
@@ -250,9 +250,10 @@ public struct PlaybackContextSidebar: View {
     private var emptyState: some View {
         switch model.state {
         case .loading, .loadingPage, .preparingPlayback:
-            ProgressView("正在加载视频上下文…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .accessibilityIdentifier("sidebar.playback-loading")
+            PlaybackContextSidebarSkeleton(
+                loadingLabel: "正在加载视频上下文"
+            )
+            .accessibilityIdentifier("sidebar.playback-loading")
         case .failed(_, let failure), .failedPage(_, _, let failure):
             failureView(failure)
         case .idle:
@@ -270,12 +271,9 @@ public struct PlaybackContextSidebar: View {
     private var presentedContextOverlay: some View {
         switch model.state {
         case .loading:
-            ZStack {
-                Rectangle().fill(.background)
-                ProgressView("正在加载所选视频…")
-                    .controlSize(.large)
-            }
-            .accessibilityElement(children: .combine)
+            PlaybackContextSidebarSkeleton(
+                loadingLabel: "正在加载所选视频上下文"
+            )
             .accessibilityIdentifier("sidebar.playback-replacement-loading")
         case .failed(_, let failure):
             failureView(failure)

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/PlaybackDetailLayout.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/PlaybackDetailLayout.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct PlaybackDetailLayout<
+    Metadata: View,
+    Player: View,
+    Controls: View,
+    Related: View
+>: View {
+    private let metadata: Metadata
+    private let player: Player
+    private let controls: Controls
+    private let related: Related
+
+    init(
+        @ViewBuilder metadata: () -> Metadata,
+        @ViewBuilder player: () -> Player,
+        @ViewBuilder controls: () -> Controls,
+        @ViewBuilder related: () -> Related
+    ) {
+        self.metadata = metadata()
+        self.player = player()
+        self.controls = controls()
+        self.related = related()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: PlaybackPageLayout.sectionSpacing) {
+            metadata
+            player
+
+            Divider()
+            controls
+
+            related
+                .padding(
+                    .horizontal,
+                    -PlaybackPageLayout.horizontalContentPadding
+                )
+        }
+        .padding(
+            .horizontal,
+            PlaybackPageLayout.horizontalContentPadding
+        )
+        .padding(
+            .vertical,
+            PlaybackPageLayout.verticalContentPadding
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/RelatedVideoShelf.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/RelatedVideoShelf.swift
@@ -64,10 +64,32 @@ struct RelatedVideoShelf: View {
             header
                 .padding(.horizontal, Self.contentPadding)
 
-            content
+            ZStack(alignment: .topLeading) {
+                content
+                    .transition(.opacity)
+            }
+            .animation(
+                LoadingStateTransition.animation(reduceMotion: reduceMotion),
+                value: contentVisualPhase
+            )
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityIdentifier("related-videos.shelf")
+    }
+
+    private var contentVisualPhase: LoadingVisualPhase {
+        switch state {
+        case .loading:
+            .loading
+        case .loaded(let items) where items.isEmpty:
+            .empty
+        case .loaded:
+            .content
+        case .empty:
+            .empty
+        case .failure:
+            .failure
+        }
     }
 
     private var header: some View {

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoLoadingSkeletons.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoLoadingSkeletons.swift
@@ -4,33 +4,18 @@ struct VideoDetailSkeleton: View {
     let loadingLabel: String
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                metadata
-                player
-
-                Divider()
-                controls
-
-                RelatedVideoShelf(
-                    state: .loading,
-                    onSelect: { _ in },
-                    onRetry: {}
-                )
-                .padding(
-                    .horizontal,
-                    -PlaybackPageLayout.horizontalContentPadding
-                )
-            }
-            .padding(
-                .horizontal,
-                PlaybackPageLayout.horizontalContentPadding
+        PlaybackDetailLayout {
+            metadata
+        } player: {
+            player
+        } controls: {
+            controls
+        } related: {
+            RelatedVideoShelf(
+                state: .loading,
+                onSelect: { _ in },
+                onRetry: {}
             )
-            .padding(
-                .vertical,
-                PlaybackPageLayout.verticalContentPadding
-            )
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(.background)
         .accessibilityElement(children: .ignore)

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoLoadingSkeletons.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoLoadingSkeletons.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+
+struct VideoDetailSkeleton: View {
+    let loadingLabel: String
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                metadata
+                player
+
+                Divider()
+                controls
+
+                RelatedVideoShelf(
+                    state: .loading,
+                    onSelect: { _ in },
+                    onRetry: {}
+                )
+                .padding(
+                    .horizontal,
+                    -PlaybackPageLayout.horizontalContentPadding
+                )
+            }
+            .padding(
+                .horizontal,
+                PlaybackPageLayout.horizontalContentPadding
+            )
+            .padding(
+                .vertical,
+                PlaybackPageLayout.verticalContentPadding
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(.background)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(loadingLabel)
+    }
+
+    private var metadata: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            RoundedRectangle(cornerRadius: 5)
+                .fill(.quaternary)
+                .frame(maxWidth: 520)
+                .frame(height: 30)
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 16) {
+                    metadataItems
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    metadataItems
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var metadataItems: some View {
+        metadataItem(width: 120)
+        metadataItem(width: 84)
+        metadataItem(width: 84)
+        metadataItem(width: 104)
+    }
+
+    private func metadataItem(width: CGFloat) -> some View {
+        HStack(spacing: 7) {
+            Circle()
+                .fill(.quinary)
+                .frame(width: 14, height: 14)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quinary)
+                .frame(width: width, height: 14)
+        }
+    }
+
+    private var player: some View {
+        Rectangle()
+            .fill(.black)
+            .overlay {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(.white)
+            }
+            .aspectRatio(
+                PlaybackPageLayout.playerAspectRatio,
+                contentMode: .fit
+            )
+            .frame(maxWidth: .infinity)
+    }
+
+    private var controls: some View {
+        HStack(spacing: 16) {
+            RoundedRectangle(cornerRadius: 7)
+                .fill(.quaternary)
+                .frame(width: 92, height: 28)
+            RoundedRectangle(cornerRadius: 7)
+                .fill(.quaternary)
+                .frame(width: 108, height: 28)
+            Spacer()
+        }
+    }
+}
+
+struct PlaybackContextSidebarSkeleton: View {
+    let loadingLabel: String
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                sectionTitle(width: 64)
+                textLine()
+                textLine(width: 0.9)
+                textLine(width: 0.68)
+
+                Divider()
+
+                sectionTitle(width: 92)
+                ForEach(0..<3, id: \.self) { _ in
+                    partRow
+                }
+
+                Divider()
+
+                sectionTitle(width: 116)
+                textLine(width: 0.82)
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(.background)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(loadingLabel)
+    }
+
+    private func sectionTitle(width: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: 4)
+            .fill(.quaternary)
+            .frame(width: width, height: 18)
+    }
+
+    private func textLine(width: CGFloat = 1) -> some View {
+        GeometryReader { geometry in
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quinary)
+                .frame(width: geometry.size.width * width, height: 13)
+        }
+        .frame(height: 13)
+    }
+
+    private var partRow: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(.quinary)
+                .frame(width: 16, height: 16)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quinary)
+                .frame(width: 32, height: 14)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quaternary)
+                .frame(maxWidth: .infinity)
+                .frame(height: 14)
+        }
+        .frame(height: 32)
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoPlaybackView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoPlaybackView.swift
@@ -1,4 +1,5 @@
 import BiliApplication
+import BiliUI
 import SwiftUI
 
 /// 把视频准备状态连接到弹幕的播放 identity 生命周期。
@@ -6,6 +7,7 @@ import SwiftUI
 /// 详情上下文一旦可用就选择同一 BVID/CID；状态回到 idle/loading/failed 时 identity 变为
 /// `nil`，由 `.task(id:)` 完整 reset 弹幕支线。原生字幕由 AVPlayerEngine 随媒体 load 拥有。
 public struct VideoPlaybackView<PlayerContent: View>: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let model: GuestVideoViewModel
     private let danmakuModel: DanmakuControlsViewModel
     private let onRetry: () -> Void
@@ -45,11 +47,17 @@ public struct VideoPlaybackView<PlayerContent: View>: View {
                     .accessibilityHidden(blocksRetainedContext)
 
                     retainedContextOverlay
+                        .transition(.opacity)
                 }
             } else {
                 emptyState
+                    .transition(.opacity)
             }
         }
+        .animation(
+            LoadingStateTransition.animation(reduceMotion: reduceMotion),
+            value: visualPhase
+        )
         .task(id: playbackIdentity) {
             guard let playbackIdentity else {
                 danmakuModel.reset()
@@ -78,6 +86,30 @@ public struct VideoPlaybackView<PlayerContent: View>: View {
             true
         case .idle, .loadingPage, .preparingPlayback, .ready:
             false
+        }
+    }
+
+    private var visualPhase: LoadingVisualPhase {
+        if currentContext != nil {
+            switch model.state {
+            case .loading:
+                return .replacementLoading
+            case .failed, .failedPage:
+                return .failure
+            case .idle, .loadingPage, .preparingPlayback, .ready:
+                return .content
+            }
+        }
+
+        switch model.state {
+        case .idle:
+            return .idle
+        case .loading, .loadingPage:
+            return .loading
+        case .failed, .failedPage:
+            return .failure
+        case .preparingPlayback, .ready:
+            return .content
         }
     }
 

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoPlaybackView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoPlaybackView.swift
@@ -64,17 +64,19 @@ public struct VideoPlaybackView<PlayerContent: View>: View {
     }
 
     private var showsPlaybackActivity: Bool {
-        if case .preparingPlayback = model.state {
-            return true
+        switch model.state {
+        case .loadingPage, .preparingPlayback:
+            true
+        case .idle, .loading, .ready, .failed, .failedPage:
+            false
         }
-        return false
     }
 
     private var blocksRetainedContext: Bool {
         switch model.state {
-        case .loading, .loadingPage, .failed, .failedPage:
+        case .loading, .failed, .failedPage:
             true
-        case .idle, .preparingPlayback, .ready:
+        case .idle, .loadingPage, .preparingPlayback, .ready:
             false
         }
     }
@@ -89,9 +91,11 @@ public struct VideoPlaybackView<PlayerContent: View>: View {
                 description: Text("从热门或搜索结果中选择视频后，这里会显示详情与播放器。")
             )
             .accessibilityIdentifier("detail.empty")
-        case .loading, .loadingPage:
-            ProgressView("正在加载视频详情…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .loading:
+            VideoDetailSkeleton(loadingLabel: "正在加载视频详情")
+                .accessibilityIdentifier("playback.loading")
+        case .loadingPage:
+            VideoDetailSkeleton(loadingLabel: "正在加载所选分 P")
                 .accessibilityIdentifier("playback.loading")
         case .failed(_, let failure), .failedPage(_, _, let failure):
             BrowseFailureView(
@@ -108,15 +112,11 @@ public struct VideoPlaybackView<PlayerContent: View>: View {
     @ViewBuilder
     private var retainedContextOverlay: some View {
         switch model.state {
-        case .loading, .loadingPage:
-            ZStack {
-                Rectangle()
-                    .fill(.background)
-                ProgressView("正在加载所选视频…")
-                    .controlSize(.large)
-            }
-            .accessibilityElement(children: .combine)
-            .accessibilityIdentifier("playback.replacement.loading")
+        case .loading:
+            VideoDetailSkeleton(loadingLabel: "正在加载所选视频")
+                .accessibilityIdentifier("playback.replacement.loading")
+        case .loadingPage:
+            EmptyView()
         case .failed(_, let failure), .failedPage(_, _, let failure):
             BrowseFailureView(
                 title: failure.title,

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoPlaybackView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoPlaybackView.swift
@@ -31,24 +31,8 @@ public struct VideoPlaybackView<PlayerContent: View>: View {
     @ViewBuilder
     public var body: some View {
         Group {
-            if let currentContext {
-                ZStack {
-                    GuestVideoDetailView(
-                        context: currentContext,
-                        isPreparingPlayback: showsPlaybackActivity,
-                        danmakuModel: danmakuModel,
-                        relatedVideoState: model.relatedVideoState,
-                        onSelectRelatedVideo: onSelectRelatedVideo,
-                        onRetryRelatedVideos: model.retryRelatedVideos,
-                        playerContent: playerContent
-                    )
-                    .disabled(blocksRetainedContext)
-                    .allowsHitTesting(!blocksRetainedContext)
-                    .accessibilityHidden(blocksRetainedContext)
-
-                    retainedContextOverlay
-                        .transition(.opacity)
-                }
+            if usesDetailSurface {
+                detailSurface
             } else {
                 emptyState
                     .transition(.opacity)
@@ -65,6 +49,75 @@ public struct VideoPlaybackView<PlayerContent: View>: View {
             }
             danmakuModel.selectVideo(playbackIdentity)
         }
+    }
+
+    private var usesDetailSurface: Bool {
+        if currentContext != nil {
+            return true
+        }
+
+        switch model.state {
+        case .loading, .loadingPage:
+            return true
+        case .idle, .preparingPlayback, .ready, .failed, .failedPage:
+            return false
+        }
+    }
+
+    private var detailSurface: some View {
+        ScrollView {
+            detailSurfaceContent
+                .overlay(alignment: .topLeading) {
+                    if currentContext != nil, isLoadingReplacement {
+                        replacementLoadingOverlay
+                            .frame(
+                                maxWidth: .infinity,
+                                maxHeight: .infinity,
+                                alignment: .topLeading
+                            )
+                            .background(.background)
+                            .transition(.opacity)
+                    }
+                }
+        }
+        .overlay {
+            replacementFailureOverlay
+        }
+    }
+
+    private var isLoadingReplacement: Bool {
+        if case .loading = model.state {
+            return true
+        }
+        return false
+    }
+
+    @ViewBuilder
+    private var detailSurfaceContent: some View {
+        if let currentContext {
+            GuestVideoDetailView(
+                context: currentContext,
+                isPreparingPlayback: showsPlaybackActivity,
+                danmakuModel: danmakuModel,
+                relatedVideoState: model.relatedVideoState,
+                onSelectRelatedVideo: onSelectRelatedVideo,
+                onRetryRelatedVideos: model.retryRelatedVideos,
+                playerContent: playerContent
+            )
+            .disabled(blocksRetainedContext)
+            .allowsHitTesting(!blocksRetainedContext)
+            .accessibilityHidden(blocksRetainedContext)
+        } else {
+            VideoDetailSkeleton(loadingLabel: initialLoadingLabel)
+                .accessibilityIdentifier("playback.loading")
+        }
+    }
+
+    private var initialLoadingLabel: String {
+        if case .loadingPage = model.state {
+            return "正在加载所选分 P"
+        }
+        return "正在加载视频详情"
     }
 
     private var currentContext: GuestVideoContext? {
@@ -124,11 +177,9 @@ public struct VideoPlaybackView<PlayerContent: View>: View {
             )
             .accessibilityIdentifier("detail.empty")
         case .loading:
-            VideoDetailSkeleton(loadingLabel: "正在加载视频详情")
-                .accessibilityIdentifier("playback.loading")
+            EmptyView()
         case .loadingPage:
-            VideoDetailSkeleton(loadingLabel: "正在加载所选分 P")
-                .accessibilityIdentifier("playback.loading")
+            EmptyView()
         case .failed(_, let failure), .failedPage(_, _, let failure):
             BrowseFailureView(
                 title: failure.title,
@@ -142,24 +193,28 @@ public struct VideoPlaybackView<PlayerContent: View>: View {
     }
 
     @ViewBuilder
-    private var retainedContextOverlay: some View {
-        switch model.state {
-        case .loading:
-            VideoDetailSkeleton(loadingLabel: "正在加载所选视频")
-                .accessibilityIdentifier("playback.replacement.loading")
-        case .loadingPage:
-            EmptyView()
-        case .failed(_, let failure), .failedPage(_, _, let failure):
-            BrowseFailureView(
-                title: failure.title,
-                message: failure.message,
-                retry: retryAction
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(.background)
-            .accessibilityIdentifier("playback.replacement.failure")
-        case .idle, .preparingPlayback, .ready:
-            EmptyView()
+    private var replacementLoadingOverlay: some View {
+        VideoDetailSkeleton(loadingLabel: "正在加载所选视频")
+            .accessibilityIdentifier("playback.replacement.loading")
+    }
+
+    @ViewBuilder
+    private var replacementFailureOverlay: some View {
+        if currentContext != nil {
+            switch model.state {
+            case .failed(_, let failure), .failedPage(_, _, let failure):
+                BrowseFailureView(
+                    title: failure.title,
+                    message: failure.message,
+                    retry: retryAction
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(.background)
+                .accessibilityIdentifier("playback.replacement.failure")
+                .transition(.opacity)
+            case .idle, .loading, .loadingPage, .preparingPlayback, .ready:
+                EmptyView()
+            }
         }
     }
 

--- a/Packages/BiliKitCore/Sources/BiliLibraryFeature/History/WatchHistoryContentView.swift
+++ b/Packages/BiliKitCore/Sources/BiliLibraryFeature/History/WatchHistoryContentView.swift
@@ -4,12 +4,24 @@ import BiliUI
 import SwiftUI
 
 struct WatchHistoryContentView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let model: WatchHistoryViewModel
     @Binding var scrollPosition: ScrollPosition
     let onSelect: (String) -> Void
 
-    @ViewBuilder
     var body: some View {
+        ZStack {
+            content
+                .transition(.opacity)
+        }
+        .animation(
+            LoadingStateTransition.animation(reduceMotion: reduceMotion),
+            value: visualPhase
+        )
+    }
+
+    @ViewBuilder
+    private var content: some View {
         switch model.state {
         case .idle, .loading:
             VideoCardGridSkeleton(loadingLabel: "正在加载观看历史")
@@ -37,6 +49,19 @@ struct WatchHistoryContentView: View {
             )
         case .failed(let error):
             failure(error)
+        }
+    }
+
+    private var visualPhase: LoadingVisualPhase {
+        switch model.state {
+        case .idle, .loading:
+            .loading
+        case .loaded(let items, _, _) where items.isEmpty:
+            .empty
+        case .loaded, .loadingMore:
+            .content
+        case .failed:
+            .failure
         }
     }
 
@@ -107,10 +132,20 @@ struct WatchHistoryContentView: View {
                 if canLoadMore {
                     HStack {
                         Spacer()
-                        Button(isLoadingMore ? "正在加载…" : "加载更多") {
+                        Button {
                             model.loadMore()
+                        } label: {
+                            Text(isLoadingMore ? "正在加载…" : "加载更多")
+                                .contentTransition(.opacity)
+                                .frame(minWidth: 80)
                         }
                         .disabled(isLoadingMore)
+                        .animation(
+                            LoadingStateTransition.animation(
+                                reduceMotion: reduceMotion
+                            ),
+                            value: isLoadingMore
+                        )
                         .accessibilityIdentifier("history.load-more")
                         Spacer()
                     }

--- a/Packages/BiliKitCore/Sources/BiliLibraryFeature/History/WatchHistoryContentView.swift
+++ b/Packages/BiliKitCore/Sources/BiliLibraryFeature/History/WatchHistoryContentView.swift
@@ -12,8 +12,7 @@ struct WatchHistoryContentView: View {
     var body: some View {
         switch model.state {
         case .idle, .loading:
-            ProgressView("正在加载观看历史…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            VideoCardGridSkeleton(loadingLabel: "正在加载观看历史")
                 .accessibilityIdentifier("history.loading")
         case .loaded(let items, let continuation, let loadMoreError):
             if items.isEmpty {

--- a/Packages/BiliKitCore/Sources/BiliUI/LoadingStateTransition.swift
+++ b/Packages/BiliKitCore/Sources/BiliUI/LoadingStateTransition.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+/// 主要加载状态共用的克制淡入淡出语言。
+package enum LoadingStateTransition {
+    package static func animation(reduceMotion: Bool) -> Animation? {
+        reduceMotion ? nil : .easeOut(duration: 0.16)
+    }
+}
+
+/// 只表达视觉阶段，不携带内容或请求 identity，避免数据刷新触发整页动画。
+package enum LoadingVisualPhase: Equatable {
+    case idle
+    case loading
+    case replacementLoading
+    case content
+    case empty
+    case failure
+    case transitioning
+}

--- a/Packages/BiliKitCore/Sources/BiliUI/VideoCard.swift
+++ b/Packages/BiliKitCore/Sources/BiliUI/VideoCard.swift
@@ -11,6 +11,8 @@ package struct VideoCardMetric: Sendable, Equatable {
 }
 
 package struct VideoCard: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private let coverURL: URL?
     private let avatarURL: URL?
     private let showsAvatar: Bool
@@ -56,15 +58,20 @@ package struct VideoCard: View {
     private var cover: some View {
         Color.secondary.opacity(0.12)
             .overlay {
-                AsyncImage(url: coverURL) { phase in
+                AsyncImage(
+                    url: coverURL,
+                    transaction: imageLoadingTransaction
+                ) { phase in
                     switch phase {
                     case .success(let image):
                         image
                             .resizable()
                             .scaledToFill()
+                            .transition(.opacity)
                     default:
                         Image(systemName: "photo")
                             .foregroundStyle(.tertiary)
+                            .transition(.opacity)
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -100,19 +107,32 @@ package struct VideoCard: View {
     }
 
     private var avatar: some View {
-        AsyncImage(url: avatarURL) { phase in
+        AsyncImage(
+            url: avatarURL,
+            transaction: imageLoadingTransaction
+        ) { phase in
             switch phase {
             case .success(let image):
                 image
                     .resizable()
                     .scaledToFill()
+                    .transition(.opacity)
             default:
                 Image(systemName: "person.crop.circle.fill")
                     .resizable()
                     .foregroundStyle(.quaternary)
+                    .transition(.opacity)
             }
         }
         .accessibilityHidden(true)
+    }
+
+    private var imageLoadingTransaction: Transaction {
+        Transaction(
+            animation: LoadingStateTransition.animation(
+                reduceMotion: reduceMotion
+            )
+        )
     }
 
     private var titleContent: some View {

--- a/Packages/BiliKitCore/Sources/BiliUI/VideoCard.swift
+++ b/Packages/BiliKitCore/Sources/BiliUI/VideoCard.swift
@@ -41,16 +41,20 @@ package struct VideoCard: View {
     }
 
     package var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VideoCardLayout(showsLeading: showsAvatar) {
             cover
-            details
+        } leading: {
+            avatar
+        } title: {
+            titleContent
+        } footer: {
+            footer
         }
         .accessibilityElement(children: .combine)
     }
 
     private var cover: some View {
         Color.secondary.opacity(0.12)
-            .aspectRatio(16 / 9, contentMode: .fit)
             .overlay {
                 AsyncImage(url: coverURL) { phase in
                     switch phase {
@@ -93,48 +97,42 @@ package struct VideoCard: View {
                     .accessibilityHidden(true)
                 )
             }
-            .clipShape(RoundedRectangle(cornerRadius: 10))
     }
 
-    private var details: some View {
-        HStack(alignment: .top, spacing: 10) {
-            if showsAvatar {
-                AsyncImage(url: avatarURL) { phase in
-                    switch phase {
-                    case .success(let image):
-                        image
-                            .resizable()
-                            .scaledToFill()
-                    default:
-                        Image(systemName: "person.crop.circle.fill")
-                            .resizable()
-                            .foregroundStyle(.quaternary)
-                    }
-                }
-                .frame(width: 34, height: 34)
-                .clipShape(Circle())
-                .accessibilityHidden(true)
-            }
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text(title)
-                    .font(.title3.weight(.medium))
-                    .lineLimit(2, reservesSpace: true)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                HStack(spacing: 8) {
-                    Text(footerLeadingText)
-                        .lineLimit(1)
-                    if let footerTrailingText {
-                        Spacer(minLength: 8)
-                        Text(footerTrailingText)
-                            .lineLimit(1)
-                            .monospacedDigit()
-                    }
-                }
-                .font(.body)
-                .foregroundStyle(.secondary)
+    private var avatar: some View {
+        AsyncImage(url: avatarURL) { phase in
+            switch phase {
+            case .success(let image):
+                image
+                    .resizable()
+                    .scaledToFill()
+            default:
+                Image(systemName: "person.crop.circle.fill")
+                    .resizable()
+                    .foregroundStyle(.quaternary)
             }
         }
+        .accessibilityHidden(true)
+    }
+
+    private var titleContent: some View {
+        Text(title)
+            .font(.title3.weight(.medium))
+            .lineLimit(2, reservesSpace: true)
+    }
+
+    private var footer: some View {
+        HStack(spacing: 8) {
+            Text(footerLeadingText)
+                .lineLimit(1)
+            if let footerTrailingText {
+                Spacer(minLength: 8)
+                Text(footerTrailingText)
+                    .lineLimit(1)
+                    .monospacedDigit()
+            }
+        }
+        .font(.body)
+        .foregroundStyle(.secondary)
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliUI/VideoCardGridSkeleton.swift
+++ b/Packages/BiliKitCore/Sources/BiliUI/VideoCardGridSkeleton.swift
@@ -34,30 +34,27 @@ package struct VideoCardGridSkeleton: View {
 
 private struct VideoCardSkeleton: View {
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            RoundedRectangle(cornerRadius: 10)
+        VideoCardLayout(showsLeading: true) {
+            Rectangle()
                 .fill(.quaternary)
-                .aspectRatio(16 / 9, contentMode: .fit)
-
-            HStack(alignment: .top, spacing: 10) {
-                Circle()
+        } leading: {
+            Circle()
+                .fill(.quaternary)
+        } title: {
+            VStack(alignment: .leading, spacing: 8) {
+                RoundedRectangle(cornerRadius: 4)
                     .fill(.quaternary)
-                    .frame(width: 34, height: 34)
-
-                VStack(alignment: .leading, spacing: 8) {
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(.quaternary)
-                        .frame(height: 18)
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(.quaternary)
-                        .frame(maxWidth: 180)
-                        .frame(height: 18)
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(.quinary)
-                        .frame(maxWidth: 130)
-                        .frame(height: 14)
-                }
+                    .frame(height: 18)
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(.quaternary)
+                    .frame(maxWidth: 180)
+                    .frame(height: 18)
             }
+        } footer: {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(.quinary)
+                .frame(maxWidth: 130)
+                .frame(height: 14)
         }
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliUI/VideoCardGridSkeleton.swift
+++ b/Packages/BiliKitCore/Sources/BiliUI/VideoCardGridSkeleton.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// 与生产视频卡片网格保持相同列数、间距和内容边距的首载骨架。
+package struct VideoCardGridSkeleton: View {
+    private let loadingLabel: String
+
+    package init(loadingLabel: String) {
+        self.loadingLabel = loadingLabel
+    }
+
+    package var body: some View {
+        GeometryReader { geometry in
+            ScrollView {
+                LazyVGrid(
+                    columns: VideoCardGridLayout.columns(
+                        for: geometry.size.width
+                    ),
+                    alignment: .leading,
+                    spacing: VideoCardGridLayout.verticalSpacing
+                ) {
+                    ForEach(0..<12, id: \.self) { _ in
+                        VideoCardSkeleton()
+                    }
+                }
+                .padding(VideoCardGridLayout.contentPadding)
+            }
+            .scrollDisabled(true)
+            .scrollIndicators(.hidden)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(loadingLabel)
+    }
+}
+
+private struct VideoCardSkeleton: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(.quaternary)
+                .aspectRatio(16 / 9, contentMode: .fit)
+
+            HStack(alignment: .top, spacing: 10) {
+                Circle()
+                    .fill(.quaternary)
+                    .frame(width: 34, height: 34)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(.quaternary)
+                        .frame(height: 18)
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(.quaternary)
+                        .frame(maxWidth: 180)
+                        .frame(height: 18)
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(.quinary)
+                        .frame(maxWidth: 130)
+                        .frame(height: 14)
+                }
+            }
+        }
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliUI/VideoCardLayout.swift
+++ b/Packages/BiliKitCore/Sources/BiliUI/VideoCardLayout.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct VideoCardLayout<
+    Cover: View,
+    Leading: View,
+    Title: View,
+    Footer: View
+>: View {
+    private let showsLeading: Bool
+    private let cover: Cover
+    private let leading: Leading
+    private let title: Title
+    private let footer: Footer
+
+    init(
+        showsLeading: Bool,
+        @ViewBuilder cover: () -> Cover,
+        @ViewBuilder leading: () -> Leading,
+        @ViewBuilder title: () -> Title,
+        @ViewBuilder footer: () -> Footer
+    ) {
+        self.showsLeading = showsLeading
+        self.cover = cover()
+        self.leading = leading()
+        self.title = title()
+        self.footer = footer()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            cover
+                .aspectRatio(16 / 9, contentMode: .fit)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            HStack(alignment: .top, spacing: 10) {
+                if showsLeading {
+                    leading
+                        .frame(width: 34, height: 34)
+                        .clipShape(Circle())
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    title
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    footer
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
> Stacked PR：当前以 #32 的 `codex/related-recommendations` 为 base；#32 合并后应将 base 改回 `main`。

## 变化

- 用骨架屏替换热门、搜索、历史、详情和播放侧栏的主要加载状态。
- 统一 loading/content/empty/failure/replacement loading 的克制过渡，并尊重 Reduce Motion。
- 让真实卡片与骨架共享布局 primitive，降低后续修改产生几何漂移的风险。
- 统一详情布局与滚动容器；A→B replacement loading 保留当前滚动位置，失败/retry 固定在可见 viewport。
- 为卡片远端封面和头像增加原位淡入，不改变卡片尺寸。

## 原因与用户影响

真实相关推荐接入后，详情、播放和图片加载的状态差异变得更明显。此次调整让加载过程保持稳定几何，减少 ProgressView、内容突现和滚动位置变化造成的割裂，同时保证 UI 状态变化不会重建 player host 或中断时间轴。

## 边界

- 不加入 blurhash、预取缓存或新的图片管线。
- 不显示 synthetic 生产内容；fixture 仍限制在 Debug/UITest/Preview。
- 共享抽象仅覆盖已有真实消费者，不预建首页视频流或通用 Utils。

## 验证

- 在该 stacked 分支精确运行 `sh Scripts/run-quality-gates.sh app`：static、Swift Package、App build-for-testing、App unit tests 全部通过。
- 覆盖窄 detail 列响应式骨架、底部 A→B replacement、failure/retry viewport、滚动 owner/offset 和 player continuity。
- 实施阶段经过布局、生命周期和 UI/测试独立审查；发现项修复并复审关闭后无 P0–P3。

## 未覆盖边界

- 自动化验证不等同于所有窗口尺寸、Reduce Motion 和 VoiceOver 的完整人工矩阵。
- 远端图片淡入依赖实际网络时序，未引入针对动画帧的脆弱截图测试。