### PR TITLE
feat(browse): 增加播放侧栏 UP 主信息

### DIFF
--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/PlaybackContextSidebar.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/PlaybackContextSidebar.swift
@@ -51,6 +51,10 @@ public struct PlaybackContextSidebar: View {
     private func sidebarContent(_ context: GuestVideoContext) -> some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 16) {
+                VideoUploaderHeader(owner: context.detail.owner)
+
+                Divider()
+
                 if !context.detail.summary.isEmpty {
                     summarySection(context.detail.summary)
                     Divider()

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoLoadingSkeletons.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoLoadingSkeletons.swift
@@ -91,9 +91,20 @@ struct VideoDetailSkeleton: View {
 struct PlaybackContextSidebarSkeleton: View {
     let loadingLabel: String
 
+    @ScaledMetric(relativeTo: .title3)
+    private var uploaderNameSkeletonHeight =
+        VideoUploaderHeaderMetrics.nameSkeletonHeight
+    @ScaledMetric(relativeTo: .callout)
+    private var uploaderSignatureSkeletonHeight =
+        VideoUploaderHeaderMetrics.signatureSkeletonHeight
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
+                uploader
+
+                Divider()
+
                 sectionTitle(width: 64)
                 textLine()
                 textLine(width: 0.9)
@@ -117,6 +128,37 @@ struct PlaybackContextSidebarSkeleton: View {
         .background(.background)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(loadingLabel)
+    }
+
+    private var uploader: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(.quaternary)
+                .frame(
+                    width: VideoUploaderHeaderMetrics.avatarSize,
+                    height: VideoUploaderHeaderMetrics.avatarSize
+                )
+
+            VStack(
+                alignment: .leading,
+                spacing: VideoUploaderHeaderMetrics.textSpacing
+            ) {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(.quaternary)
+                    .frame(
+                        width: VideoUploaderHeaderMetrics.nameSkeletonWidth,
+                        height: uploaderNameSkeletonHeight
+                    )
+
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.quinary)
+                    .frame(
+                        maxWidth:
+                            VideoUploaderHeaderMetrics.signatureSkeletonWidth
+                    )
+                    .frame(height: uploaderSignatureSkeletonHeight)
+            }
+        }
     }
 
     private func sectionTitle(width: CGFloat) -> some View {

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoUploaderHeader.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoUploaderHeader.swift
@@ -1,0 +1,192 @@
+import BiliModels
+import BiliUI
+import SwiftUI
+
+/// 播放 Sidebar 顶部的只读 UP 主摘要。
+///
+/// 只投影 `VideoOwner` 的展示字段，不拥有 UP 主资料请求、关注或充电行为。未来接入独立
+/// 资料来源时只需更新 owner 数据，Sidebar 的布局与播放生命周期保持不变。
+struct VideoUploaderHeader: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @ScaledMetric(relativeTo: .callout)
+    private var signatureSkeletonHeight =
+        VideoUploaderHeaderMetrics.signatureSkeletonHeight
+
+    private let content: VideoUploaderHeaderContent
+
+    init(owner: VideoOwner) {
+        self.init(
+            owner: owner,
+            signatureState: .loaded(owner.signature)
+        )
+    }
+
+    init(
+        owner: VideoOwner,
+        signatureState: VideoUploaderSignatureState
+    ) {
+        content = VideoUploaderHeaderContent(
+            owner: owner,
+            signatureState: signatureState
+        )
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            avatar
+
+            VStack(
+                alignment: .leading,
+                spacing: VideoUploaderHeaderMetrics.textSpacing
+            ) {
+                Text(content.name)
+                    .font(.title3.weight(.semibold))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                signature
+                    .animation(
+                        LoadingStateTransition.animation(
+                            reduceMotion: reduceMotion
+                        ),
+                        value: content.signature
+                    )
+            }
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(content.accessibilityLabel)
+        .accessibilityIdentifier("sidebar.playback-uploader")
+    }
+
+    @ViewBuilder
+    private var signature: some View {
+        switch content.signature {
+        case .loading:
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quinary)
+                .frame(
+                    width: VideoUploaderHeaderMetrics.signatureSkeletonWidth,
+                    height: signatureSkeletonHeight
+                )
+                .transition(.opacity)
+                .accessibilityHidden(true)
+        case .text(let signature):
+            Text(signature)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .transition(.opacity)
+        case .hidden:
+            EmptyView()
+        }
+    }
+
+    private var avatar: some View {
+        AsyncImage(
+            url: content.avatarURL,
+            transaction: Transaction(
+                animation: LoadingStateTransition.animation(
+                    reduceMotion: reduceMotion
+                )
+            )
+        ) { phase in
+            switch phase {
+            case .success(let image):
+                image
+                    .resizable()
+                    .scaledToFill()
+                    .transition(.opacity)
+            default:
+                fallbackAvatar
+                    .transition(.opacity)
+            }
+        }
+        .frame(
+            width: VideoUploaderHeaderMetrics.avatarSize,
+            height: VideoUploaderHeaderMetrics.avatarSize
+        )
+        .background(Color.secondary.opacity(0.1))
+        .clipShape(Circle())
+        .overlay {
+            Circle()
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        }
+        .accessibilityHidden(true)
+    }
+
+    private var fallbackAvatar: some View {
+        Image(systemName: "person.crop.circle.fill")
+            .resizable()
+            .scaledToFit()
+            .symbolRenderingMode(.hierarchical)
+            .foregroundStyle(.secondary)
+    }
+}
+
+enum VideoUploaderHeaderMetrics {
+    static let avatarSize: CGFloat = 48
+    static let textSpacing: CGFloat = 4
+    static let nameSkeletonWidth: CGFloat = 128
+    static let nameSkeletonHeight: CGFloat = 20
+    static let signatureSkeletonWidth: CGFloat = 196
+    static let signatureSkeletonHeight: CGFloat = 14
+}
+
+enum VideoUploaderSignatureState: Equatable, Sendable {
+    case loading
+    case loaded(String?)
+}
+
+enum VideoUploaderSignatureContent: Equatable, Sendable {
+    case loading
+    case hidden
+    case text(String)
+}
+
+struct VideoUploaderHeaderContent: Equatable, Sendable {
+    let name: String
+    let avatarURL: URL?
+    let signature: VideoUploaderSignatureContent
+
+    init(
+        owner: VideoOwner,
+        signatureState: VideoUploaderSignatureState? = nil
+    ) {
+        let normalizedName = Self.normalized(owner.name)
+        name = normalizedName ?? "未知 UP 主"
+        avatarURL = owner.avatarURL
+        switch signatureState ?? .loaded(owner.signature) {
+        case .loading:
+            signature = .loading
+        case .loaded(let value):
+            signature =
+                Self.normalized(value).map {
+                    .text($0)
+                } ?? .hidden
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch signature {
+        case .loading:
+            return "UP 主，\(name)，签名正在加载"
+        case .text(let signature):
+            return "UP 主，\(name)，签名，\(signature)"
+        case .hidden:
+            return "UP 主，\(name)"
+        }
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized =
+            value
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+        return normalized.isEmpty ? nil : normalized
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliModels/Video/VideoModels.swift
+++ b/Packages/BiliKitCore/Sources/BiliModels/Video/VideoModels.swift
@@ -4,11 +4,18 @@ public struct VideoOwner: Sendable, Equatable {
     public let id: Int64
     public let name: String
     public let avatarURL: URL?
+    public let signature: String?
 
-    public init(id: Int64, name: String, avatarURL: URL? = nil) {
+    public init(
+        id: Int64,
+        name: String,
+        avatarURL: URL? = nil,
+        signature: String? = nil
+    ) {
         self.id = id
         self.name = name
         self.avatarURL = avatarURL
+        self.signature = signature
     }
 }
 

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/VideoUploaderHeaderTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/VideoUploaderHeaderTests.swift
@@ -1,0 +1,59 @@
+import BiliModels
+import Foundation
+import Testing
+@testable import BiliBrowseFeature
+
+struct VideoUploaderHeaderTests {
+    @Test
+    func normalizesNameAndSignatureForSingleLinePresentation() {
+        let avatarURL = URL(string: "https://example.com/avatar.webp")
+        let content = VideoUploaderHeaderContent(
+            owner: VideoOwner(
+                id: 42,
+                name: "  示例 UP 主  ",
+                avatarURL: avatarURL,
+                signature: "  用影像记录生活\n也记录技术  "
+            )
+        )
+
+        #expect(content.name == "示例 UP 主")
+        #expect(content.avatarURL == avatarURL)
+        #expect(content.signature == .text("用影像记录生活 也记录技术"))
+        #expect(
+            content.accessibilityLabel
+                == "UP 主，示例 UP 主，签名，用影像记录生活 也记录技术"
+        )
+    }
+
+    @Test
+    func hidesBlankSignatureAndProvidesNameFallback() {
+        let content = VideoUploaderHeaderContent(
+            owner: VideoOwner(
+                id: 42,
+                name: " \n ",
+                signature: "  \t\n  "
+            )
+        )
+
+        #expect(content.name == "未知 UP 主")
+        #expect(content.signature == .hidden)
+        #expect(content.accessibilityLabel == "UP 主，未知 UP 主")
+    }
+
+    @Test
+    func representsIndependentSignatureLoadingWithoutReplacingOwner() {
+        let content = VideoUploaderHeaderContent(
+            owner: VideoOwner(
+                id: 42,
+                name: "示例 UP 主",
+                avatarURL: URL(string: "https://example.com/avatar.webp")
+            ),
+            signatureState: .loading
+        )
+
+        #expect(content.name == "示例 UP 主")
+        #expect(content.avatarURL != nil)
+        #expect(content.signature == .loading)
+        #expect(content.accessibilityLabel == "UP 主，示例 UP 主，签名正在加载")
+    }
+}


### PR DESCRIPTION
## 变化

- 在播放侧栏增加 `VideoUploaderHeader`，展示视频详情已有的 UP 主头像与昵称
- 增加完整详情骨架与局部签名骨架
- 保留可选签名展示语义，为后续公开签名接入提供稳定 UI 边界
- 增加内容规范化与展示状态测试

## 原因

播放页缺少明确的内容作者信息。该层先建立由视频详情驱动的原生侧栏组件，不引入新的用户资料请求，也不改变播放器所有权。

## 用户影响

播放详情加载后可以在侧栏看到真实头像与昵称；加载期间使用既有视觉风格的骨架过渡。

## 验证

- Package 与 App 相关测试通过
- 在最新 `main` 上重放验证
- 独立 UI review 通过

## 边界

- 本 PR 不请求公开签名；签名网络接入位于下一层 stacked PR
- 不包含评论、关注、头像点击或用户资料页
- 不改变 `AppWindowOwner`、`AVPlayerEngine` 或播放器 host/item 所有权

## Stack

- 当前层：播放侧栏 UP 主卡片 UI
- 下一层：`codex/uploader-signature`