### PR TITLE
fix(playback): 消除播放偏好并发警告

### DIFF
--- a/BiliKitMac/Platform/PlaybackPreferencesController.swift
+++ b/BiliKitMac/Platform/PlaybackPreferencesController.swift
@@ -14,14 +14,17 @@ struct PlaybackPreferences: Equatable, Sendable {
     let preferredRate: Float
 }
 
-protocol PlaybackPreferencesStoring: AnyObject {
+protocol PlaybackPreferencesStoring: AnyObject, Sendable {
     func load() -> PlaybackPreferences
     func saveVolume(_ volume: Float)
     func saveMuted(_ isMuted: Bool)
     func savePreferredRate(_ rate: Float)
 }
 
-final class UserDefaultsPlaybackPreferencesStore: PlaybackPreferencesStoring {
+/// `UserDefaults` 官方保证线程安全，但当前 SDK 尚未声明其为 `Sendable`。
+final class UserDefaultsPlaybackPreferencesStore:
+    PlaybackPreferencesStoring, @unchecked Sendable
+{
     private enum Key {
         static let volume = "player.volume"
         static let isMuted = "player.isMuted"


### PR DESCRIPTION
## 变化

- 将 `PlaybackPreferencesStoring` 的线程安全约束集中到受控的 Sendable 边界。
- 消除 `PlaybackPreferencesController.swift` 中 `@Sendable` closure 捕获 non-Sendable store 的 Swift 6 警告。
- 保持现有 MainActor 控制器、读取/写入行为和持久化格式不变。

## 原因

该 store 由现有同步实现提供线程安全保证，但协议类型没有把这一事实表达给 Swift 并发检查器，导致闭包捕获产生警告。修复只补足并发契约，不改变运行时所有权。

## 风险与用户影响

- 不改变播放偏好 UI 或数据。
- `@unchecked Sendable` 仅包裹已有 store 引用；安全性依赖 store 实现继续保持同步线程安全，因此边界被限制在单个适配器中。

## 验证

- 在从 `main` 创建的独立单 commit 分支运行 `sh Scripts/run-quality-gates.sh app`：static、Swift Package、App build-for-testing、App unit tests 全部通过。
- 实施阶段独立审查未发现 P0–P3。