### PR TITLE
fix(danmaku): 修复二进制响应误判

### DIFF
--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
@@ -702,14 +702,22 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
         else {
             return false
         }
-        let prefix = String(
-            decoding: response.body.prefix(256),
-            as: UTF8.self
-        ).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return !prefix.hasPrefix("{")
-            && !prefix.hasPrefix("[")
-            && !prefix.hasPrefix("<html")
-            && !prefix.hasPrefix("<!doctype")
+        return !isKnownNonProtobufBody(response.body)
+    }
+
+    private static func isKnownNonProtobufBody(_ body: Data) -> Bool {
+        if (try? JSONSerialization.jsonObject(with: body)) != nil {
+            return true
+        }
+        guard let text = String(data: body, encoding: .utf8) else {
+            return false
+        }
+        let normalized =
+            text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return normalized.hasPrefix("<html")
+            || normalized.hasPrefix("<!doctype")
     }
 }
 

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliDanmakuRepositoryTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliDanmakuRepositoryTests.swift
@@ -67,7 +67,12 @@ struct BiliDanmakuRepositoryTests {
             HTTPResponse(
                 statusCode: 200,
                 headers: ["Content-Type": "application/octet-stream"],
-                body: Data("<!doctype html><title>blocked</title>".utf8)
+                body: Data(" \n{\"code\":-412}\n".utf8)
+            ),
+            HTTPResponse(
+                statusCode: 200,
+                headers: ["Content-Type": "application/octet-stream"],
+                body: Data(" \n<!doctype html><title>blocked</title>".utf8)
             ),
         ] {
             let repository = repository(response: response)
@@ -75,6 +80,38 @@ struct BiliDanmakuRepositoryTests {
                 try await repository.segment(index: 1, for: identity)
             }
         }
+    }
+
+    @Test
+    func validProtobufLengthByteThatLooksLikeJSONIsAccepted() async throws {
+        var element = Bilikit_Danmaku_Element()
+        element.id = 1
+        element.progressMilliseconds = 1_000
+        element.mode = 1
+        element.fontSize = 25
+        element.colorRgb = 0xFF_FF_FF
+        element.content = String(repeating: "x", count: 96)
+        element.weight = 5
+        element.idString = "fixture"
+
+        let encodedElement = try element.serializedData()
+        #expect(encodedElement.count == 123)
+
+        var payload = Bilikit_Danmaku_SegmentReply()
+        payload.elements = [element]
+        let body = try payload.serializedData()
+        #expect(body.starts(with: [0x0A, 0x7B]))
+
+        let segment = try await repository(
+            response: HTTPResponse(
+                statusCode: 200,
+                headers: ["Content-Type": "application/octet-stream"],
+                body: body
+            )
+        ).segment(index: 1, for: identity)
+
+        #expect(segment.events.count == 1)
+        #expect(segment.events.first?.id == "fixture")
     }
 
     @Test


### PR DESCRIPTION
## 变化

- 停止将 protobuf 前缀强制解码为 UTF-8 并裁剪空白
- 仅在完整 body 可解析为 JSON，或完整 body 可严格解码为 HTML 文本时拒绝响应
- 增加首个长度字节恰好为 `0x7B` 的合法 protobuf 回归测试
- 保留伪装成 octet-stream 的 JSON/HTML 拒绝行为

## 根因

protobuf 顶层 repeated field 的首字节可能是 `0x0A`。旧逻辑会把它当作换行裁掉；当下一字节恰好为 `0x7B` 时，又会把合法二进制误判为以 `{` 开头的 JSON，最终映射为 `requestRestricted`，导致整段弹幕静默失败。

## 用户影响

受该字节组合影响的视频可以正常解码、调度并显示弹幕；请求、protobuf decoder、scheduler 和 Core Animation renderer 的行为不变。

## 验证

- 定向回归由修复前稳定失败转为 9/9 通过
- fresh task-specific 构建目录：313 tests / 44 suites 全部通过
- Debug App 构建成功
- 匿名真实 probe：解码 276 条、调度 275 条，结果 PASS
- 真实 Debug App 播放观察到多条滚动弹幕
- `git diff --check` 通过

## 边界

- 真实 probe 未记录 BVID、CID、弹幕正文、完整 URL 或响应正文
- 共享 SwiftPM 构建目录曾出现无关的 `no such module 'Testing'` 缓存异常；fresh 构建目录复核通过
- 不改变弹幕大小、颜色、速度、lane、动画、请求身份或失败映射