### PR TITLE
test(playback): 稳定播放器纵向滚动测试

### DIFF
--- a/BiliKitMacTests/PlayerHostViewIdentityTests.swift
+++ b/BiliKitMacTests/PlayerHostViewIdentityTests.swift
@@ -9,9 +9,39 @@ import Testing
 
 @Suite(.serialized)
 struct PlayerHostViewIdentityTests {
-    @Test(.timeLimit(.minutes(1)))
+    @Test
     @MainActor
     func playerSurfaceCaptureRoutesVerticalWheelWithoutLocalMonitor()
+        throws
+    {
+        let scrollView = ScrollWheelRecordingScrollView(
+            frame: NSRect(x: 0, y: 0, width: 800, height: 600)
+        )
+        let documentView = NSView(
+            frame: NSRect(x: 0, y: 0, width: 800, height: 1_200)
+        )
+        let playerView = AVPlayerView(
+            frame: NSRect(x: 0, y: 900, width: 800, height: 300)
+        )
+        let scrollCaptureView = PlayerScrollWheelCaptureView(
+            frame: playerView.bounds
+        )
+        scrollView.documentView = documentView
+        documentView.addSubview(playerView)
+        playerView.addSubview(scrollCaptureView)
+
+        let event = try makeScrollWheelEvent(deltaX: 0, deltaY: -80)
+        #expect(event.hasPreciseScrollingDeltas)
+
+        scrollCaptureView.scrollWheel(with: event)
+
+        #expect(scrollView.receivedScrollWheelEvents.count == 1)
+        #expect(scrollView.receivedScrollWheelEvents.first === event)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func playerHostInstallsSurfaceCaptureInScrollableDetailHierarchy()
         async throws
     {
         let renderer = CoreAnimationDanmakuRenderer()
@@ -33,6 +63,12 @@ struct PlayerHostViewIdentityTests {
             defer: false
         )
         window.contentView = hostingView
+        window.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
+        window.orderFrontRegardless()
+        defer {
+            window.orderOut(nil)
+            window.contentView = NSView()
+        }
         hostingView.layoutSubtreeIfNeeded()
 
         #expect(
@@ -41,7 +77,8 @@ struct PlayerHostViewIdentityTests {
                     ofType: AVPlayerView.self,
                     in: hostingView
                 ) != nil
-            }
+            },
+            "AVPlayerView 应在已进入 Window Server 生命周期的测试窗口中完成挂载"
         )
         let playerView = try #require(
             firstView(
@@ -85,27 +122,9 @@ struct PlayerHostViewIdentityTests {
                 }
                 return documentView.bounds.height
                     > scrollView.contentView.bounds.height
-            }
+            },
+            "详情滚动文档应完成布局并大于可见区域"
         )
-        let initialOrigin = scrollView.contentView.bounds.origin
-        let event = try makeScrollWheelEvent(deltaX: 0, deltaY: -80)
-        #expect(event.hasPreciseScrollingDeltas)
-
-        scrollCaptureView.scrollWheel(with: event)
-
-        #expect(
-            await waitUntil(in: hostingView) {
-                scrollView.contentView.bounds.origin.y > initialOrigin.y
-            }
-        )
-
-        let scrolledOrigin = scrollView.contentView.bounds.origin
-        let horizontalEvent = try makeScrollWheelEvent(deltaX: -80, deltaY: 0)
-        scrollCaptureView.scrollWheel(with: horizontalEvent)
-        hostingView.layoutSubtreeIfNeeded()
-        #expect(scrollView.contentView.bounds.origin == scrolledOrigin)
-
-        window.contentView = NSView()
     }
 
     @Test
@@ -817,6 +836,15 @@ struct PlayerHostViewIdentityTests {
         maximumActiveCount: DanmakuLaneConfiguration.hardMaximumActiveCount,
         displayAreaFraction: 1
     )
+}
+
+@MainActor
+private final class ScrollWheelRecordingScrollView: NSScrollView {
+    private(set) var receivedScrollWheelEvents: [NSEvent] = []
+
+    override func scrollWheel(with event: NSEvent) {
+        receivedScrollWheelEvents.append(event)
+    }
 }
 
 private struct PlayerHostScrollRoutingHarness: View {


### PR DESCRIPTION
## 变化

- 将播放器表面的纵向滚轮路由断言改为记录型 `NSScrollView`，直接验证事件被交给播放器外层滚动容器。
- 保留真实 SwiftUI / `AVPlayerView` 组合测试，单独验证 capture 的安装位置、弹幕层级与可滚动详情层级。
- 让真实组合测试窗口进入 Window Server 生命周期，并在结束时安全移出且解除内容。
- 为异步挂载和布局等待补充明确的失败阶段信息。

## 原因

macOS 26 CI 两次在 `playerSurfaceCaptureRoutesVerticalWheelWithoutLocalMonitor()` 失败。失败 `.xcresult` 证明超时发生在调用 `NSScrollView.scrollWheel(with:)` 后等待 AppKit 实际改变滚动位置。

原测试把两项责任混在一起：BiliKit 是否把纵向事件交给外层滚动视图，以及 AppKit 是否处理无窗口编号的合成 `NSEvent` 并产生滚动。后者受 Window Server 和测试调度影响，导致相同代码树有时通过、有时在 2 秒后失败。

## 影响

- 不修改生产 `PlayerHostView` 或滚轮路由逻辑。
- 仍覆盖真实 capture 安装层级和纵向事件转交边界。
- 减少 macOS 26 CI 的非确定性失败，并使挂载/布局失败更容易诊断。

## 验证

在 macOS 26.6.1、Xcode 26.6、未签名测试环境下：

- 两条目标测试首次实际执行通过。
- 两条目标测试连续 10 轮通过。
- 完整 `BiliKitMacTests` 在并发条件下连续 5 轮通过；每轮 39 项，35 通过、4 个显式 probe 跳过。
- `sh Scripts/run-quality-gates.sh app` 通过：static、Swift Package、App build-for-testing、App unit tests 全部通过。
- `git diff --check` 通过。

## 未覆盖边界

- 本 PR 不替代真实触控板交互或 XCUI 播放连续性验证；它只修复单元/集成测试边界。
- CI runner 的长期稳定性仍需由本 PR 的 macOS 15/26 检查继续观察。