### PR TITLE
feat(auth): 在侧栏显示真实账户身份

### DIFF
--- a/BiliKitMac/App/AppRootView.swift
+++ b/BiliKitMac/App/AppRootView.swift
@@ -77,9 +77,16 @@ struct AppRootView: View {
             authenticationModel.restoreIfNeeded()
             await authenticationModel.waitForCurrentTask()
         }
-        .onChange(of: authenticationModel.isSignedIn) { _, isSignedIn in
+        .onChange(of: authenticationModel.sessionPhase) {
+            previousPhase,
+            phase in
+            guard previousPhase != .unresolved, phase != .unresolved,
+                previousPhase != phase
+            else {
+                return
+            }
             navigationCoordinator.closePlaybackForAuthenticationChange()
-            if !isSignedIn {
+            if phase == .signedOut {
                 historyModel.reset()
             }
         }

--- a/BiliKitMac/App/AppShellView.swift
+++ b/BiliKitMac/App/AppShellView.swift
@@ -43,7 +43,7 @@ struct AppShellView: View {
                 } else {
                     AppNavigationSidebar(
                         selection: $navigationCoordinator.selectedTab,
-                        isSignedIn: authenticationModel.isSignedIn,
+                        accountState: authenticationModel.accountPresentationState,
                         onPresentAuthentication: {
                             isAuthenticationPresented = true
                         }
@@ -82,10 +82,14 @@ struct AppShellView: View {
             guard previousQuery != query else { return }
             searchScrollPosition = ScrollPosition(idType: String.self)
         }
-        .onChange(of: authenticationModel.isSignedIn) {
-            previousIsSignedIn,
-            isSignedIn in
-            guard previousIsSignedIn != isSignedIn else { return }
+        .onChange(of: authenticationModel.sessionPhase) {
+            previousPhase,
+            phase in
+            guard previousPhase != .unresolved, phase != .unresolved,
+                previousPhase != phase
+            else {
+                return
+            }
             historyScrollPosition = ScrollPosition(idType: String.self)
         }
     }
@@ -147,7 +151,7 @@ struct AppShellView: View {
         case .history:
             HistoryTabRoot(
                 model: historyModel,
-                isSignedIn: authenticationModel.isSignedIn,
+                accountState: authenticationModel.accountPresentationState,
                 scrollPosition: $historyScrollPosition,
                 onSelect: navigationCoordinator.openPlayback,
                 onPresentAuthentication: {

--- a/BiliKitMac/App/AppSidebarViews.swift
+++ b/BiliKitMac/App/AppSidebarViews.swift
@@ -1,9 +1,10 @@
+import BiliAuthFeature
 import SwiftUI
 
 /// 使用系统 Sidebar List 表达窗口内当前可用的平级来源。
 struct AppNavigationSidebar: View {
     @Binding var selection: AppTab
-    let isSignedIn: Bool
+    let accountState: AccountPresentationState
     let onPresentAuthentication: () -> Void
 
     var body: some View {
@@ -51,7 +52,7 @@ struct AppNavigationSidebar: View {
             HStack(spacing: 12) {
                 accountAvatar
 
-                Text(isSignedIn ? "账号" : "登录")
+                Text(accountTitle)
 
                 Spacer(minLength: 0)
             }
@@ -61,8 +62,32 @@ struct AppNavigationSidebar: View {
         .buttonStyle(.plain)
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
-        .accessibilityHint(isSignedIn ? "打开账号管理" : "打开扫码登录")
+        .accessibilityHint(accountAccessibilityHint)
         .accessibilityIdentifier("sidebar.account")
+    }
+
+    private var accountTitle: String {
+        switch accountState {
+        case .resolving, .unavailable:
+            "账号"
+        case .signedOut:
+            "登录"
+        case .signedIn:
+            "账号"
+        }
+    }
+
+    private var accountAccessibilityHint: String {
+        switch accountState {
+        case .resolving:
+            "正在检查本机登录状态"
+        case .unavailable:
+            "打开账号以重试恢复"
+        case .signedOut:
+            "打开扫码登录"
+        case .signedIn:
+            "打开账号管理"
+        }
     }
 
     private var accountAvatar: some View {

--- a/BiliKitMac/App/AppSidebarViews.swift
+++ b/BiliKitMac/App/AppSidebarViews.swift
@@ -7,6 +7,15 @@ struct AppNavigationSidebar: View {
     let onPresentAuthentication: () -> Void
 
     var body: some View {
+        VStack(spacing: 0) {
+            navigationList
+            accountBar
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("sidebar.navigation")
+    }
+
+    private var navigationList: some View {
         List(selection: selectionBinding) {
             Label("搜索", systemImage: "magnifyingglass")
                 .tag(AppTab.search)
@@ -21,12 +30,10 @@ struct AppNavigationSidebar: View {
                 .accessibilityIdentifier("sidebar.history")
         }
         .listStyle(.sidebar)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            Divider()
-            accountButton
-        }
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("sidebar.navigation")
+    }
+
+    private var accountBar: some View {
+        accountButton
     }
 
     private var selectionBinding: Binding<AppTab?> {
@@ -41,10 +48,8 @@ struct AppNavigationSidebar: View {
 
     private var accountButton: some View {
         Button(action: onPresentAuthentication) {
-            HStack(spacing: 10) {
-                Image(systemName: "person.crop.circle.fill")
-                    .font(.title2)
-                    .symbolRenderingMode(.hierarchical)
+            HStack(spacing: 12) {
+                accountAvatar
 
                 Text(isSignedIn ? "账号" : "登录")
 
@@ -54,9 +59,19 @@ struct AppNavigationSidebar: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, 14)
+        .padding(.horizontal, 16)
         .padding(.vertical, 10)
         .accessibilityHint(isSignedIn ? "打开账号管理" : "打开扫码登录")
         .accessibilityIdentifier("sidebar.account")
+    }
+
+    private var accountAvatar: some View {
+        Image(systemName: "person.crop.circle.fill")
+            .resizable()
+            .scaledToFit()
+            .symbolRenderingMode(.hierarchical)
+            .frame(width: 32, height: 32)
+            .clipShape(Circle())
+            .accessibilityHidden(true)
     }
 }

--- a/BiliKitMac/App/AppSidebarViews.swift
+++ b/BiliKitMac/App/AppSidebarViews.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 /// 使用系统 Sidebar List 表达窗口内当前可用的平级来源。
 struct AppNavigationSidebar: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Binding var selection: AppTab
     let accountState: AccountPresentationState
     let onPresentAuthentication: () -> Void
@@ -53,6 +54,8 @@ struct AppNavigationSidebar: View {
                 accountAvatar
 
                 Text(accountTitle)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
 
                 Spacer(minLength: 0)
             }
@@ -73,7 +76,7 @@ struct AppNavigationSidebar: View {
         case .signedOut:
             "登录"
         case .signedIn:
-            "账号"
+            accountState.displayName ?? "账号"
         }
     }
 
@@ -91,12 +94,42 @@ struct AppNavigationSidebar: View {
     }
 
     private var accountAvatar: some View {
+        Group {
+            if let avatarURL = accountState.avatarURL {
+                AsyncImage(
+                    url: avatarURL,
+                    transaction: avatarLoadingTransaction
+                ) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .transition(.opacity)
+                    default:
+                        fallbackAvatar
+                            .transition(.opacity)
+                    }
+                }
+            } else {
+                fallbackAvatar
+            }
+        }
+        .frame(width: 32, height: 32)
+        .clipShape(Circle())
+        .accessibilityHidden(true)
+    }
+
+    private var fallbackAvatar: some View {
         Image(systemName: "person.crop.circle.fill")
             .resizable()
             .scaledToFit()
             .symbolRenderingMode(.hierarchical)
-            .frame(width: 32, height: 32)
-            .clipShape(Circle())
-            .accessibilityHidden(true)
+    }
+
+    private var avatarLoadingTransaction: Transaction {
+        Transaction(
+            animation: reduceMotion ? nil : .easeOut(duration: 0.16)
+        )
     }
 }

--- a/BiliKitMac/App/AppSourceRootViews.swift
+++ b/BiliKitMac/App/AppSourceRootViews.swift
@@ -59,7 +59,7 @@ struct SearchTabRoot: View {
 
 struct HistoryTabRoot: View {
     let model: WatchHistoryViewModel
-    let isSignedIn: Bool
+    let accountState: AccountPresentationState
     @Binding var scrollPosition: ScrollPosition
     let onSelect: (String) -> Void
     let onPresentAuthentication: () -> Void
@@ -69,7 +69,7 @@ struct HistoryTabRoot: View {
         content
             .navigationTitle("观看历史")
             .toolbar {
-                if isSignedIn {
+                if case .signedIn = accountState {
                     ToolbarItem(placement: .primaryAction) {
                         HistoryRefreshButton(model: model)
                     }
@@ -79,14 +79,15 @@ struct HistoryTabRoot: View {
 
     @ViewBuilder
     private var content: some View {
-        if isSignedIn {
+        switch accountState {
+        case .signedIn:
             WatchHistoryView(
                 model: model,
                 scrollPosition: $scrollPosition,
                 onSelect: onSelect,
                 onAuthenticationRequired: onAuthenticationRequired
             )
-        } else {
+        case .signedOut:
             ContentUnavailableView {
                 Label("登录后查看观看历史", systemImage: "person.crop.circle")
             } description: {
@@ -98,6 +99,24 @@ struct HistoryTabRoot: View {
                     .accessibilityIdentifier("history.login")
             }
             .accessibilityIdentifier("history.signed-out")
+        case .resolving:
+            ProgressView("正在检查登录状态…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .accessibilityIdentifier("history.restoring")
+        case .unavailable:
+            ContentUnavailableView {
+                Label(
+                    "暂时无法确认登录状态",
+                    systemImage: "person.crop.circle.badge.exclamationmark"
+                )
+            } description: {
+                Text("本机登录状态没有被自动清除，请在账号页面重试。")
+            } actions: {
+                Button("查看账号状态", action: onPresentAuthentication)
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier("history.authentication-status")
+            }
+            .accessibilityIdentifier("history.authentication-unavailable")
         }
     }
 }

--- a/BiliKitMac/Composition/UITestContentView.swift
+++ b/BiliKitMac/Composition/UITestContentView.swift
@@ -26,6 +26,9 @@
                 && arguments.contains(
                     "-ui-testing-single-part-empty-summary"
                 )
+            let usesAccountIdentity =
+                arguments.contains("-ui-testing")
+                && arguments.contains("-ui-testing-account-identity")
             let sourceRequests = UITestSourceRequestRecorder()
             _sourceRequests = State(initialValue: sourceRequests)
             dynamicTypeSize =
@@ -55,6 +58,10 @@
             let authenticationModel = AuthenticationViewModel(
                 service: UITestAuthenticationService(
                     restoresSignedIn: usesContextualNavigator
+                        || usesAccountIdentity,
+                    identity: usesAccountIdentity
+                        ? Self.accountIdentityFixture
+                        : nil
                 ),
                 qrCodeProvider: UITestQRCodeProvider()
             )
@@ -141,6 +148,12 @@
                 )
             )
         }
+
+        private static let accountIdentityFixture = AccountIdentity(
+            id: 42,
+            displayName: "Fixture Account",
+            avatarURL: nil
+        )
     }
 
     private struct UITestGuestRepository: GuestContentRepository {
@@ -317,9 +330,10 @@
 
     private struct UITestAuthenticationService: AuthenticationServicing {
         let restoresSignedIn: Bool
+        let identity: AccountIdentity?
 
         func restore() async -> AuthenticationState {
-            restoresSignedIn ? .signedIn(nil) : .signedOut
+            restoresSignedIn ? .signedIn(identity) : .signedOut
         }
         func requestQRCode() async -> AuthenticationState { .signedOut }
         func pollOnce() async -> AuthenticationState { .signedOut }

--- a/BiliKitMac/Composition/UITestContentView.swift
+++ b/BiliKitMac/Composition/UITestContentView.swift
@@ -319,7 +319,7 @@
         let restoresSignedIn: Bool
 
         func restore() async -> AuthenticationState {
-            restoresSignedIn ? .signedIn : .signedOut
+            restoresSignedIn ? .signedIn(nil) : .signedOut
         }
         func requestQRCode() async -> AuthenticationState { .signedOut }
         func pollOnce() async -> AuthenticationState { .signedOut }

--- a/BiliKitMacTests/VideoDetailLifecycleTests.swift
+++ b/BiliKitMacTests/VideoDetailLifecycleTests.swift
@@ -397,9 +397,9 @@ struct VideoDetailLifecycleTests {
         window.contentView = NSView()
     }
 
-    @Test
+    @Test(.timeLimit(.minutes(1)))
     @MainActor
-    func authenticationChangeClosesPlaybackWithoutImplicitRestore() async {
+    func onlyResolvedAuthenticationBoundaryClosesPlayback() async throws {
         let fixture = VideoDetailLifecycleFixture()
         let repository = VideoDetailLifecycleRepository(fixture: fixture)
         let playback = RecordingLifecyclePlayback()
@@ -414,7 +414,8 @@ struct VideoDetailLifecycleTests {
             presentation: RecordingPresentation()
         )
         let authenticationService = LifecycleAuthenticationService(
-            restoreState: .signedOut
+            restoreState: .signedIn(nil),
+            blocksFirstRestore: true
         )
         let authenticationModel = AuthenticationViewModel(
             service: authenticationService,
@@ -453,9 +454,8 @@ struct VideoDetailLifecycleTests {
         )
         window.contentView = hostingView
         window.layoutIfNeeded()
-        await Task.yield()
-        await authenticationModel.waitForCurrentTask()
-        #expect(!authenticationModel.isSignedIn)
+        try await authenticationService.waitForFirstRestoreStart()
+        #expect(authenticationModel.sessionState == .unresolved)
 
         coordinator.openPlayback(fixture.bvid)
         await videoModel.waitForCurrentTask()
@@ -466,20 +466,39 @@ struct VideoDetailLifecycleTests {
             }
         )
 
-        let loadCountBeforeSignIn = playback.loadedIdentities.count
-        let stopCountBeforeSignIn = playback.stopCallCount
-        await authenticationService.setRestoreState(.signedIn)
+        let loadCountBeforeRestore = playback.loadedIdentities.count
+        let stopCountBeforeRestore = playback.stopCallCount
+        await authenticationService.releaseFirstRestore()
+        await authenticationModel.waitForCurrentTask()
+        #expect(authenticationModel.sessionState == .signedIn(nil))
+        #expect(coordinator.currentPlaybackBVID == fixture.bvid)
+        #expect(playback.loadedIdentities.count == loadCountBeforeRestore)
+        #expect(playback.stopCallCount == stopCountBeforeRestore)
+
+        let identity = AccountIdentity(
+            id: 42,
+            displayName: "测试账号",
+            avatarURL: nil
+        )
+        await authenticationService.setRestoreState(.signedIn(identity))
+        let stopCountBeforeIdentity = playback.stopCallCount
         authenticationModel.revalidate()
+        await authenticationModel.waitForCurrentTask()
+        #expect(authenticationModel.sessionState == .signedIn(identity))
+        #expect(coordinator.currentPlaybackBVID == fixture.bvid)
+        #expect(playback.stopCallCount == stopCountBeforeIdentity)
+
+        let stopCountBeforeLogout = playback.stopCallCount
+        authenticationModel.logout()
         await authenticationModel.waitForCurrentTask()
         #expect(
             await waitUntil {
-                authenticationModel.isSignedIn
+                authenticationModel.sessionState == .signedOut
                     && videoModel.state == .idle
                     && coordinator.currentPlaybackBVID == nil
             }
         )
-        #expect(playback.loadedIdentities.count == loadCountBeforeSignIn)
-        #expect(playback.stopCallCount == stopCountBeforeSignIn + 1)
+        #expect(playback.stopCallCount == stopCountBeforeLogout + 1)
 
         coordinator.openPlayback(fixture.bvid)
         await videoModel.waitForCurrentTask()
@@ -492,20 +511,21 @@ struct VideoDetailLifecycleTests {
                     && coordinator.currentPlaybackBVID == fixture.bvid
             }
         )
-        let loadCountBeforeLogout = playback.loadedIdentities.count
-        let stopCountBeforeLogout = playback.stopCallCount
+        let loadCountBeforeSignIn = playback.loadedIdentities.count
+        let stopCountBeforeSignIn = playback.stopCallCount
 
-        authenticationModel.logout()
+        await authenticationService.setRestoreState(.signedIn(identity))
+        authenticationModel.revalidate()
         await authenticationModel.waitForCurrentTask()
         #expect(
             await waitUntil {
-                !authenticationModel.isSignedIn
+                authenticationModel.sessionState == .signedIn(identity)
                     && videoModel.state == .idle
                     && coordinator.currentPlaybackBVID == nil
             }
         )
-        #expect(playback.loadedIdentities.count == loadCountBeforeLogout)
-        #expect(playback.stopCallCount == stopCountBeforeLogout + 1)
+        #expect(playback.loadedIdentities.count == loadCountBeforeSignIn)
+        #expect(playback.stopCallCount == stopCountBeforeSignIn + 1)
 
         window.contentView = NSView()
     }
@@ -1001,16 +1021,60 @@ private final class RecordingPresentation: DanmakuPresentationControlling {
 
 private actor LifecycleAuthenticationService: AuthenticationServicing {
     private var restoreState: AuthenticationState
+    private let blocksFirstRestore: Bool
+    private var restoreCount = 0
+    private var firstRestoreStarted = false
+    private var firstRestoreReleased = false
+    private var restoreStartWaiters: [CheckedContinuation<Void, Never>] = []
+    private var restoreReleaseWaiters: [CheckedContinuation<Void, Never>] = []
 
-    init(restoreState: AuthenticationState) {
+    init(
+        restoreState: AuthenticationState,
+        blocksFirstRestore: Bool = false
+    ) {
         self.restoreState = restoreState
+        self.blocksFirstRestore = blocksFirstRestore
     }
 
     func setRestoreState(_ state: AuthenticationState) {
         restoreState = state
     }
 
-    func restore() async -> AuthenticationState { restoreState }
+    func restore() async -> AuthenticationState {
+        restoreCount += 1
+        if blocksFirstRestore, restoreCount == 1 {
+            firstRestoreStarted = true
+            resume(&restoreStartWaiters)
+            await withCheckedContinuation { continuation in
+                if firstRestoreReleased {
+                    continuation.resume()
+                } else {
+                    restoreReleaseWaiters.append(continuation)
+                }
+            }
+        }
+        return restoreState
+    }
+
+    func waitForFirstRestoreStart() async throws {
+        if firstRestoreStarted { return }
+        await withCheckedContinuation { continuation in
+            restoreStartWaiters.append(continuation)
+        }
+    }
+
+    func releaseFirstRestore() {
+        firstRestoreReleased = true
+        resume(&restoreReleaseWaiters)
+    }
+
+    private func resume(_ waiters: inout [CheckedContinuation<Void, Never>]) {
+        let pending = waiters
+        waiters.removeAll(keepingCapacity: false)
+        for waiter in pending {
+            waiter.resume()
+        }
+    }
     func requestQRCode() async -> AuthenticationState { .signedOut }
     func pollOnce() async -> AuthenticationState { .signedOut }
     func finalizeLogin() async -> AuthenticationState { .signedOut }

--- a/BiliKitMacUITests/BiliKitMacUITests.swift
+++ b/BiliKitMacUITests/BiliKitMacUITests.swift
@@ -7,6 +7,21 @@ final class BiliKitMacUITests: XCTestCase {
     }
 
     @MainActor
+    func testConfirmedAccountIdentityAppearsInStableSidebarAccountSlot() {
+        let app = launchFixture(
+            arguments: [
+                "-ui-testing",
+                "-ui-testing-account-identity",
+            ]
+        )
+        let account = element("sidebar.account", in: app)
+
+        XCTAssertTrue(waitForHittable(account, timeout: 5))
+        XCTAssertEqual(account.label, "Fixture Account")
+        XCTAssertFalse(app.buttons["登录"].exists)
+    }
+
+    @MainActor
     func testPlaybackRoundTripInOneWindow() throws {
         let app = XCUIApplication()
         app.launchArguments = [

--- a/Packages/BiliKitCore/Package.swift
+++ b/Packages/BiliKitCore/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .target(name: "BiliNetworking"),
         .target(
             name: "BiliAuth",
-            dependencies: ["BiliApplication", "BiliNetworking"]
+            dependencies: ["BiliApplication", "BiliModels", "BiliNetworking"]
         ),
         .target(
             name: "BiliAPI",
@@ -64,7 +64,7 @@ let package = Package(
         ),
         .target(
             name: "BiliAuthFeature",
-            dependencies: ["BiliApplication"]
+            dependencies: ["BiliApplication", "BiliModels"]
         ),
         .target(
             name: "BiliLibraryFeature",
@@ -113,7 +113,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BiliAuthTests",
-            dependencies: ["BiliAuth", "BiliNetworking"],
+            dependencies: ["BiliAuth", "BiliModels", "BiliNetworking"],
             resources: [
                 .copy("Fixtures")
             ]

--- a/Packages/BiliKitCore/Sources/BiliApplication/Auth/AuthenticationContracts.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Auth/AuthenticationContracts.swift
@@ -1,3 +1,12 @@
+import BiliModels
+
+/// 已经确认的账户会话事实；认证操作进行中不会把原有事实降级为未登录。
+public enum AccountSessionState: Sendable, Equatable {
+    case unresolved
+    case signedOut
+    case signedIn(AccountIdentity?)
+}
+
 /// Feature 可观察的非秘密认证状态；不携带二维码 payload、Cookie 或 Keychain 细节。
 public enum AuthenticationState: Sendable, Equatable {
     case signedOut
@@ -6,7 +15,7 @@ public enum AuthenticationState: Sendable, Equatable {
     case awaitingScan
     case awaitingConfirmation
     case finalizing
-    case signedIn
+    case signedIn(AccountIdentity?)
     case signingOut
     case expired
     case failed(AuthenticationFailure)

--- a/Packages/BiliKitCore/Sources/BiliAuth/Application/BiliAuthenticationService.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/Application/BiliAuthenticationService.swift
@@ -51,16 +51,22 @@ public actor BiliAuthenticationService: AuthenticationServicing {
         state = .restoring
 
         do {
-            let restored = try await activeAuthorizer.restoreLoginState()
+            let restored = try await activeAuthorizer.restoreAccountSession()
             guard generation == operationGeneration else { return state }
-            requiresLogout = restored
-            state = restored ? .signedIn : .signedOut
+            switch restored {
+            case .signedOut:
+                requiresLogout = false
+                state = .signedOut
+            case .signedIn(let identity):
+                requiresLogout = true
+                state = .signedIn(identity)
+            }
         } catch is CancellationError {
             guard generation == operationGeneration else { return state }
             state = .signedOut
         } catch let error as BiliRequestAuthorizationError {
             guard generation == operationGeneration else { return state }
-            // restoreLoginState only throws after credential access or validation
+            // restoreAccountSession only throws after credential access or validation
             // becomes unavailable. Keep logout as the sole signed-out transition.
             requiresLogout = true
             state = .failed(Self.map(error))
@@ -130,8 +136,14 @@ public actor BiliAuthenticationService: AuthenticationServicing {
             let stored = try await activeSession.validateAndStorePendingCredential()
             guard generation == operationGeneration else { return state }
             qrCode = nil
-            requiresLogout = stored
-            state = stored ? .signedIn : .failed(.serviceUnavailable)
+            switch stored {
+            case .signedOut:
+                requiresLogout = false
+                state = .failed(.serviceUnavailable)
+            case .signedIn(let identity):
+                requiresLogout = true
+                state = .signedIn(identity)
+            }
         } catch is CancellationError {
             guard generation == operationGeneration else { return state }
             qrCode = nil

--- a/Packages/BiliKitCore/Sources/BiliAuth/Credential/BiliCredentialRequestAuthorizer.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/Credential/BiliCredentialRequestAuthorizer.swift
@@ -108,7 +108,7 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
     }
 
     /// 验证已存凭据当前是否仍登录；明确失效会清除，验证不可用则保留并抛错。
-    public func restoreLoginState() async throws -> Bool {
+    func restoreAccountSession() async throws -> NavigationAuthenticationResult {
         let request = HTTPRequest(
             url: Self.navigationValidationURL,
             headers: [
@@ -124,7 +124,7 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
             BiliRequestAuthorizationError.expiredCredential,
             BiliRequestAuthorizationError.invalidCredential
         {
-            return false
+            return .signedOut
         }
 
         let response: HTTPResponse
@@ -138,7 +138,7 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
         guard response.body.count <= Self.maximumResponseSize,
             Self.looksLikeJSON(response),
             let envelope = try? JSONDecoder().decode(
-                NavigationEnvelope.self,
+                NavigationAuthenticationEnvelope.self,
                 from: response.body
             ),
             envelope.code == 0,
@@ -146,11 +146,12 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
         else {
             throw BiliRequestAuthorizationError.validationUnavailable
         }
-        guard data.isLogin else {
+        let result = data.authenticationResult
+        guard case .signedIn = result else {
             try purgeStoredCredential()
-            return false
+            return .signedOut
         }
-        return true
+        return result
     }
 
     private static func isAllowed(_ request: HTTPRequest) -> Bool {
@@ -284,14 +285,5 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
             configuration: configuration,
             redirectPolicy: .reject
         )
-    }
-
-    private struct NavigationEnvelope: Decodable {
-        let code: Int
-        let data: NavigationData?
-    }
-
-    private struct NavigationData: Decodable {
-        let isLogin: Bool
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliAuth/Remote/NavigationAuthenticationPayload.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/Remote/NavigationAuthenticationPayload.swift
@@ -1,0 +1,69 @@
+import BiliModels
+import BiliNetworking
+import Foundation
+
+struct NavigationAuthenticationEnvelope: Decodable, Sendable {
+    let code: Int
+    let data: NavigationAuthenticationPayload?
+}
+
+struct NavigationAuthenticationPayload: Decodable, Sendable {
+    let isLogin: Bool
+    private let mid: Int64?
+    private let uname: String?
+    private let face: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case isLogin
+        case mid
+        case uname
+        case face
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        isLogin = try container.decode(Bool.self, forKey: .isLogin)
+        mid = try? container.decode(Int64.self, forKey: .mid)
+        uname = try? container.decode(String.self, forKey: .uname)
+        face = try? container.decode(String.self, forKey: .face)
+    }
+
+    var authenticationResult: NavigationAuthenticationResult {
+        guard isLogin else { return .signedOut }
+        guard let mid, mid > 0, let uname else {
+            return .signedIn(nil)
+        }
+        let displayName = uname.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !displayName.isEmpty else { return .signedIn(nil) }
+        return .signedIn(
+            AccountIdentity(
+                id: mid,
+                displayName: displayName,
+                avatarURL: Self.imageURL(from: face)
+            )
+        )
+    }
+
+    private static func imageURL(from value: String?) -> URL? {
+        guard let value, !value.isEmpty else { return nil }
+        let normalized: String
+        if value.hasPrefix("//") {
+            normalized = "https:\(value)"
+        } else if value.lowercased().hasPrefix("http://") {
+            normalized = "https://" + value.dropFirst("http://".count)
+        } else {
+            normalized = value
+        }
+        guard let url = URL(string: normalized),
+            PublicHTTPSURLPolicy().allows(url)
+        else {
+            return nil
+        }
+        return url
+    }
+}
+
+enum NavigationAuthenticationResult: Sendable, Equatable {
+    case signedOut
+    case signedIn(AccountIdentity?)
+}

--- a/Packages/BiliKitCore/Sources/BiliAuth/WebQR/WebQRLoginSession.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/WebQR/WebQRLoginSession.swift
@@ -214,13 +214,20 @@ public actor WebQRLoginSession {
 
     public func validatePendingCredential() async throws -> Bool {
         let pendingCredential = try takePendingCredential()
-        return try await validate(pendingCredential)
+        let result = try await validate(pendingCredential)
+        if case .signedIn = result {
+            return true
+        }
+        return false
     }
 
     /// 一次性消费候选凭据，验证登录态与有效期后才提交 Keychain。
-    public func validateAndStorePendingCredential() async throws -> Bool {
+    func validateAndStorePendingCredential() async throws
+        -> NavigationAuthenticationResult
+    {
         let pendingCredential = try takePendingCredential()
-        guard try await validate(pendingCredential) else { return false }
+        let result = try await validate(pendingCredential)
+        guard case .signedIn = result else { return .signedOut }
         guard !pendingCredential.credential.isExpired() else {
             throw WebQRLoginFailure.incompleteCredential
         }
@@ -229,7 +236,7 @@ public actor WebQRLoginSession {
         } catch {
             throw WebQRLoginFailure.credentialStoreUnavailable
         }
-        return true
+        return result
     }
 
     private func takePendingCredential() throws -> PendingCredential {
@@ -243,7 +250,9 @@ public actor WebQRLoginSession {
         return pendingCredential
     }
 
-    private func validate(_ pendingCredential: PendingCredential) async throws -> Bool {
+    private func validate(
+        _ pendingCredential: PendingCredential
+    ) async throws -> NavigationAuthenticationResult {
         let response = try await sendNavigationValidation(
             cookieHeader: pendingCredential.credential.cookieHeader
         )
@@ -251,16 +260,19 @@ public actor WebQRLoginSession {
         guard generation == pendingCredential.generation else {
             throw CancellationError()
         }
-        let envelope: NavigationEnvelope
+        let envelope: NavigationAuthenticationEnvelope
         do {
-            envelope = try decoder.decode(NavigationEnvelope.self, from: response.body)
+            envelope = try decoder.decode(
+                NavigationAuthenticationEnvelope.self,
+                from: response.body
+            )
         } catch {
             throw WebQRLoginFailure.invalidResponse
         }
         guard envelope.code == 0, let data = envelope.data else {
             throw WebQRLoginFailure.invalidResponse
         }
-        return data.isLogin
+        return data.authenticationResult
     }
 
     private func send(
@@ -592,13 +604,4 @@ private struct PollData: Decodable, Sendable {
         let allFields = try decoder.container(keyedBy: FieldKey.self)
         fieldNames = allFields.allKeys.map(\.stringValue)
     }
-}
-
-private struct NavigationEnvelope: Decodable, Sendable {
-    let code: Int
-    let data: NavigationData?
-}
-
-private struct NavigationData: Decodable, Sendable {
-    let isLogin: Bool
 }

--- a/Packages/BiliKitCore/Sources/BiliAuthFeature/Authentication/AuthenticationView.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuthFeature/Authentication/AuthenticationView.swift
@@ -23,7 +23,7 @@ public struct AuthenticationView: View {
             await model.waitForCurrentTask()
         }
         .onDisappear {
-            model.cancelTransientWork()
+            model.cancelPresentedLoginWork()
         }
     }
 

--- a/Packages/BiliKitCore/Sources/BiliAuthFeature/Authentication/AuthenticationViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuthFeature/Authentication/AuthenticationViewModel.swift
@@ -1,7 +1,32 @@
 import BiliApplication
+import BiliModels
 import CoreGraphics
 import Foundation
 import Observation
+
+public enum AccountSessionPhase: Sendable, Equatable {
+    case unresolved
+    case signedOut
+    case signedIn
+}
+
+/// 供产品界面使用的诚实账户呈现状态；不可用与确定登出保持区分。
+public enum AccountPresentationState: Sendable, Equatable {
+    case resolving
+    case unavailable
+    case signedOut
+    case signedIn(AccountIdentity?)
+
+    public var displayName: String? {
+        guard case .signedIn(let identity) = self else { return nil }
+        return identity?.displayName
+    }
+
+    public var avatarURL: URL? {
+        guard case .signedIn(let identity) = self else { return nil }
+        return identity?.avatarURL
+    }
+}
 
 @MainActor
 @Observable
@@ -11,10 +36,32 @@ import Observation
 /// 始终留在 `BiliAuth` adapter，失败重试也保持原操作类型，避免把登出失败误当成登录失败。
 public final class AuthenticationViewModel {
     public private(set) var state: AuthenticationState = .signedOut
+    public private(set) var sessionState: AccountSessionState = .unresolved
     public private(set) var qrCodeImage: CGImage?
 
-    public var isSignedIn: Bool {
-        state == .signedIn
+    public var sessionPhase: AccountSessionPhase {
+        switch sessionState {
+        case .unresolved:
+            .unresolved
+        case .signedOut:
+            .signedOut
+        case .signedIn:
+            .signedIn
+        }
+    }
+
+    public var accountPresentationState: AccountPresentationState {
+        switch sessionState {
+        case .unresolved:
+            if case .failed = state {
+                return .unavailable
+            }
+            return .resolving
+        case .signedOut:
+            return .signedOut
+        case .signedIn(let identity):
+            return .signedIn(identity)
+        }
     }
 
     public var canCancelFailure: Bool {
@@ -39,6 +86,7 @@ public final class AuthenticationViewModel {
     @ObservationIgnored private let maximumPollAttempts: Int
     @ObservationIgnored private var task: Task<Void, Never>?
     @ObservationIgnored private var generation = 0
+    @ObservationIgnored private var didStartInitialRestore = false
     @ObservationIgnored private var retryAction: RetryAction = .login
 
     public init(
@@ -67,11 +115,13 @@ public final class AuthenticationViewModel {
     }
 
     public func restoreIfNeeded() {
-        guard state == .signedOut else { return }
+        guard !didStartInitialRestore else { return }
+        didStartInitialRestore = true
         restore()
     }
 
     public func revalidate() {
+        didStartInitialRestore = true
         restore()
     }
 
@@ -80,7 +130,11 @@ public final class AuthenticationViewModel {
         begin(state: .restoring) { [weak self] operationGeneration in
             guard let self else { return }
             let nextState = await service.restore()
-            await apply(nextState, generation: operationGeneration)
+            await apply(
+                nextState,
+                generation: operationGeneration,
+                commitsConfirmedSession: true
+            )
         }
     }
 
@@ -127,7 +181,11 @@ public final class AuthenticationViewModel {
         begin(state: .signingOut) { [weak self] operationGeneration in
             guard let self else { return }
             let nextState = await service.logout()
-            await apply(nextState, generation: operationGeneration)
+            await apply(
+                nextState,
+                generation: operationGeneration,
+                commitsConfirmedSession: true
+            )
         }
     }
 
@@ -136,18 +194,27 @@ public final class AuthenticationViewModel {
         logout()
     }
 
-    /// 在 sheet/窗口生命周期结束时取消临时登录工作，但不会把已登录状态当作可取消挑战。
-    public func cancelTransientWork() {
+    /// Sheet 关闭时只取消由该登录界面发起的挑战，不接管窗口级启动恢复。
+    public func cancelPresentedLoginWork() {
         switch state {
-        case .restoring, .requestingQRCode, .awaitingScan, .awaitingConfirmation,
+        case .requestingQRCode, .awaitingScan, .awaitingConfirmation,
             .finalizing, .expired:
             cancelLogin()
         case .failed:
             if retryAction == .login {
                 cancelLogin()
             }
-        case .signedOut, .signedIn, .signingOut:
+        case .signedOut, .restoring, .signedIn, .signingOut:
             break
+        }
+    }
+
+    /// 窗口生命周期结束时取消所有临时认证工作，包括启动恢复。
+    public func cancelTransientWork() {
+        if state == .restoring {
+            cancelLogin()
+        } else {
+            cancelPresentedLoginWork()
         }
     }
 
@@ -213,7 +280,11 @@ public final class AuthenticationViewModel {
             }
             if polled == .finalizing {
                 let finalized = await service.finalizeLogin()
-                _ = await apply(finalized, generation: operationGeneration)
+                _ = await apply(
+                    finalized,
+                    generation: operationGeneration,
+                    commitsConfirmedSession: true
+                )
                 return
             }
         }
@@ -231,12 +302,16 @@ public final class AuthenticationViewModel {
     @discardableResult
     private func apply(
         _ nextState: AuthenticationState,
-        generation operationGeneration: Int
+        generation operationGeneration: Int,
+        commitsConfirmedSession: Bool = false
     ) async -> Bool {
         guard generation == operationGeneration, !Task.isCancelled else {
             return false
         }
         state = nextState
+        if commitsConfirmedSession {
+            updateConfirmedSession(from: nextState)
+        }
         switch nextState {
         case .awaitingScan, .awaitingConfirmation:
             do {
@@ -256,6 +331,18 @@ public final class AuthenticationViewModel {
             qrCodeImage = nil
         }
         return generation == operationGeneration && !Task.isCancelled
+    }
+
+    private func updateConfirmedSession(from nextState: AuthenticationState) {
+        switch nextState {
+        case .signedOut:
+            sessionState = .signedOut
+        case .signedIn(let identity):
+            sessionState = .signedIn(identity)
+        case .restoring, .requestingQRCode, .awaitingScan,
+            .awaitingConfirmation, .finalizing, .signingOut, .expired, .failed:
+            break
+        }
     }
 }
 

--- a/Packages/BiliKitCore/Sources/BiliModels/Account/AccountIdentity.swift
+++ b/Packages/BiliKitCore/Sources/BiliModels/Account/AccountIdentity.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// 已认证账户可供界面显示的最小非秘密身份。
+public struct AccountIdentity: Sendable, Equatable {
+    public let id: Int64
+    public let displayName: String
+    public let avatarURL: URL?
+
+    public init(id: Int64, displayName: String, avatarURL: URL?) {
+        self.id = id
+        self.displayName = displayName
+        self.avatarURL = avatarURL
+    }
+}

--- a/Packages/BiliKitCore/Tests/BiliAuthFeatureTests/AuthenticationViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthFeatureTests/AuthenticationViewModelTests.swift
@@ -13,7 +13,7 @@ struct AuthenticationViewModelTests {
         let service = AuthenticationServiceStub(
             requestStates: [.awaitingScan],
             pollStates: [.awaitingConfirmation, .finalizing],
-            finalizeState: .signedIn
+            finalizeState: .signedIn(nil)
         )
         let model = AuthenticationViewModel(
             service: service,
@@ -21,10 +21,13 @@ struct AuthenticationViewModelTests {
             pollInterval: .zero
         )
 
+        #expect(model.accountPresentationState == .resolving)
         model.startLogin()
         await model.waitForCurrentTask()
 
-        #expect(model.state == .signedIn)
+        #expect(model.state == .signedIn(nil))
+        #expect(model.sessionState == .signedIn(nil))
+        #expect(model.accountPresentationState == .signedIn(nil))
         #expect(model.qrCodeImage == nil)
         #expect(
             await service.observedCalls()
@@ -63,7 +66,7 @@ struct AuthenticationViewModelTests {
     @MainActor
     func restoreAndLogoutUseApplicationServiceWithoutExposingCredentials() async {
         let service = AuthenticationServiceStub(
-            restoreState: .signedIn,
+            restoreState: .signedIn(nil),
             logoutState: .signedOut
         )
         let model = AuthenticationViewModel(
@@ -74,14 +77,96 @@ struct AuthenticationViewModelTests {
 
         model.restoreIfNeeded()
         await model.waitForCurrentTask()
-        #expect(model.state == .signedIn)
+        #expect(model.state == .signedIn(nil))
+        #expect(model.sessionState == .signedIn(nil))
 
         model.logout()
         #expect(model.state == .signingOut)
+        #expect(model.sessionState == .signedIn(nil))
         await model.waitForCurrentTask()
 
         #expect(model.state == .signedOut)
+        #expect(model.sessionState == .signedOut)
+        #expect(model.accountPresentationState == .signedOut)
         #expect(await service.observedCalls() == ["restore", "logout"])
+    }
+
+    @Test
+    @MainActor
+    func initialRestoreConfirmsSignedOutOnlyOnce() async {
+        let service = AuthenticationServiceStub(restoreState: .signedOut)
+        let model = AuthenticationViewModel(
+            service: service,
+            qrCodeProvider: service,
+            pollInterval: .zero
+        )
+
+        #expect(model.sessionState == .unresolved)
+        model.restoreIfNeeded()
+        await model.waitForCurrentTask()
+        model.restoreIfNeeded()
+        await model.waitForCurrentTask()
+
+        #expect(model.state == .signedOut)
+        #expect(model.sessionState == .signedOut)
+        #expect(await service.observedCalls() == ["restore"])
+    }
+
+    @Test
+    @MainActor
+    func concurrentInitialRestoreCallsReuseTheInFlightIntent() async throws {
+        let service = AuthenticationServiceStub(
+            restoreState: .signedIn(nil),
+            suspendsFirstRestore: true
+        )
+        let model = AuthenticationViewModel(
+            service: service,
+            qrCodeProvider: service,
+            pollInterval: .zero
+        )
+
+        model.restoreIfNeeded()
+        try await service.waitForFirstRestoreStart()
+        model.restoreIfNeeded()
+
+        #expect(model.state == .restoring)
+        #expect(model.sessionState == .unresolved)
+        #expect(await service.observedCalls() == ["restore"])
+
+        await service.releaseFirstRestore()
+        await model.waitForCurrentTask()
+
+        #expect(model.state == .signedIn(nil))
+        #expect(model.sessionState == .signedIn(nil))
+        #expect(await service.observedCalls() == ["restore"])
+    }
+
+    @Test
+    @MainActor
+    func dismissingAuthenticationSheetDoesNotCancelWindowRestore() async throws {
+        let service = AuthenticationServiceStub(
+            restoreState: .signedIn(nil),
+            suspendsFirstRestore: true
+        )
+        let model = AuthenticationViewModel(
+            service: service,
+            qrCodeProvider: service,
+            pollInterval: .zero
+        )
+
+        model.restoreIfNeeded()
+        try await service.waitForFirstRestoreStart()
+        model.cancelPresentedLoginWork()
+
+        #expect(model.state == .restoring)
+        #expect(model.sessionState == .unresolved)
+        #expect(await service.observedCalls() == ["restore"])
+
+        await service.releaseFirstRestore()
+        await model.waitForCurrentTask()
+
+        #expect(model.state == .signedIn(nil))
+        #expect(model.sessionState == .signedIn(nil))
     }
 
     @Test
@@ -98,10 +183,13 @@ struct AuthenticationViewModelTests {
 
         model.restoreIfNeeded()
         await model.waitForCurrentTask()
+        #expect(model.sessionState == .unresolved)
         model.retry()
         await model.waitForCurrentTask()
 
         #expect(model.state == .failed(.network))
+        #expect(model.sessionState == .unresolved)
+        #expect(model.accountPresentationState == .unavailable)
         #expect(model.canCancelFailure == false)
         #expect(await service.observedCalls() == ["restore", "restore"])
     }
@@ -127,6 +215,7 @@ struct AuthenticationViewModelTests {
         await model.waitForCurrentTask()
 
         #expect(model.state == .signedOut)
+        #expect(model.sessionState == .signedOut)
         #expect(!model.canClearLocalCredentials)
         #expect(await service.observedCalls() == ["restore", "logout"])
     }
@@ -161,7 +250,7 @@ struct AuthenticationViewModelTests {
     @MainActor
     func logoutFailureRetriesLogoutAndCannotBeCancelledAsLogin() async {
         let service = AuthenticationServiceStub(
-            restoreState: .signedIn,
+            restoreState: .signedIn(nil),
             logoutState: .failed(.credentialUnavailable)
         )
         let model = AuthenticationViewModel(
@@ -173,11 +262,15 @@ struct AuthenticationViewModelTests {
         model.restoreIfNeeded()
         await model.waitForCurrentTask()
         model.logout()
+        #expect(model.sessionState == .signedIn(nil))
         await model.waitForCurrentTask()
+        #expect(model.sessionState == .signedIn(nil))
         model.retry()
         await model.waitForCurrentTask()
 
         #expect(model.state == .failed(.credentialUnavailable))
+        #expect(model.sessionState == .signedIn(nil))
+        #expect(model.accountPresentationState == .signedIn(nil))
         #expect(model.canCancelFailure == false)
         #expect(model.retryButtonTitle == "重试退出")
         #expect(
@@ -206,7 +299,33 @@ struct AuthenticationViewModelTests {
         await model.waitForCurrentTask()
 
         #expect(model.state == .signedOut)
+        #expect(model.sessionState == .unresolved)
         #expect(await service.observedCalls() == ["request", "cancel"])
+    }
+
+    @Test
+    @MainActor
+    func revalidationKeepsConfirmedSessionUntilTerminalResult() async {
+        let service = AuthenticationServiceStub(
+            restoreState: .signedIn(nil)
+        )
+        let model = AuthenticationViewModel(
+            service: service,
+            qrCodeProvider: service,
+            pollInterval: .zero
+        )
+
+        model.restoreIfNeeded()
+        await model.waitForCurrentTask()
+        #expect(model.sessionState == .signedIn(nil))
+
+        model.revalidate()
+        #expect(model.state == .restoring)
+        #expect(model.sessionState == .signedIn(nil))
+        await model.waitForCurrentTask()
+
+        #expect(model.sessionState == .signedIn(nil))
+        #expect(await service.observedCalls() == ["restore", "restore"])
     }
 }
 
@@ -220,11 +339,16 @@ private actor AuthenticationServiceStub: AuthenticationServicing,
     private let cancelState: AuthenticationState
     private let logoutState: AuthenticationState
     private let suspendedFirstImageCompletion: StaleQRCodeCompletion?
+    private let suspendsFirstRestore: Bool
     private var imageCount = 0
+    private var restoreCount = 0
     private var calls: [String] = []
     private var firstImageReleased = false
+    private var firstRestoreReleased = false
     private let firstImageEvents = TestEventCounter()
+    private let firstRestoreEvents = TestEventCounter()
     private var imageReleaseWaiters: [CheckedContinuation<Void, Never>] = []
+    private var restoreReleaseWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(
         requestStates: [AuthenticationState] = [],
@@ -233,7 +357,8 @@ private actor AuthenticationServiceStub: AuthenticationServicing,
         finalizeState: AuthenticationState = .signedOut,
         cancelState: AuthenticationState = .signedOut,
         logoutState: AuthenticationState = .signedOut,
-        suspendedFirstImageCompletion: StaleQRCodeCompletion? = nil
+        suspendedFirstImageCompletion: StaleQRCodeCompletion? = nil,
+        suspendsFirstRestore: Bool = false
     ) {
         self.requestStates = requestStates
         self.pollStates = pollStates
@@ -242,10 +367,22 @@ private actor AuthenticationServiceStub: AuthenticationServicing,
         self.cancelState = cancelState
         self.logoutState = logoutState
         self.suspendedFirstImageCompletion = suspendedFirstImageCompletion
+        self.suspendsFirstRestore = suspendsFirstRestore
     }
 
-    func restore() -> AuthenticationState {
+    func restore() async -> AuthenticationState {
         calls.append("restore")
+        restoreCount += 1
+        if suspendsFirstRestore, restoreCount == 1 {
+            await firstRestoreEvents.signal()
+            await withCheckedContinuation { continuation in
+                if firstRestoreReleased {
+                    continuation.resume()
+                } else {
+                    restoreReleaseWaiters.append(continuation)
+                }
+            }
+        }
         return restoreState
     }
 
@@ -314,6 +451,20 @@ private actor AuthenticationServiceStub: AuthenticationServicing,
     func releaseFirstImage() {
         firstImageReleased = true
         resume(&imageReleaseWaiters)
+    }
+
+    func waitForFirstRestoreStart() async throws {
+        do {
+            try await firstRestoreEvents.wait(until: 1)
+        } catch {
+            releaseFirstRestore()
+            throw error
+        }
+    }
+
+    func releaseFirstRestore() {
+        firstRestoreReleased = true
+        resume(&restoreReleaseWaiters)
     }
 
     private static func makeFixtureImage() -> CGImage? {

--- a/Packages/BiliKitCore/Tests/BiliAuthTests/BiliAuthenticationServiceTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthTests/BiliAuthenticationServiceTests.swift
@@ -1,4 +1,5 @@
 import BiliApplication
+import BiliModels
 import BiliNetworking
 import Foundation
 import Testing
@@ -15,7 +16,10 @@ struct BiliAuthenticationServiceTests {
                 "Set-Cookie": fixtureSetCookieHeader,
             ]
         )
-        let navigation = navigationResponse(isLogin: true)
+        let navigation = navigationResponse(
+            isLogin: true,
+            includesIdentity: true
+        )
         let store = MemoryWebCredentialStore()
         let session = WebQRLoginSession(
             transport: RecordingAuthTransport(
@@ -41,7 +45,9 @@ struct BiliAuthenticationServiceTests {
         #expect(await service.pollOnce() == .finalizing)
         #expect(store.saveCount == 0)
 
-        #expect(await service.finalizeLogin() == .signedIn)
+        #expect(
+            await service.finalizeLogin() == .signedIn(fixtureAccountIdentity)
+        )
         #expect(store.saveCount == 1)
         #expect(try store.load() != nil)
     }
@@ -59,13 +65,18 @@ struct BiliAuthenticationServiceTests {
             authorizer: BiliCredentialRequestAuthorizer(
                 store: store,
                 transport: RecordingAuthTransport(
-                    responses: [navigationResponse(isLogin: true)]
+                    responses: [
+                        navigationResponse(
+                            isLogin: true,
+                            includesIdentity: true
+                        )
+                    ]
                 )
             ),
             store: store
         )
 
-        #expect(await service.restore() == .signedIn)
+        #expect(await service.restore() == .signedIn(fixtureAccountIdentity))
     }
 
     @Test
@@ -110,7 +121,7 @@ struct BiliAuthenticationServiceTests {
             ]
         )
 
-        #expect(await service.restore() == .signedIn)
+        #expect(await service.restore() == .signedIn(nil))
         #expect(await service.logout() == .signedOut)
 
         #expect(try store.load() == nil)
@@ -167,7 +178,7 @@ struct BiliAuthenticationServiceTests {
             ]
         )
 
-        #expect(await service.restore() == .signedIn)
+        #expect(await service.restore() == .signedIn(nil))
         #expect(await service.logout() == .failed(.credentialUnavailable))
         #expect(await service.cancelLogin() == .failed(.credentialUnavailable))
 
@@ -206,12 +217,29 @@ struct BiliAuthenticationServiceTests {
     }
 }
 
-private func navigationResponse(isLogin: Bool) -> HTTPResponse {
-    HTTPResponse(
+private let fixtureAccountIdentity = AccountIdentity(
+    id: 42,
+    displayName: "Fixture Account",
+    avatarURL: URL(string: "https://i0.hdslb.com/fixture/avatar.png")
+)
+
+private func navigationResponse(
+    isLogin: Bool,
+    includesIdentity: Bool = false
+) -> HTTPResponse {
+    let identityFields: String
+    if includesIdentity {
+        identityFields =
+            ",\"mid\":42,\"uname\":\"  Fixture Account  \""
+            + ",\"face\":\"//i0.hdslb.com/fixture/avatar.png\""
+    } else {
+        identityFields = ""
+    }
+    return HTTPResponse(
         statusCode: 200,
         headers: ["Content-Type": "application/json"],
         body: Data(
-            #"{"code":0,"data":{"isLogin":\#(isLogin)}}"#.utf8
+            "{\"code\":0,\"data\":{\"isLogin\":\(isLogin)\(identityFields)}}".utf8
         )
     )
 }

--- a/Packages/BiliKitCore/Tests/BiliAuthTests/Credential/BiliCredentialRequestAuthorizerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthTests/Credential/BiliCredentialRequestAuthorizerTests.swift
@@ -205,9 +205,9 @@ struct BiliCredentialRequestAuthorizerTests {
             transport: transport
         )
 
-        let isLoggedIn = try await authorizer.restoreLoginState()
+        let session = try await authorizer.restoreAccountSession()
 
-        #expect(isLoggedIn)
+        #expect(session == .signedIn(nil))
         let request = try #require(await transport.capturedRequest)
         #expect(request.url.absoluteString == "https://api.bilibili.com/x/web-interface/nav")
         #expect(request.headers["Cookie"]?.contains("SESSDATA=FIXTURE_") == true)
@@ -222,7 +222,7 @@ struct BiliCredentialRequestAuthorizerTests {
             store: MemoryWebCredentialStore(),
             transport: missingTransport
         )
-        #expect(try await missing.restoreLoginState() == false)
+        #expect(try await missing.restoreAccountSession() == .signedOut)
         #expect(await missingTransport.capturedRequest == nil)
 
         let invalidStore = MemoryWebCredentialStore(
@@ -234,7 +234,7 @@ struct BiliCredentialRequestAuthorizerTests {
                 response: navigationResponse(isLogin: false)
             )
         )
-        #expect(try await invalid.restoreLoginState() == false)
+        #expect(try await invalid.restoreAccountSession() == .signedOut)
         #expect(invalidStore.deleteCount == 1)
 
         let failedPurge = BiliCredentialRequestAuthorizer(
@@ -249,7 +249,7 @@ struct BiliCredentialRequestAuthorizerTests {
         await #expect(
             throws: BiliRequestAuthorizationError.credentialStoreUnavailable
         ) {
-            try await failedPurge.restoreLoginState()
+            try await failedPurge.restoreAccountSession()
         }
     }
 
@@ -262,7 +262,7 @@ struct BiliCredentialRequestAuthorizerTests {
         )
 
         await #expect(throws: BiliRequestAuthorizationError.validationUnavailable) {
-            try await authorizer.restoreLoginState()
+            try await authorizer.restoreAccountSession()
         }
         #expect(store.deleteCount == 0)
         #expect(try store.load() != nil)

--- a/Packages/BiliKitCore/Tests/BiliAuthTests/NavigationAuthenticationPayloadTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthTests/NavigationAuthenticationPayloadTests.swift
@@ -1,0 +1,90 @@
+import BiliModels
+import Foundation
+import Testing
+
+@testable import BiliAuth
+
+struct NavigationAuthenticationPayloadTests {
+    @Test
+    func mapsCompleteIdentityAndNormalizesAvatarURL() throws {
+        let result = try authenticationResult(
+            #"{"isLogin":true,"mid":42,"uname":"  Fixture Account  ","face":"//i0.hdslb.com/fixture/avatar.png"}"#
+        )
+        let identity = AccountIdentity(
+            id: 42,
+            displayName: "Fixture Account",
+            avatarURL: URL(
+                string: "https://i0.hdslb.com/fixture/avatar.png"
+            )
+        )
+
+        #expect(result == .signedIn(identity))
+    }
+
+    @Test
+    func missingOrMalformedOptionalIdentityDoesNotDenyAuthentication() throws {
+        #expect(
+            try authenticationResult(#"{"isLogin":true}"#)
+                == .signedIn(nil)
+        )
+        #expect(
+            try authenticationResult(
+                #"{"isLogin":true,"mid":"unexpected","uname":42,"face":false}"#
+            ) == .signedIn(nil)
+        )
+    }
+
+    @Test
+    func invalidAvatarKeepsOtherwiseValidIdentity() throws {
+        let result = try authenticationResult(
+            #"{"isLogin":true,"mid":42,"uname":"Fixture Account","face":"javascript:fixture"}"#
+        )
+        let identity = AccountIdentity(
+            id: 42,
+            displayName: "Fixture Account",
+            avatarURL: nil
+        )
+
+        #expect(result == .signedIn(identity))
+    }
+
+    @Test
+    func localOrAddressLiteralAvatarDoesNotCrossPublicImageBoundary() throws {
+        for avatar in [
+            "https://localhost/avatar.png",
+            "https://127.0.0.1/avatar.png",
+            "https://[::1]/avatar.png",
+        ] {
+            let result = try authenticationResult(
+                "{\"isLogin\":true,\"mid\":42,\"uname\":\"Fixture Account\",\"face\":\"\(avatar)\"}"
+            )
+            let identity = AccountIdentity(
+                id: 42,
+                displayName: "Fixture Account",
+                avatarURL: nil
+            )
+
+            #expect(result == .signedIn(identity))
+        }
+    }
+
+    @Test
+    func explicitSignedOutIgnoresIdentityFields() throws {
+        #expect(
+            try authenticationResult(
+                #"{"isLogin":false,"mid":42,"uname":"Fixture Account"}"#
+            ) == .signedOut
+        )
+    }
+
+    private func authenticationResult(
+        _ dataJSON: String
+    ) throws -> NavigationAuthenticationResult {
+        let envelopeJSON = "{\"code\":0,\"data\":\(dataJSON)}"
+        let envelope = try JSONDecoder().decode(
+            NavigationAuthenticationEnvelope.self,
+            from: Data(envelopeJSON.utf8)
+        )
+        return try #require(envelope.data).authenticationResult
+    }
+}

--- a/Packages/BiliKitCore/Tests/BiliAuthTests/WebQRLoginSessionTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthTests/WebQRLoginSessionTests.swift
@@ -211,7 +211,7 @@ struct WebQRLoginSessionTests {
         _ = try await session.pollOnce()
         let stored = try await session.validateAndStorePendingCredential()
 
-        #expect(stored)
+        #expect(stored == .signedIn(nil))
         #expect(store.saveCount == 1)
         #expect(try store.load()?.cookies.count == 5)
     }
@@ -246,7 +246,7 @@ struct WebQRLoginSessionTests {
         _ = try await session.pollOnce()
         let stored = try await session.validateAndStorePendingCredential()
 
-        #expect(!stored)
+        #expect(stored == .signedOut)
         #expect(store.saveCount == 0)
         #expect(try store.load() == nil)
     }


### PR DESCRIPTION
> Stacked PR：当前以 #33 的 `codex/loading-continuity` 为 base；前置 PR 合并后应将 base 改回 `main`。

## 变化

- 修正 NavigationSplitView sidebar 底部账户入口的原生布局与背景关系，保留 32×32 头像槽。
- 将瞬时认证操作状态与已确认账户会话拆分为 `unresolved / signedOut / signedIn(identity)`。
- 移除 `isSignedIn: Bool` 对 App、History 和 sidebar 的界面驱动。
- 复用既有 authenticated `GET /x/web-interface/nav`，从同一次响应映射 `mid / uname / face` 到最小 `AccountIdentity`。
- sidebar 登录后显示真实昵称；头像在固定槽内由 fallback 原位淡入，并尊重 Reduce Motion。
- 仅真实的 signed-in / signed-out 边界关闭播放或重置历史；启动恢复和 identity 补全不触发导航、player host 或来源上下文副作用。

## 原因与用户影响

Bool 无法区分“尚未确认”“明确退出”和“恢复暂时失败”，会造成启动时“登录 → 昵称”的错误跳变。显式账户事实让 sidebar 从启动开始保持诚实稳定，也为后续可折叠收藏夹提供可靠 owner 和生命周期边界。

## 认证与安全边界

- 不增加第二个账户请求，不放宽 authorizer allowlist。
- `isLogin` 仍是认证事实；`mid / uname / face` 缺失或畸形时降级为 `signedIn(nil)`，不会误删有效凭据。
- 账户身份仅在内存传播，不写入 UserDefaults、日志或 fixture。
- 头像 URL 经过公共 HTTPS 边界；BiliKit 认证秘密仍仅由精确 endpoint authorizer 管理。

## 验证

- 在该 stacked 分支精确运行 `sh Scripts/run-quality-gates.sh app`：static、Swift Package、App build-for-testing、App unit tests 全部通过。
- 签名 macOS XCUI `testConfirmedAccountIdentityAppearsInStableSidebarAccountSlot`：1/1 通过。
- 覆盖 restore 单飞、sheet/window 取消所有权、失败保持已确认事实、身份字段映射、URL 边界和 identity-only 更新不关闭播放。
- 生命周期、API/安全和 UI/测试 agent 分阶段审查；发现项修复并复审关闭后无 P0–P3。

## 未覆盖边界

- 真实账户与头像验证是当前时点单样本，不能保证 B 站长期 schema 稳定。
- XCUI 使用明确 Debug fixture，不证明所有远端头像失败时序或完整 Reduce Motion/VoiceOver 人工矩阵。