### PR TITLE
feat(playback): 接入 UP 主公开签名

### DIFF
--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -22,6 +22,7 @@ struct AppEnvironment {
     let playbackPreferencesController: PlaybackPreferencesController
     private let guestContentRepository: any GuestContentRepository
     private let relatedVideoRepository: any RelatedVideoRepository
+    private let uploaderSignatureRepository: any UploaderSignatureRepository
     private let historyRepository: any WatchHistoryRepository
     private let danmakuSession: DanmakuSession
     private let danmakuController: DanmakuPresentationController
@@ -32,6 +33,7 @@ struct AppEnvironment {
     init(
         guestContentRepository: any GuestContentRepository,
         relatedVideoRepository: any RelatedVideoRepository,
+        uploaderSignatureRepository: any UploaderSignatureRepository,
         historyRepository: any WatchHistoryRepository,
         danmakuRepository: any DanmakuSegmentRepository,
         playerEngine: AVPlayerEngine,
@@ -45,6 +47,7 @@ struct AppEnvironment {
         )
         self.guestContentRepository = guestContentRepository
         self.relatedVideoRepository = relatedVideoRepository
+        self.uploaderSignatureRepository = uploaderSignatureRepository
         self.historyRepository = historyRepository
         self.playerEngine = playerEngine
         self.playbackPreferencesController = playbackPreferencesController
@@ -80,6 +83,9 @@ struct AppEnvironment {
             playback: playerEngine,
             relatedVideoUseCase: RelatedVideoUseCase(
                 repository: relatedVideoRepository
+            ),
+            uploaderSignatureUseCase: UploaderSignatureUseCase(
+                repository: uploaderSignatureRepository
             )
         )
     }
@@ -156,6 +162,7 @@ struct AppEnvironment {
         return AppEnvironment(
             guestContentRepository: guestRepository,
             relatedVideoRepository: guestRepository,
+            uploaderSignatureRepository: guestRepository,
             historyRepository: BiliWatchHistoryRepository(client: api),
             danmakuRepository: BiliDanmakuRepository(client: api),
             playerEngine: playerEngine,

--- a/BiliKitMac/Composition/UITestContentView.swift
+++ b/BiliKitMac/Composition/UITestContentView.swift
@@ -50,7 +50,10 @@
             )
             let videoModel = GuestVideoViewModel(
                 useCase: GuestVideoUseCase(repository: repository),
-                playback: playback
+                playback: playback,
+                uploaderSignatureUseCase: UploaderSignatureUseCase(
+                    repository: repository
+                )
             )
             let danmakuModel = DanmakuControlsViewModel(
                 presentation: UITestDanmakuPresentation()
@@ -156,7 +159,9 @@
         )
     }
 
-    private struct UITestGuestRepository: GuestContentRepository {
+    private struct UITestGuestRepository: GuestContentRepository,
+        UploaderSignatureRepository
+    {
         let featuredBVID: String
         let includesSourceFixtures: Bool
         let usesMinimalPlaybackContext: Bool
@@ -199,6 +204,10 @@
                 publishedAt: Self.publishedAt,
                 dimension: VideoDimension(width: 1_920, height: 1_080, rotation: 0)
             )
+        }
+
+        func signature(for ownerID: Int64) async throws -> String? {
+            "用于验证窄侧栏中签名默认单行显示，点击后完整换行展开，再次点击恢复收起状态的公开假值。"
         }
 
         func pages(for bvid: String) async throws -> [VideoPage] {

--- a/BiliKitMacTests/VideoDetailLifecycleTests.swift
+++ b/BiliKitMacTests/VideoDetailLifecycleTests.swift
@@ -112,13 +112,19 @@ struct VideoDetailLifecycleTests {
             first: first,
             replacement: replacement
         )
-        let relatedRepository = RelatedLifecycleRepository()
+        let relatedRepository = RelatedLifecycleRepository(
+            replacementBVID: replacement.bvid
+        )
+        let signatureRepository = LifecycleUploaderSignatureRepository()
         let player = ControlledReplacementPlayback()
         let videoModel = GuestVideoViewModel(
             useCase: GuestVideoUseCase(repository: repository),
             playback: player,
             relatedVideoUseCase: RelatedVideoUseCase(
                 repository: relatedRepository
+            ),
+            uploaderSignatureUseCase: UploaderSignatureUseCase(
+                repository: signatureRepository
             )
         )
         let presentation = RecordingPresentation()
@@ -148,13 +154,17 @@ struct VideoDetailLifecycleTests {
                 danmakuModel.reset()
             }
         )
+        let selectRelatedVideo: (String) -> Void = { bvid in
+            coordinator.openPlayback(bvid)
+        }
         let playerSurface = PlayerSurfaceRecorder()
         let hostingView = NSHostingView(
             rootView: AnyView(
                 VideoPlaybackView(
                     model: videoModel,
                     danmakuModel: danmakuModel,
-                    onRetry: {}
+                    onRetry: {},
+                    onSelectRelatedVideo: selectRelatedVideo
                 ) {
                     ZStack {
                         PlayerHostView(
@@ -243,6 +253,8 @@ struct VideoDetailLifecycleTests {
                 )
         )
         #expect(player.loadedIdentities == [first.identity])
+        await videoModel.waitForCurrentUploaderSignatureTask()
+        #expect(videoModel.uploaderSignatureState == .loaded("首个签名"))
         #expect(playerSurface.createdIdentities == [surfaceIdentity])
         #expect(playerSurface.dismantledIdentities.isEmpty)
         #expect(
@@ -257,7 +269,7 @@ struct VideoDetailLifecycleTests {
         let replacementViewportOrigin = scrollToBottom(detailScrollView)
         #expect(replacementViewportOrigin.y > 0)
 
-        coordinator.openPlayback(replacement.bvid)
+        selectRelatedVideo(relatedRepository.fixture.bvid)
         #expect(
             await waitUntilAsync {
                 guard
@@ -353,6 +365,7 @@ struct VideoDetailLifecycleTests {
 
         player.succeedPendingLoad()
         await videoModel.waitForCurrentTask()
+        await videoModel.waitForCurrentUploaderSignatureTask()
         #expect(
             await waitUntil {
                 if case .ready(let context) = videoModel.state {
@@ -363,6 +376,8 @@ struct VideoDetailLifecycleTests {
             }
         )
         #expect(playerSurface.createdIdentities == [surfaceIdentity])
+        #expect(videoModel.uploaderSignatureState == .loaded("替换后签名"))
+        #expect(await signatureRepository.callCount == 2)
         #expect(playerSurface.dismantledIdentities.isEmpty)
         #expect(
             playerViews(in: hostingView).first.map(ObjectIdentifier.init)
@@ -395,6 +410,45 @@ struct VideoDetailLifecycleTests {
         #expect(presentation.stopCount > stopCountBeforeBack)
 
         window.contentView = NSView()
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func backCancelsPendingUploaderSignatureRequest()
+        async throws
+    {
+        let fixture = VideoDetailLifecycleFixture()
+        let signatureRepository = PendingLifecycleUploaderSignatureRepository()
+        let videoModel = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(
+                repository: VideoDetailLifecycleRepository(fixture: fixture)
+            ),
+            playback: RecordingLifecyclePlayback(),
+            uploaderSignatureUseCase: UploaderSignatureUseCase(
+                repository: signatureRepository
+            )
+        )
+        let coordinator = AppNavigationCoordinator(
+            startPlayback: { bvid in
+                videoModel.loadVideo(bvid)
+            },
+            stopPlayback: {
+                videoModel.reset()
+            }
+        )
+
+        coordinator.openPlayback(fixture.bvid)
+        await videoModel.waitForCurrentTask()
+        try await signatureRepository.waitForRequest()
+        #expect(videoModel.uploaderSignatureState == .loading)
+
+        coordinator.playbackPath = []
+        await signatureRepository.releaseLateResult()
+        try await signatureRepository.waitForCompletion()
+
+        #expect(videoModel.state == .idle)
+        #expect(videoModel.presentedContext == nil)
+        #expect(videoModel.uploaderSignatureState == .loaded(nil))
     }
 
     @Test(.timeLimit(.minutes(1)))
@@ -880,17 +934,21 @@ private actor ReplacementLifecycleRepository: GuestContentRepository {
 }
 
 private actor RelatedLifecycleRepository: RelatedVideoRepository {
-    nonisolated let fixture = RelatedVideo(
-        bvid: "BV1RelatedA1",
-        title: "相关推荐",
-        coverURL: nil,
-        ownerName: "测试作者",
-        viewCount: 100,
-        danmakuCount: 10,
-        durationSeconds: 120
-    )
+    nonisolated let fixture: RelatedVideo
     private var didStartFirstRequest = false
     private var firstRequest: CheckedContinuation<[RelatedVideo], Never>?
+
+    init(replacementBVID: String) {
+        fixture = RelatedVideo(
+            bvid: replacementBVID,
+            title: "相关推荐",
+            coverURL: nil,
+            ownerName: "测试作者",
+            viewCount: 100,
+            danmakuCount: 10,
+            durationSeconds: 120
+        )
+    }
 
     func relatedVideos(to bvid: String) async throws -> [RelatedVideo] {
         guard !didStartFirstRequest else { return [] }
@@ -907,6 +965,63 @@ private actor RelatedLifecycleRepository: RelatedVideoRepository {
     func releaseFirstRequest() {
         firstRequest?.resume(returning: [fixture])
         firstRequest = nil
+    }
+}
+
+private actor LifecycleUploaderSignatureRepository:
+    UploaderSignatureRepository
+{
+    private(set) var callCount = 0
+
+    func signature(for ownerID: Int64) async throws -> String? {
+        callCount += 1
+        return callCount == 1 ? "首个签名" : "替换后签名"
+    }
+}
+
+private actor PendingLifecycleUploaderSignatureRepository:
+    UploaderSignatureRepository
+{
+    private var requestStarted = false
+    private var requestWaiters: [CheckedContinuation<Void, Never>] = []
+    private var resultContinuation: CheckedContinuation<String?, Never>?
+    private var requestCompleted = false
+    private var completionWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func signature(for ownerID: Int64) async throws -> String? {
+        requestStarted = true
+        for waiter in requestWaiters {
+            waiter.resume()
+        }
+        requestWaiters.removeAll()
+        let result = await withCheckedContinuation { continuation in
+            resultContinuation = continuation
+        }
+        requestCompleted = true
+        for waiter in completionWaiters {
+            waiter.resume()
+        }
+        completionWaiters.removeAll()
+        return result
+    }
+
+    func waitForRequest() async throws {
+        guard !requestStarted else { return }
+        await withCheckedContinuation { continuation in
+            requestWaiters.append(continuation)
+        }
+    }
+
+    func releaseLateResult() {
+        resultContinuation?.resume(returning: "迟到签名")
+        resultContinuation = nil
+    }
+
+    func waitForCompletion() async throws {
+        guard !requestCompleted else { return }
+        await withCheckedContinuation { continuation in
+            completionWaiters.append(continuation)
+        }
     }
 }
 

--- a/BiliKitMacUITests/BiliKitMacUITests.swift
+++ b/BiliKitMacUITests/BiliKitMacUITests.swift
@@ -342,6 +342,48 @@ final class BiliKitMacUITests: XCTestCase {
     }
 
     @MainActor
+    func testUploaderSignatureButtonExpandsWithinSidebarAndCollapses() {
+        let app = launchFixture(arguments: ["-ui-testing"])
+        let video = element("feed.item.fixture-video-1", in: app)
+        XCTAssertTrue(waitForHittable(video, timeout: 5))
+        video.click()
+
+        let sidebar = element("sidebar.playback-context", in: app)
+        let signature = app.buttons[
+            "sidebar.playback-uploader.signature"
+        ]
+        XCTAssertTrue(sidebar.waitForExistence(timeout: 5))
+        XCTAssertTrue(waitForHittable(signature, timeout: 5))
+        XCTAssertEqual(signature.label, "UP 主签名")
+        XCTAssertTrue(accessibilityText(of: signature).hasPrefix("已收起，"))
+        let collapsedFrame = signature.frame
+
+        signature.click()
+
+        XCTAssertTrue(
+            waitForAccessibilityText(
+                signature,
+                beginningWith: "已展开，",
+                timeout: 5
+            )
+        )
+        XCTAssertGreaterThan(signature.frame.height, collapsedFrame.height)
+        XCTAssertGreaterThanOrEqual(signature.frame.minX, sidebar.frame.minX)
+        XCTAssertLessThanOrEqual(signature.frame.maxX, sidebar.frame.maxX)
+
+        signature.click()
+
+        XCTAssertTrue(
+            waitForAccessibilityText(
+                signature,
+                beginningWith: "已收起，",
+                timeout: 5
+            )
+        )
+        XCTAssertEqual(signature.frame.height, collapsedFrame.height, accuracy: 1)
+    }
+
+    @MainActor
     func testPlaybackSidebarHidesEmptySummaryAndSinglePart() {
         let app = launchFixture(arguments: [
             "-ui-testing",
@@ -972,6 +1014,21 @@ final class BiliKitMacUITests: XCTestCase {
         let expectation = XCTNSPredicateExpectation(
             predicate: NSPredicate { _, _ in
                 self.accessibilityText(of: element) == expectedText
+            },
+            object: element
+        )
+        return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    @MainActor
+    private func waitForAccessibilityText(
+        _ element: XCUIElement,
+        beginningWith expectedPrefix: String,
+        timeout: TimeInterval
+    ) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in
+                self.accessibilityText(of: element).hasPrefix(expectedPrefix)
             },
             object: element
         )

--- a/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliGuestRepository.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliGuestRepository.swift
@@ -1,7 +1,9 @@
 import BiliApplication
 import BiliModels
 
-public struct BiliGuestRepository: GuestContentRepository, RelatedVideoRepository {
+public struct BiliGuestRepository: GuestContentRepository, RelatedVideoRepository,
+    UploaderSignatureRepository
+{
     private let client: BiliAPIClient
 
     public init(client: BiliAPIClient) {
@@ -35,6 +37,12 @@ public struct BiliGuestRepository: GuestContentRepository, RelatedVideoRepositor
     public func relatedVideos(to bvid: String) async throws -> [RelatedVideo] {
         try await mapError {
             try await client.relatedVideos(to: bvid)
+        }
+    }
+
+    public func signature(for ownerID: Int64) async throws -> String? {
+        try await mapError {
+            try await client.uploaderSignature(for: ownerID)
         }
     }
 

--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
@@ -128,6 +128,35 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
         return try payload.map { try $0.model() }
     }
 
+    /// 匿名读取公开 UP 主签名；不会请求认证授权器或 WBI 签名。
+    public func uploaderSignature(for ownerID: Int64) async throws -> String? {
+        guard ownerID > 0 else {
+            throw BiliAPIError.invalidRequest
+        }
+        let path = "/x/web-interface/card"
+        let queryItems = [
+            URLQueryItem(name: "mid", value: String(ownerID)),
+            URLQueryItem(name: "photo", value: "false"),
+        ]
+        let url = try endpoint(path: path, queryItems: queryItems)
+        guard
+            Self.isExactUploaderCardEndpoint(
+                url,
+                ownerID: ownerID
+            )
+        else {
+            throw BiliAPIError.invalidRequest
+        }
+        let payload: UploaderCardDataPayload = try await get(
+            url: url,
+            referer: "https://space.bilibili.com/"
+        )
+        guard payload.card.mid == ownerID else {
+            throw BiliAPIError.decodingFailed
+        }
+        return payload.card.sign
+    }
+
     public func pages(for bvid: String) async throws -> [VideoPage] {
         guard Self.isValidBVID(bvid) else {
             throw BiliAPIError.invalidRequest
@@ -621,6 +650,28 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
 
     private static func videoReferer(_ bvid: String) -> String {
         "https://www.bilibili.com/video/\(bvid)/"
+    }
+
+    private static func isExactUploaderCardEndpoint(
+        _ url: URL,
+        ownerID: Int64
+    ) -> Bool {
+        guard
+            let components = URLComponents(
+                url: url,
+                resolvingAgainstBaseURL: false
+            )
+        else { return false }
+        return components.scheme == "https"
+            && components.host == "api.bilibili.com"
+            && components.port == nil
+            && components.user == nil
+            && components.password == nil
+            && components.path == "/x/web-interface/card"
+            && components.queryItems == [
+                URLQueryItem(name: "mid", value: String(ownerID)),
+                URLQueryItem(name: "photo", value: "false"),
+            ]
     }
 
     private static func looksLikeJSON(_ response: HTTPResponse) -> Bool {

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/VideoEndpointPayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/VideoEndpointPayloads.swift
@@ -89,6 +89,38 @@ struct OwnerPayload: Decodable, Sendable {
     }
 }
 
+struct UploaderCardDataPayload: Decodable, Sendable {
+    let card: UploaderCardPayload
+}
+
+struct UploaderCardPayload: Decodable, Sendable {
+    let mid: Int64
+    let sign: String
+
+    private enum CodingKeys: String, CodingKey {
+        case mid
+        case sign
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let numericMID = try? container.decode(Int64.self, forKey: .mid) {
+            mid = numericMID
+        } else {
+            let stringMID = try container.decode(String.self, forKey: .mid)
+            guard let numericMID = Int64(stringMID) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .mid,
+                    in: container,
+                    debugDescription: "Uploader MID is not an integer"
+                )
+            }
+            mid = numericMID
+        }
+        sign = try container.decode(String.self, forKey: .sign)
+    }
+}
+
 struct StatisticsPayload: Decodable, Sendable {
     let view: Int64
     let danmaku: Int64

--- a/Packages/BiliKitCore/Sources/BiliAPIProbe/main.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPIProbe/main.swift
@@ -11,6 +11,8 @@ struct BiliAPIProbe {
                 try await runSearch(keyword: keyword, page: page)
             case .related:
                 try await runRelated()
+            case .uploaderSignature:
+                try await runUploaderSignature()
             case .m4Contract(let bvid, let cid):
                 try await M4ContractProbe().run(bvid: bvid, cid: cid)
             }
@@ -39,6 +41,35 @@ struct BiliAPIProbe {
         print("related: count=\(videos.count) production-decoder=ready")
     }
 
+    private static func runUploaderSignature() async throws {
+        let client = BiliAPIClient(
+            transport: UploaderSignatureProbeTransport()
+        )
+        guard let sample = try await client.popular(pageSize: 1).videos.first
+        else {
+            throw ProbeError.emptyResponse
+        }
+        let signature = try await client.uploaderSignature(
+            for: sample.owner.id
+        )
+        let count = signature?.count ?? 0
+        let lengthRange: String
+        switch count {
+        case 0:
+            lengthRange = "empty"
+        case 1...80:
+            lengthRange = "1-80"
+        case 81...256:
+            lengthRange = "81-256"
+        default:
+            lengthRange = "over-256"
+        }
+        print(
+            "uploader-signature: business=success mid-match=true "
+                + "sign-present=\(count > 0) length-range=\(lengthRange)"
+        )
+    }
+
     private static func runSearch(keyword: String, page: Int) async throws {
         let page = try await BiliAPIClient(
             transport: SearchProbeTransport()
@@ -50,6 +81,26 @@ struct BiliAPIProbe {
 
     private static func writeError(_ message: String) {
         FileHandle.standardError.write(Data(message.utf8))
+    }
+}
+
+private actor UploaderSignatureProbeTransport: HTTPTransport {
+    private let transport: URLSessionTransport
+
+    init() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpShouldSetCookies = false
+        configuration.httpCookieStorage = nil
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        transport = URLSessionTransport(
+            configuration: configuration,
+            redirectPolicy: .reject
+        )
+    }
+
+    func send(_ request: HTTPRequest) async throws -> HTTPResponse {
+        try await transport.send(request)
     }
 }
 
@@ -204,6 +255,7 @@ private struct Configuration {
     enum Mode {
         case search(keyword: String, page: Int)
         case related
+        case uploaderSignature
         case m4Contract(bvid: String, cid: Int64)
     }
 
@@ -220,6 +272,8 @@ private struct Configuration {
         switch values["mode"] {
         case "related":
             mode = .related
+        case "uploader-signature":
+            mode = .uploaderSignature
         case "m4-contract":
             guard
                 let bvid = values["bvid"],

--- a/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestContracts.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestContracts.swift
@@ -25,3 +25,8 @@ public protocol GuestContentRepository: Sendable {
 public protocol RelatedVideoRepository: Sendable {
     func relatedVideos(to bvid: String) async throws -> [RelatedVideo]
 }
+
+/// 播放页只读 UP 主签名所需的独立匿名 port。
+public protocol UploaderSignatureRepository: Sendable {
+    func signature(for ownerID: Int64) async throws -> String?
+}

--- a/Packages/BiliKitCore/Sources/BiliApplication/Guest/UploaderSignatureUseCase.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Guest/UploaderSignatureUseCase.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// 取得并规范化当前视频 UP 主的可选公开签名。
+public struct UploaderSignatureUseCase: Sendable {
+    private let repository: any UploaderSignatureRepository
+
+    public init(repository: any UploaderSignatureRepository) {
+        self.repository = repository
+    }
+
+    public func signature(for ownerID: Int64) async throws -> String? {
+        guard ownerID > 0 else {
+            throw GuestApplicationError.invalidRequest
+        }
+        let signature = try await repository.signature(for: ownerID)
+        try Task.checkCancellation()
+        guard let signature else { return nil }
+        let normalized =
+            signature
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+        return normalized.isEmpty ? nil : normalized
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoViewModel.swift
@@ -37,6 +37,8 @@ public enum RelatedVideoState: Sendable, Equatable {
 public final class GuestVideoViewModel {
     public private(set) var state: GuestVideoState = .idle
     public private(set) var relatedVideoState: RelatedVideoState = .idle
+    public private(set) var uploaderSignatureState: VideoUploaderSignatureState =
+        .loaded(nil)
     /// 供播放主区与上下文 Sidebar 共享的最近有效详情。
     ///
     /// 新视频加载或失败期间保留旧值，使同一个播放 surface 不因短暂状态拆除；取得新
@@ -52,21 +54,26 @@ public final class GuestVideoViewModel {
     @ObservationIgnored private let useCase: GuestVideoUseCase
     @ObservationIgnored private let playback: any PlaybackControlling
     @ObservationIgnored private let relatedVideoUseCase: RelatedVideoUseCase?
+    @ObservationIgnored private let uploaderSignatureUseCase: UploaderSignatureUseCase?
     @ObservationIgnored private var loadTask: Task<Void, Never>?
     @ObservationIgnored private var relatedVideoTask: Task<Void, Never>?
+    @ObservationIgnored private var uploaderSignatureTask: Task<Void, Never>?
     @ObservationIgnored private var playbackFailureTask: Task<Void, Never>?
     @ObservationIgnored private var playbackIntent: PlaybackLoadIntent?
     @ObservationIgnored private var generation = 0
     @ObservationIgnored private var relatedVideoGeneration = 0
+    @ObservationIgnored private var uploaderSignatureGeneration = 0
 
     public init(
         useCase: GuestVideoUseCase,
         playback: any PlaybackControlling,
-        relatedVideoUseCase: RelatedVideoUseCase? = nil
+        relatedVideoUseCase: RelatedVideoUseCase? = nil,
+        uploaderSignatureUseCase: UploaderSignatureUseCase? = nil
     ) {
         self.useCase = useCase
         self.playback = playback
         self.relatedVideoUseCase = relatedVideoUseCase
+        self.uploaderSignatureUseCase = uploaderSignatureUseCase
         playbackFailureTask = Task { [weak self, playback] in
             for await event in playback.playbackFailureEvents() {
                 guard !Task.isCancelled else { return }
@@ -78,6 +85,7 @@ public final class GuestVideoViewModel {
     deinit {
         loadTask?.cancel()
         relatedVideoTask?.cancel()
+        uploaderSignatureTask?.cancel()
         playbackFailureTask?.cancel()
     }
 
@@ -86,6 +94,7 @@ public final class GuestVideoViewModel {
         generation += 1
         let currentGeneration = generation
         loadTask?.cancel()
+        cancelUploaderSignature()
         if state != .idle {
             playback.stop()
         }
@@ -164,6 +173,7 @@ public final class GuestVideoViewModel {
         relatedVideoTask?.cancel()
         relatedVideoTask = nil
         relatedVideoState = .idle
+        cancelUploaderSignature()
         presentedContext = nil
         requestedPlaybackIdentity = nil
         presentedPlaybackIdentity = nil
@@ -186,6 +196,14 @@ public final class GuestVideoViewModel {
 
     func relatedVideoTaskSnapshotForTesting() -> Task<Void, Never>? {
         relatedVideoTask
+    }
+
+    public func waitForCurrentUploaderSignatureTask() async {
+        await uploaderSignatureTask?.value
+    }
+
+    func uploaderSignatureTaskSnapshotForTesting() -> Task<Void, Never>? {
+        uploaderSignatureTask
     }
 
     private func loadRelatedVideos(for bvid: String) {
@@ -247,6 +265,7 @@ public final class GuestVideoViewModel {
             guard generation == currentGeneration else { return }
 
             presentedContext = context
+            loadUploaderSignature(for: context.detail.owner.id)
             let identity = PlaybackItemIdentity(
                 bvid: context.detail.bvid,
                 cid: context.selectedPage.cid
@@ -379,5 +398,42 @@ public final class GuestVideoViewModel {
     ) {
         guard error == .authenticationInvalid else { return }
         authenticationRevalidationGeneration += 1
+    }
+
+    private func loadUploaderSignature(for ownerID: Int64) {
+        uploaderSignatureGeneration += 1
+        let currentGeneration = uploaderSignatureGeneration
+        uploaderSignatureTask?.cancel()
+        guard let uploaderSignatureUseCase else {
+            uploaderSignatureState = .loaded(nil)
+            uploaderSignatureTask = nil
+            return
+        }
+        uploaderSignatureState = .loading
+        uploaderSignatureTask = Task { [weak self] in
+            let signature: String?
+            do {
+                let resolved = try await uploaderSignatureUseCase.signature(
+                    for: ownerID
+                )
+                try Task.checkCancellation()
+                signature = resolved
+            } catch {
+                signature = nil
+            }
+            guard let self,
+                self.uploaderSignatureGeneration == currentGeneration,
+                !Task.isCancelled
+            else { return }
+            self.uploaderSignatureState = .loaded(signature)
+            self.uploaderSignatureTask = nil
+        }
+    }
+
+    private func cancelUploaderSignature() {
+        uploaderSignatureGeneration += 1
+        uploaderSignatureTask?.cancel()
+        uploaderSignatureTask = nil
+        uploaderSignatureState = .loaded(nil)
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/PlaybackContextSidebar.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/PlaybackContextSidebar.swift
@@ -51,7 +51,11 @@ public struct PlaybackContextSidebar: View {
     private func sidebarContent(_ context: GuestVideoContext) -> some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 16) {
-                VideoUploaderHeader(owner: context.detail.owner)
+                VideoUploaderHeader(
+                    owner: context.detail.owner,
+                    signatureState: model.uploaderSignatureState
+                )
+                .id(context.detail.bvid)
 
                 Divider()
 
@@ -79,8 +83,10 @@ public struct PlaybackContextSidebar: View {
             Text(summary)
                 .font(.callout)
                 .foregroundStyle(.secondary)
+                .multilineTextAlignment(.leading)
                 .textSelection(.enabled)
                 .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.top, 8)
                 .accessibilityIdentifier("sidebar.playback-summary.text")
         }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/RelatedVideoShelf.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/RelatedVideoShelf.swift
@@ -14,6 +14,14 @@ struct RelatedVideoShelfItem: Identifiable, Equatable, Sendable {
     var id: String { bvid }
 }
 
+struct RelatedVideoShelfSelection {
+    let onSelect: (String) -> Void
+
+    func select(_ item: RelatedVideoShelfItem) {
+        onSelect(item.bvid)
+    }
+}
+
 enum RelatedVideoShelfState: Equatable, Sendable {
     case loading
     case loaded([RelatedVideoShelfItem])
@@ -38,7 +46,7 @@ struct RelatedVideoShelf: View {
     private static let contentPadding: CGFloat = 40
 
     let state: RelatedVideoShelfState
-    let onSelect: (String) -> Void
+    let selection: RelatedVideoShelfSelection
     let onRetry: () -> Void
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -55,7 +63,7 @@ struct RelatedVideoShelf: View {
         onRetry: @escaping () -> Void
     ) {
         self.state = state
-        self.onSelect = onSelect
+        selection = RelatedVideoShelfSelection(onSelect: onSelect)
         self.onRetry = onRetry
     }
 
@@ -178,7 +186,7 @@ struct RelatedVideoShelf: View {
 
     private func card(_ item: RelatedVideoShelfItem) -> some View {
         Button {
-            onSelect(item.bvid)
+            selection.select(item)
         } label: {
             RelatedVideoCard(
                 item: item,

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoUploaderHeader.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoUploaderHeader.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// 资料来源时只需更新 owner 数据，Sidebar 的布局与播放生命周期保持不变。
 struct VideoUploaderHeader: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isSignatureExpanded = false
     @ScaledMetric(relativeTo: .callout)
     private var signatureSkeletonHeight =
         VideoUploaderHeaderMetrics.signatureSkeletonHeight
@@ -43,6 +44,8 @@ struct VideoUploaderHeader: View {
                     .font(.title3.weight(.semibold))
                     .lineLimit(1)
                     .truncationMode(.tail)
+                    .textSelection(.enabled)
+                    .accessibilityLabel("UP 主，\(content.name)")
 
                 signature
                     .animation(
@@ -51,13 +54,14 @@ struct VideoUploaderHeader: View {
                         ),
                         value: content.signature
                     )
+                    .onChange(of: content.signature) {
+                        isSignatureExpanded = false
+                    }
             }
-            .textSelection(.enabled)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(content.accessibilityLabel)
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("sidebar.playback-uploader")
     }
 
@@ -72,17 +76,64 @@ struct VideoUploaderHeader: View {
                     height: signatureSkeletonHeight
                 )
                 .transition(.opacity)
-                .accessibilityHidden(true)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("签名正在加载")
         case .text(let signature):
-            Text(signature)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .transition(.opacity)
+            ViewThatFits(in: .horizontal) {
+                signatureText(signature, lineLimit: 1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .textSelection(.enabled)
+                    .accessibilityIdentifier(
+                        "sidebar.playback-uploader.signature"
+                    )
+
+                Button {
+                    withAnimation(
+                        LoadingStateTransition.animation(
+                            reduceMotion: reduceMotion
+                        )
+                    ) {
+                        isSignatureExpanded.toggle()
+                    }
+                } label: {
+                    signatureText(
+                        signature,
+                        lineLimit: isSignatureExpanded ? nil : 1
+                    )
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityLabel("UP 主签名")
+                .accessibilityValue(
+                    isSignatureExpanded ? "已展开，\(signature)" : "已收起，\(signature)"
+                )
+                .accessibilityHint(
+                    isSignatureExpanded ? "点击收起" : "点击展开完整签名"
+                )
+                .accessibilityIdentifier(
+                    "sidebar.playback-uploader.signature"
+                )
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .transition(.opacity)
         case .hidden:
             EmptyView()
         }
+    }
+
+    private func signatureText(
+        _ signature: String,
+        lineLimit: Int?
+    ) -> some View {
+        Text(signature)
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .lineLimit(lineLimit)
+            .truncationMode(.tail)
+            .multilineTextAlignment(.leading)
     }
 
     private var avatar: some View {
@@ -136,7 +187,7 @@ enum VideoUploaderHeaderMetrics {
     static let signatureSkeletonHeight: CGFloat = 14
 }
 
-enum VideoUploaderSignatureState: Equatable, Sendable {
+public enum VideoUploaderSignatureState: Equatable, Sendable {
     case loading
     case loaded(String?)
 }

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
@@ -129,6 +129,106 @@ struct BiliAPIClientTests {
     }
 
     @Test
+    func uploaderSignatureUsesExactAnonymousCardEndpoint() async throws {
+        let transport = RecordingTransport(
+            responses: [try fixtureResponse("uploader-card")]
+        )
+        let authorizer = RecordingRequestAuthorizer()
+        let client = BiliAPIClient(
+            transport: transport,
+            requestAuthorizer: authorizer
+        )
+
+        let signature = try await client.uploaderSignature(for: 10_001)
+
+        #expect(signature == "用影像记录生活")
+        let request = try #require(await transport.capturedRequests().first)
+        #expect(request.method == .get)
+        #expect(request.url.scheme == "https")
+        #expect(request.url.host == "api.bilibili.com")
+        #expect(request.url.port == nil)
+        #expect(request.url.path == "/x/web-interface/card")
+        #expect(
+            URLComponents(url: request.url, resolvingAgainstBaseURL: false)?
+                .queryItems == [
+                    URLQueryItem(name: "mid", value: "10001"),
+                    URLQueryItem(name: "photo", value: "false"),
+                ]
+        )
+        #expect(request.headers["Cookie"] == nil)
+        #expect(request.headers["Authorization"] == nil)
+        #expect(await authorizer.capturedPaths().isEmpty)
+    }
+
+    @Test
+    func uploaderSignatureAcceptsNumericMID() async throws {
+        let response = jsonResponse(
+            #"{"code":0,"data":{"card":{"mid":10001,"sign":"签名"}}}"#
+        )
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [response])
+        )
+
+        #expect(try await client.uploaderSignature(for: 10_001) == "签名")
+    }
+
+    @Test
+    func uploaderSignatureRejectsMismatchedMID() async {
+        let response = jsonResponse(
+            #"{"code":0,"data":{"card":{"mid":"10002","sign":"签名"}}}"#
+        )
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [response])
+        )
+
+        await #expect(throws: BiliAPIError.decodingFailed) {
+            try await client.uploaderSignature(for: 10_001)
+        }
+    }
+
+    @Test
+    func uploaderSignaturePreservesBlankValueForApplicationNormalization()
+        async throws
+    {
+        let response = jsonResponse(
+            #"{"code":0,"data":{"card":{"mid":"10001","sign":"  \n "}}}"#
+        )
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [response])
+        )
+
+        #expect(try await client.uploaderSignature(for: 10_001) == "  \n ")
+    }
+
+    @Test(arguments: [302, 307])
+    func uploaderSignatureRejectsRedirectResponse(statusCode: Int) async {
+        let client = BiliAPIClient(
+            transport: RecordingTransport(
+                responses: [HTTPResponse(statusCode: statusCode, body: Data())]
+            )
+        )
+
+        await #expect(throws: BiliAPIError.httpStatus(statusCode)) {
+            try await client.uploaderSignature(for: 10_001)
+        }
+    }
+
+    @Test
+    func uploaderSignatureRejectsBusinessFailure() async {
+        let client = BiliAPIClient(
+            transport: RecordingTransport(
+                responses: [jsonResponse(#"{"code":-352,"message":"blocked"}"#)]
+            )
+        )
+
+        await #expect(
+            throws: BiliAPIError.apiRejected(code: -352, message: "blocked")
+        ) {
+            try await client.uploaderSignature(for: 10_001)
+        }
+    }
+
+    @Test
     func searchUsesWBIAndNormalizesEndpointQuirks() async throws {
         let transport = RecordingTransport(
             responses: [
@@ -812,6 +912,14 @@ struct BiliAPIClientTests {
             statusCode: 200,
             headers: ["Content-Type": "application/json; charset=utf-8"],
             body: try Data(contentsOf: url)
+        )
+    }
+
+    private func jsonResponse(_ source: String) -> HTTPResponse {
+        HTTPResponse(
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"],
+            body: Data(source.utf8)
         )
     }
 }

--- a/Packages/BiliKitCore/Tests/BiliAPITests/Fixtures/README.md
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/Fixtures/README.md
@@ -5,6 +5,7 @@
 - 标识符、标题、详情、作者和统计数据为虚构值。
 - 图片与媒体地址只使用 `example.invalid`。
 - 不包含 Cookie、token、WBI 签名、实时响应 body 或带签名媒体 URL。
+- `uploader-card.json` 只包含虚构身份与自写签名，用于固定公开 card DTO 边界。
 - 热门、详情、分 P、playurl、nav WBI key 与搜索字段形状依据 2026-07-21 的匿名接口响应重新核对，但内容不是线上响应副本。
 
 M4 fixture 同样全部为手写假值：

--- a/Packages/BiliKitCore/Tests/BiliAPITests/Fixtures/uploader-card.json
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/Fixtures/uploader-card.json
@@ -1,0 +1,16 @@
+{
+  "code": 0,
+  "message": "0",
+  "data": {
+    "card": {
+      "mid": "10001",
+      "name": "虚构作者",
+      "face": "https://image.example.invalid/avatar.jpg",
+      "sign": "用影像记录生活",
+      "fans": 123,
+      "likes": 456,
+      "vip": { "type": 2 },
+      "sex": "保密"
+    }
+  }
+}

--- a/Packages/BiliKitCore/Tests/BiliApplicationTests/UploaderSignatureUseCaseTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliApplicationTests/UploaderSignatureUseCaseTests.swift
@@ -1,0 +1,57 @@
+import BiliApplication
+import Testing
+
+struct UploaderSignatureUseCaseTests {
+    @Test
+    func normalizesPublicSignatureWhitespace() async throws {
+        let useCase = UploaderSignatureUseCase(
+            repository: UploaderSignatureRepositoryStub(
+                result: "  记录生活\n也记录技术  "
+            )
+        )
+
+        #expect(
+            try await useCase.signature(for: 10_001)
+                == "记录生活 也记录技术"
+        )
+    }
+
+    @Test(arguments: [nil, "", " \t\n "])
+    func emptyPublicSignatureBecomesAbsent(value: String?) async throws {
+        let useCase = UploaderSignatureUseCase(
+            repository: UploaderSignatureRepositoryStub(result: value)
+        )
+
+        #expect(try await useCase.signature(for: 10_001) == nil)
+    }
+
+    @Test
+    func rejectsInvalidOwnerBeforeRepository() async {
+        let repository = CountingUploaderSignatureRepository()
+        let useCase = UploaderSignatureUseCase(repository: repository)
+
+        await #expect(throws: GuestApplicationError.invalidRequest) {
+            try await useCase.signature(for: 0)
+        }
+        #expect(await repository.callCount == 0)
+    }
+}
+
+private struct UploaderSignatureRepositoryStub: UploaderSignatureRepository {
+    let result: String?
+
+    func signature(for ownerID: Int64) async throws -> String? {
+        result
+    }
+}
+
+private actor CountingUploaderSignatureRepository:
+    UploaderSignatureRepository
+{
+    private(set) var callCount = 0
+
+    func signature(for ownerID: Int64) async throws -> String? {
+        callCount += 1
+        return nil
+    }
+}

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
@@ -701,6 +701,213 @@ struct GuestBrowseAndVideoViewModelTests {
         #expect(player.loadedPlaybacks.count == 1)
         #expect(await relatedRepository.callCount == 2)
     }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func uploaderSignatureLoadsWithoutBlockingReadyDetail() async throws {
+        let fixture = GuestFixtures()
+        let signatureRepository = SequencedUploaderSignatureRepository()
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(
+                repository: GuestRepositoryStub(fixtures: fixture)
+            ),
+            playback: RecordingPlayerEngine(),
+            uploaderSignatureUseCase: UploaderSignatureUseCase(
+                repository: signatureRepository
+            )
+        )
+
+        model.loadVideo(fixture.bvid)
+        await model.waitForCurrentTask()
+        try await signatureRepository.waitForRequestCount(1)
+
+        #expect(model.presentedContext?.detail == fixture.detail)
+        #expect(model.uploaderSignatureState == .loading)
+
+        await signatureRepository.releaseRequest(0, signature: "公开签名")
+        await model.waitForCurrentUploaderSignatureTask()
+
+        #expect(model.uploaderSignatureState == .loaded("公开签名"))
+    }
+
+    @Test
+    @MainActor
+    func uploaderSignatureFailureHidesOnlyEnhancement() async {
+        let fixture = GuestFixtures()
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(
+                repository: GuestRepositoryStub(fixtures: fixture)
+            ),
+            playback: RecordingPlayerEngine(),
+            uploaderSignatureUseCase: UploaderSignatureUseCase(
+                repository: FailingUploaderSignatureRepository()
+            )
+        )
+
+        model.loadVideo(fixture.bvid)
+        await model.waitForCurrentTask()
+        await model.waitForCurrentUploaderSignatureTask()
+
+        #expect(
+            model.state
+                == .ready(
+                    GuestVideoContext(
+                        detail: fixture.detail,
+                        pages: [fixture.page],
+                        selectedPage: fixture.page,
+                        playback: fixture.playback
+                    )
+                )
+        )
+        #expect(model.uploaderSignatureState == .loaded(nil))
+    }
+
+    @Test
+    @MainActor
+    func pageSwitchDoesNotReloadUploaderSignature() async {
+        let fixture = GuestFixtures()
+        let signatureRepository = CountingUploaderSignatureRepositoryStub()
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(
+                repository: PartSwitchRepositoryStub(fixtures: fixture)
+            ),
+            playback: RecordingPlayerEngine(),
+            uploaderSignatureUseCase: UploaderSignatureUseCase(
+                repository: signatureRepository
+            )
+        )
+
+        model.loadVideo(fixture.bvid)
+        await model.waitForCurrentTask()
+        await model.waitForCurrentUploaderSignatureTask()
+        model.selectPage(cid: 900_002)
+        await model.waitForCurrentTask()
+
+        #expect(model.uploaderSignatureState == .loaded("公开签名"))
+        #expect(await signatureRepository.callCount == 1)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func uploaderSignatureABARejectsOldSameOwnerResult() async throws {
+        let first = GuestFixtures(bvid: "BV1SignatureA", title: "视频 A")
+        let second = GuestFixtures(bvid: "BV1SignatureB", title: "视频 B")
+        let signatureRepository = SequencedUploaderSignatureRepository()
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(
+                repository: VideoOutcomeRepositoryStub(
+                    fixtures: [first, second]
+                )
+            ),
+            playback: RecordingPlayerEngine(),
+            uploaderSignatureUseCase: UploaderSignatureUseCase(
+                repository: signatureRepository
+            )
+        )
+
+        model.loadVideo(first.bvid)
+        await model.waitForCurrentTask()
+        try await signatureRepository.waitForRequestCount(1)
+        let oldA = try #require(
+            model.uploaderSignatureTaskSnapshotForTesting()
+        )
+
+        model.loadVideo(second.bvid)
+        await model.waitForCurrentTask()
+        try await signatureRepository.waitForRequestCount(2)
+        model.loadVideo(first.bvid)
+        await model.waitForCurrentTask()
+        try await signatureRepository.waitForRequestCount(3)
+
+        await signatureRepository.releaseRequest(2, signature: "新 A 签名")
+        await model.waitForCurrentUploaderSignatureTask()
+        await signatureRepository.releaseRequest(0, signature: "旧 A 签名")
+        await oldA.value
+        await signatureRepository.releaseRequest(1, signature: "旧 B 签名")
+
+        #expect(model.presentedContext?.detail.bvid == first.bvid)
+        #expect(model.uploaderSignatureState == .loaded("新 A 签名"))
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func resetCancelsAndIsolatesLateUploaderSignature() async throws {
+        let fixture = GuestFixtures()
+        let signatureRepository = SequencedUploaderSignatureRepository()
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(
+                repository: GuestRepositoryStub(fixtures: fixture)
+            ),
+            playback: RecordingPlayerEngine(),
+            uploaderSignatureUseCase: UploaderSignatureUseCase(
+                repository: signatureRepository
+            )
+        )
+
+        model.loadVideo(fixture.bvid)
+        await model.waitForCurrentTask()
+        try await signatureRepository.waitForRequestCount(1)
+        let cancelledTask = try #require(
+            model.uploaderSignatureTaskSnapshotForTesting()
+        )
+        model.reset()
+        await signatureRepository.releaseRequest(0, signature: "迟到签名")
+        await cancelledTask.value
+
+        #expect(model.state == .idle)
+        #expect(model.presentedContext == nil)
+        #expect(model.uploaderSignatureState == .loaded(nil))
+    }
+}
+
+private struct FailingUploaderSignatureRepository:
+    UploaderSignatureRepository
+{
+    func signature(for ownerID: Int64) async throws -> String? {
+        throw GuestApplicationError.transportFailure
+    }
+}
+
+private actor CountingUploaderSignatureRepositoryStub:
+    UploaderSignatureRepository
+{
+    private(set) var callCount = 0
+
+    func signature(for ownerID: Int64) async throws -> String? {
+        callCount += 1
+        return "公开签名"
+    }
+}
+
+private actor SequencedUploaderSignatureRepository:
+    UploaderSignatureRepository
+{
+    private var continuations: [CheckedContinuation<String?, Never>?] = []
+    private var requestWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func signature(for ownerID: Int64) async throws -> String? {
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+            let waiters = requestWaiters
+            requestWaiters.removeAll()
+            for waiter in waiters {
+                waiter.resume()
+            }
+        }
+    }
+
+    func waitForRequestCount(_ count: Int) async throws {
+        while continuations.count < count {
+            await withCheckedContinuation { continuation in
+                requestWaiters.append(continuation)
+            }
+        }
+    }
+
+    func releaseRequest(_ index: Int, signature: String?) {
+        continuations[index]?.resume(returning: signature)
+        continuations[index] = nil
+    }
 }
 
 private actor RelatedVideoABARepositoryStub: RelatedVideoRepository {

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/RelatedVideoShelfTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/RelatedVideoShelfTests.swift
@@ -24,6 +24,27 @@ struct RelatedVideoShelfTests {
     }
 
     @Test
+    func selectionForwardsTheReplacementBVID() {
+        let item = RelatedVideoShelfItem(
+            bvid: "BV1Replacement",
+            title: "示例推荐",
+            coverURL: nil,
+            ownerName: "示例 UP 主",
+            viewCount: 1,
+            danmakuCount: 0,
+            durationSeconds: nil
+        )
+        var selectedBVID: String?
+        let selection = RelatedVideoShelfSelection { bvid in
+            selectedBVID = bvid
+        }
+
+        selection.select(item)
+
+        #expect(selectedBVID == item.bvid)
+    }
+
+    @Test
     func pagingAdvancesByTheVisibleCardCapacity() {
         let paging = RelatedVideoShelfPaging(
             itemCount: 8,

--- a/docs/security/M4-data-privacy.md
+++ b/docs/security/M4-data-privacy.md
@@ -46,11 +46,17 @@ Cookie、token、二维码 key 和 refresh token 继续只由 `BiliAuth` 管理�
 - 登录态 playurl 的 Cookie 必须在 API 响应前终止；映射后的 playback manifest 与媒体
   headers 不保留 Cookie。DASH SIDX/媒体 Range、图片、相关推荐与 loopback 请求继续使用
   各自无认证 transport，不能从播放信息请求继承授权状态。
+- 播放侧栏 UP 主签名只允许匿名 `GET https://api.bilibili.com/x/web-interface/card`；query
+  只能包含正 `mid` 与固定 `photo=false`。响应 `data.card.mid` 必须与请求值一致，redirect、
+  HTTP／业务失败、解码失败与空白签名均只隐藏签名行。该请求不使用 Cookie、Authorization、
+  WBI、设备画像或登录授权器，也不传播 card 中的昵称、头像及其他资料字段。
 
 ## 5. Fixture、探针与验证记录
 
 - fixture 只能使用 `example.invalid`、虚构标识和自写文本；不保存现场响应 body。
 - 现场探针不得打印 BVID、CID、标题、字幕/弹幕正文、完整 URL、用户标识或凭据。
+- UP 主签名探针不得打印 MID、签名正文或完整 URL；只记录 HTTP／业务分类、MID 是否匹配、
+  签名是否存在与长度区间。
 - 验证记录可保存日期、系统、接口路径、认证需求、Content-Type、大小级别、字段名、计数和安全分类。
 - 真实 UI 截图若包含标题、账号、二维码、字幕或弹幕正文，不进入仓库。
 


### PR DESCRIPTION
## 变化

- 通过匿名 `GET /x/web-interface/card?mid=<owner-mid>&photo=false` 补充 UP 主公开签名
- 头像与昵称继续只来自现有视频详情接口
- 为签名建立窄 Repository/UseCase 边界和独立 ViewModel task/state/generation
- 补充 loading、success、失败隐藏、A→B/ABA、分 P、Back/reset 与相关推荐生命周期测试
- 支持长签名单行收起、点击展开和再次收起，并保持窄侧栏内换行与左对齐

## 原因

视频详情接口不提供 UP 主签名；该信息适合作为可失败增强，不能阻塞详情、播放、分 P、字幕、弹幕或相关推荐。

## 用户影响

头像与昵称先显示，签名加载时只显示局部骨架；成功后显示公开签名，失败或空白时静默隐藏。长签名仅在实际溢出时提供展开操作。

## 匿名与安全边界

- 精确限定 HTTPS、`api.bilibili.com`、默认端口、GET 和固定路径
- query 仅允许 `mid` 与固定 `photo=false`
- 使用匿名 ephemeral transport，不携带 Cookie、Authorization、WBI、设备画像或登录态
- 拒绝 redirect，并校验响应 MID 与请求 MID 一致
- DTO 仅解码必要的 `card.mid` 与 `sign`；不传播额外资料字段
- 不记录 MID、签名正文、完整 URL 或响应正文

## 验证

- API、UseCase、ViewModel、App-host 生命周期与聚焦 XCUI 测试通过
- 相关推荐 A→B 后签名更新且 player host identity 保持
- 真实匿名最小 probe 通过
- 1080×680 与窄侧栏交互已人工确认
- API/匿名安全、异步生命周期和 UI/测试边界独立复审通过

## 未覆盖边界

- 未进行人工 VoiceOver/FKA spoken 体验验证
- 不包含评论、关注、粉丝数、用户资料页、缓存或持久化

## Stack

- 基础层：播放侧栏 UP 主卡片 UI
- 当前层：公开签名接入
- 基础层合并后应将本 PR 的 base 改为 `main`