### PR TITLE
fix: 统一简体中文排版字形

### DIFF
--- a/BiliKitMac/App/BiliKitMacApp.swift
+++ b/BiliKitMac/App/BiliKitMacApp.swift
@@ -17,15 +17,20 @@ struct BiliKitMacApp: App {
 
     var body: some Scene {
         WindowGroup {
-            #if DEBUG
-                if usesUITestFixture {
-                    UITestContentView()
-                } else {
+            Group {
+                #if DEBUG
+                    if usesUITestFixture {
+                        UITestContentView()
+                    } else {
+                        AppRootView()
+                    }
+                #else
                     AppRootView()
-                }
-            #else
-                AppRootView()
-            #endif
+                #endif
+            }
+            .typesettingLanguage(
+                .explicit(Locale.Language(identifier: "zh-Hans"))
+            )
         }
         .defaultSize(width: 1_320, height: 820)
     }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuRenderer.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuRenderer.swift
@@ -12,6 +12,7 @@ import QuartzCore
 public final class CoreAnimationDanmakuRenderer:
     DanmakuRenderingBackend
 {
+    private static let simplifiedChineseLanguage = "zh-Hans"
     private static let maximumTextWidthPixels: CGFloat = 8_192
     private static let maximumTextHeightPixels: CGFloat = 512
     private static let maximumTextUTF16Length = 512
@@ -200,6 +201,8 @@ public final class CoreAnimationDanmakuRenderer:
                 .font: font,
                 .foregroundColor: NSColor.white,
                 .shadow: heavyInkShadow,
+                NSAttributedString.Key(kCTLanguageAttributeName as String):
+                    Self.simplifiedChineseLanguage,
             ]
         )
     }

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import BiliApplication
 import BiliModels
+import CoreText
 import QuartzCore
 import Testing
 
@@ -285,6 +286,45 @@ struct DanmakuPresentationControllerTests {
         #expect(shadow.shadowBlurRadius == 1.5)
         #expect(shadow.shadowOffset == .zero)
         #expect(renderer.activeLayerCount == 1)
+    }
+
+    @Test
+    func coreAnimationTextCarriesSimplifiedChineseLanguage() throws {
+        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
+        renderer.updateSurfaceSize(width: 800, height: 200)
+        let fixture = DanmakuEvent(
+            id: "simplified-chinese-language",
+            timeSeconds: 1,
+            mode: .scrolling,
+            text: "弹幕字体/视频推荐/门骨直令",
+            fontSize: 24,
+            colorRGB: 0xFFFFFF,
+            weight: 1
+        )
+        let metrics = renderer.measure(fixture)
+        renderer.render(
+            placement(
+                event: fixture,
+                metrics: metrics,
+                originY: 20
+            )
+        )
+
+        let layer = try #require(renderer.textLayer(forEventID: fixture.id))
+        let attributed = try #require(layer.string as? NSAttributedString)
+        var languageRange = NSRange()
+        let language =
+            attributed.attribute(
+                NSAttributedString.Key(kCTLanguageAttributeName as String),
+                at: 0,
+                effectiveRange: &languageRange
+            ) as? String
+
+        #expect(language == "zh-Hans")
+        #expect(
+            languageRange
+                == NSRange(location: 0, length: attributed.length)
+        )
     }
 
     @Test

--- a/Scripts/check-project-contract.sh
+++ b/Scripts/check-project-contract.sh
@@ -18,6 +18,7 @@ assert_occurrences() {
 }
 
 project_file="BiliKitMac.xcodeproj/project.pbxproj"
+app_entry_file="BiliKitMac/App/BiliKitMacApp.swift"
 entitlements_file="BiliKitMac/BiliKitMac.entitlements"
 package_file="Packages/BiliKitCore/Package.swift"
 package_resolution_file="Packages/BiliKitCore/Package.resolved"
@@ -92,6 +93,17 @@ assert_occurrences 2 \
     'ENABLE_APP_SANDBOX = YES;' \
     "$project_file" \
     "App Debug/Release 必须启用 App Sandbox"
+assert_occurrences 1 \
+    '.typesettingLanguage(' \
+    "$app_entry_file" \
+    "App 根内容必须明确设置排版语言"
+assert_occurrences 1 \
+    '.explicit(Locale.Language(identifier: "zh-Hans"))' \
+    "$app_entry_file" \
+    "App 根内容排版语言必须为简体中文"
+if grep -F '.environment(\.locale' "$app_entry_file" >/dev/null; then
+    fail "App 根内容不得通过 locale 强制排版语言"
+fi
 
 deployment_count=$(awk '/MACOSX_DEPLOYMENT_TARGET = / { count += 1; if ($0 !~ /MACOSX_DEPLOYMENT_TARGET = 15\.0;/) bad += 1 } END { print count + 0, bad + 0 }' "$project_file")
 set -- $deployment_count


### PR DESCRIPTION
## 变化

- 在生产 SwiftUI 根视图设置显式 `zh-Hans` 排版语言
- 为 Core Animation 弹幕的 attributed string 增加 `kCTLanguageAttributeName = zh-Hans`
- 增加弹幕 Core Text language attribute 的确定性测试
- 增加 App 根排版设置的静态契约

## 原因

即使工程本地化源语言为简体中文，系统语言为 `ja_JP` 时 CJK 字形仍可能跟随日语排版环境；Core Animation 弹幕也不会继承 SwiftUI 的排版语言。

## 用户影响

SwiftUI 内容和弹幕文本统一使用简体中文排版字形，同时继续保留系统语义字体、字号、字重与 Dynamic Type。

## 验证

- 弹幕 attributed string 的 `zh-Hans` Core Text language attribute 测试通过
- App 根排版设置静态契约通过
- 本机 `ja_JP` 环境只读复核：设置前代表性共享汉字可能混用 Hiragino 字族，设置后统一解析为简体中文字体族
- Debug App 构建通过

## 边界

- 不设置 SwiftUI `locale` 环境值，不改变本地化选择、日期/数字格式、布局方向或业务 locale
- 不硬编码 PingFang
- 不强制覆盖 AppKit、AVPlayer 等原生自有界面
- 字体族解析结果仅为当前 macOS 的运行证据，不作为跨系统固定合同