### PR TITLE
fix(build): 隔离并管理构建产物生命周期

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,5 +69,5 @@ jobs:
 
       - name: Run selected quality gate (includes strict Swift format lint)
         env:
-          BILIKIT_DERIVED_DATA_PATH: ${{ runner.temp }}/BiliKitMac-derived
+          BILIKIT_GATE_FRESH: 1
         run: sh Scripts/run-quality-gates.sh "${{ steps.quality-gate.outputs.mode }}"

--- a/Scripts/check-project-contract.sh
+++ b/Scripts/check-project-contract.sh
@@ -60,6 +60,22 @@ assert_occurrences 1 \
     'github_summary="${GITHUB_STEP_SUMMARY:-}"' \
     "$quality_gate_file" \
     "统一质量 Gate 必须向 GitHub Actions 输出阶段摘要"
+assert_occurrences 1 \
+    'BILIKIT_GATE_FRESH: 1' \
+    "$ci_file" \
+    "CI 必须使用可确定清理的 fresh Gate"
+assert_occurrences 1 \
+    'export SWIFTPM_MODULECACHE_OVERRIDE="$swift_module_cache_path"' \
+    "$quality_gate_file" \
+    "SwiftPM manifest module cache 必须位于 Gate 隔离根"
+assert_occurrences 2 \
+    'CLANG_MODULE_CACHE_PATH="$clang_module_cache_path" \\' \
+    "$quality_gate_file" \
+    "Xcode build 与 test 必须使用隔离的 Clang module cache"
+assert_occurrences 2 \
+    'SWIFT_MODULE_CACHE_PATH="$swift_module_cache_path" \\' \
+    "$quality_gate_file" \
+    "Xcode build 与 test 必须使用隔离的 Swift module cache"
 
 /usr/bin/plutil -lint "$entitlements_file" >/dev/null \
     || fail "entitlements 不是有效 plist"

--- a/Scripts/run-quality-gates.sh
+++ b/Scripts/run-quality-gates.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+umask 077
+
 fail() {
     echo "质量 Gate 失败：$1" >&2
     exit 1
@@ -13,16 +15,187 @@ case "$mode" in
     *) fail "模式必须是 static、package 或 app" ;;
 esac
 
+fresh_artifacts="${BILIKIT_GATE_FRESH:-0}"
+retain_artifacts="${BILIKIT_GATE_RETAIN_ARTIFACTS:-0}"
+print_paths_only="${BILIKIT_GATE_PRINT_PATHS_ONLY:-0}"
+case "$fresh_artifacts" in
+    0|1) ;;
+    *) fail "BILIKIT_GATE_FRESH 必须是 0 或 1" ;;
+esac
+case "$retain_artifacts" in
+    0|1) ;;
+    *) fail "BILIKIT_GATE_RETAIN_ARTIFACTS 必须是 0 或 1" ;;
+esac
+case "$print_paths_only" in
+    0|1) ;;
+    *) fail "BILIKIT_GATE_PRINT_PATHS_ONLY 必须是 0 或 1" ;;
+esac
+[ "$retain_artifacts" = "0" ] || [ "$fresh_artifacts" = "1" ] \
+    || fail "BILIKIT_GATE_RETAIN_ARTIFACTS=1 只能与 BILIKIT_GATE_FRESH=1 一起使用"
+
+script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+repository_root=$(CDPATH= cd -- "$script_dir/.." && pwd -P)
+checkout_key=$(printf '%s' "$repository_root" | shasum -a 256 | awk '{ print substr($1, 1, 16) }')
+[ -n "$checkout_key" ] || fail "无法从 canonical worktree path 计算缓存 key"
+cd "$repository_root"
+
+fresh_root=""
+gate_log_dir=""
+cleanup_status=0
+
+safe_remove_fresh_root() {
+    [ -n "$fresh_root" ] || return 0
+    case "$fresh_root" in
+        "$temporary_base"/BiliKit-quality-gate.*) ;;
+        *)
+            echo "[Gate] 拒绝清理未验证的 fresh 路径：$fresh_root" >&2
+            return 1
+            ;;
+    esac
+    [ -f "$fresh_root/.bilikit-quality-gate-fresh-root" ] \
+        || {
+            echo "[Gate] 拒绝清理缺少 marker 的 fresh 路径：$fresh_root" >&2
+            return 1
+        }
+    [ "$(cat "$fresh_root/.bilikit-quality-gate-fresh-root")" = "$repository_root" ] \
+        || {
+            echo "[Gate] 拒绝清理 checkout marker 不匹配的 fresh 路径：$fresh_root" >&2
+            return 1
+        }
+    rm -rf -- "$fresh_root"
+    [ ! -e "$fresh_root" ] || return 1
+}
+
+safe_remove_gate_logs() {
+    [ -n "$gate_log_dir" ] || return 0
+    [ "$fresh_artifacts" = "0" ] || return 0
+    case "$gate_log_dir" in
+        "$artifact_root"/logs.*) ;;
+        *)
+            echo "[Gate] 拒绝清理未验证的日志路径：$gate_log_dir" >&2
+            return 1
+            ;;
+    esac
+    [ -f "$gate_log_dir/.bilikit-quality-gate-log-root" ] \
+        || {
+            echo "[Gate] 拒绝清理缺少 marker 的日志路径：$gate_log_dir" >&2
+            return 1
+        }
+    rm -rf -- "$gate_log_dir"
+    [ ! -e "$gate_log_dir" ] || return 1
+}
+
+finalize_artifacts() {
+    status=$?
+    trap - EXIT HUP INT TERM
+
+    if ! safe_remove_gate_logs; then
+        echo "[Gate] 临时日志清理失败" >&2
+        cleanup_status=1
+    fi
+
+    if [ "$fresh_artifacts" = "1" ] && [ -n "$fresh_root" ]; then
+        if [ "$retain_artifacts" = "1" ]; then
+            echo "[Gate] fresh 诊断产物已保留：$fresh_root"
+        elif safe_remove_fresh_root; then
+            echo "[Gate] fresh 产物已清理：$fresh_root"
+        else
+            echo "[Gate] fresh 产物清理失败：$fresh_root" >&2
+            cleanup_status=1
+        fi
+    fi
+
+    if [ "$status" -eq 0 ] && [ "$cleanup_status" -ne 0 ]; then
+        status=$cleanup_status
+    fi
+    exit "$status"
+}
+
+trap finalize_artifacts EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if [ "$fresh_artifacts" = "1" ]; then
+    [ -z "${BILIKIT_DERIVED_DATA_PATH:-}" ] \
+        || fail "fresh 模式不接受 BILIKIT_DERIVED_DATA_PATH；所有产物必须位于唯一临时根"
+    temporary_base=$(CDPATH= cd -- "${TMPDIR:-/tmp}" && pwd -P)
+    fresh_root=$(mktemp -d "$temporary_base/BiliKit-quality-gate.XXXXXX")
+    chmod 700 "$fresh_root"
+    printf '%s\n' "$repository_root" >"$fresh_root/.bilikit-quality-gate-fresh-root"
+    artifact_root=$fresh_root
+    artifact_mode="fresh"
+else
+    artifact_root="$repository_root/.build/bilikit-quality-gates/$checkout_key"
+    mkdir -p "$artifact_root"
+    artifact_root=$(CDPATH= cd -- "$artifact_root" && pwd -P)
+    artifact_mode="iteration"
+fi
+
+swiftpm_scratch_path="$artifact_root/swiftpm-scratch"
+swiftpm_cache_path="$artifact_root/swiftpm-cache"
+swiftpm_config_path="$artifact_root/swiftpm-config"
+swiftpm_security_path="$artifact_root/swiftpm-security"
+xcode_package_path="$artifact_root/xcode-packages"
+xcode_package_cache_path="$artifact_root/xcode-package-cache"
+clang_module_cache_path="$artifact_root/module-cache/clang"
+swift_module_cache_path="$artifact_root/module-cache/swift"
+
+if [ -n "${BILIKIT_DERIVED_DATA_PATH:-}" ]; then
+    derived_data_path=$BILIKIT_DERIVED_DATA_PATH
+else
+    derived_data_path="$artifact_root/xcode-derived"
+fi
+
+for path in \
+    "$swiftpm_scratch_path" \
+    "$swiftpm_cache_path" \
+    "$swiftpm_config_path" \
+    "$swiftpm_security_path" \
+    "$xcode_package_path" \
+    "$xcode_package_cache_path" \
+    "$clang_module_cache_path" \
+    "$swift_module_cache_path" \
+    "$derived_data_path"
+do
+    mkdir -p "$path"
+done
+derived_data_path=$(CDPATH= cd -- "$derived_data_path" && pwd -P)
+
+case "$derived_data_path" in
+    /|"${HOME:-/nonexistent}"|"$repository_root")
+        fail "BILIKIT_DERIVED_DATA_PATH 不能解析为根目录、HOME 或仓库根目录"
+        ;;
+esac
+
+export CLANG_MODULE_CACHE_PATH="$clang_module_cache_path"
+export SWIFT_MODULE_CACHE_PATH="$swift_module_cache_path"
+export SWIFTPM_MODULECACHE_OVERRIDE="$swift_module_cache_path"
+
+echo "[Gate] 产物模式：${artifact_mode}（checkout key: ${checkout_key}）"
+echo "[Gate] SwiftPM scratch：$swiftpm_scratch_path"
+echo "[Gate] Xcode DerivedData：$derived_data_path"
+echo "[Gate] Clang module cache：$clang_module_cache_path"
+echo "[Gate] Swift module cache：$swift_module_cache_path"
+
+if [ "$print_paths_only" = "1" ]; then
+    echo "[Gate] 仅输出产物路径；未运行检查"
+    exit 0
+fi
+
 compact_logs="${BILIKIT_COMPACT_LOGS:-0}"
 case "$compact_logs" in
     0|1) ;;
     *) fail "BILIKIT_COMPACT_LOGS 必须是 0 或 1" ;;
 esac
 
-gate_log_dir=""
 if [ "$compact_logs" = "1" ]; then
-    gate_log_dir=$(mktemp -d "${TMPDIR:-/tmp}/BiliKit-gates.XXXXXX")
-    echo "[Gate] 精简日志已启用；完整日志：$gate_log_dir"
+    gate_log_dir=$(mktemp -d "$artifact_root/logs.XXXXXX")
+    printf '%s\n' "$repository_root" >"$gate_log_dir/.bilikit-quality-gate-log-root"
+    echo "[Gate] 精简日志已启用；日志在退出时清理"
+    if [ "$fresh_artifacts" = "1" ] && [ "$retain_artifacts" = "1" ]; then
+        echo "[Gate] fresh retain 已启用；完整日志将随诊断产物保留：$gate_log_dir"
+    fi
 fi
 
 github_actions="${GITHUB_ACTIONS:-false}"
@@ -61,12 +234,18 @@ run_with_optional_compact_log() {
     else
         log_path="$gate_log_dir/$stage.log"
         if "$@" >"$log_path" 2>&1; then
-            echo "[Gate] $stage 通过；完整日志：$log_path"
+            echo "[Gate] $stage 通过"
+            if [ "$fresh_artifacts" = "1" ] && [ "$retain_artifacts" = "1" ]; then
+                echo "[Gate] $stage 完整日志：$log_path"
+            fi
             status=0
         else
             status=$?
-            echo "[Gate] $stage 失败；完整日志：$log_path" >&2
+            echo "[Gate] $stage 失败；临时日志末尾如下" >&2
             tail -n 40 "$log_path" | LC_ALL=C cut -c 1-360 >&2
+            if [ "$fresh_artifacts" = "1" ] && [ "$retain_artifacts" = "1" ]; then
+                echo "[Gate] $stage 完整日志：$log_path" >&2
+            fi
         fi
     fi
 
@@ -81,10 +260,6 @@ run_with_optional_compact_log() {
     fi
     return "$status"
 }
-
-script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
-repository_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
-cd "$repository_root"
 
 run_static_contracts() {
     sh Scripts/check-architecture.sh || return $?
@@ -106,7 +281,13 @@ fi
 echo "[Gate] Swift Package"
 run_with_optional_compact_log \
     swift-package \
-    xcrun swift test --package-path Packages/BiliKitCore
+    xcrun swift test \
+    --package-path Packages/BiliKitCore \
+    --scratch-path "$swiftpm_scratch_path" \
+    --cache-path "$swiftpm_cache_path" \
+    --config-path "$swiftpm_config_path" \
+    --security-path "$swiftpm_security_path" \
+    --manifest-cache local
 
 if [ "$mode" = "package" ]; then
     echo "[Gate] package 通过"
@@ -115,8 +296,6 @@ fi
 
 xcodebuild -version >/dev/null 2>&1 \
     || fail "app 模式需要完整 Xcode；请先切换 xcode-select 或显式设置 DEVELOPER_DIR"
-
-derived_data_path="${BILIKIT_DERIVED_DATA_PATH:-${TMPDIR:-/tmp}/BiliKitMac-derived}"
 
 echo "[Gate] App build-for-testing"
 run_with_optional_compact_log \
@@ -127,6 +306,10 @@ run_with_optional_compact_log \
     -configuration Debug \
     -destination 'platform=macOS' \
     -derivedDataPath "$derived_data_path" \
+    -clonedSourcePackagesDirPath "$xcode_package_path" \
+    -packageCachePath "$xcode_package_cache_path" \
+    CLANG_MODULE_CACHE_PATH="$clang_module_cache_path" \
+    SWIFT_MODULE_CACHE_PATH="$swift_module_cache_path" \
     CODE_SIGNING_ALLOWED=NO \
     build-for-testing
 
@@ -139,6 +322,10 @@ run_with_optional_compact_log \
     -configuration Debug \
     -destination 'platform=macOS' \
     -derivedDataPath "$derived_data_path" \
+    -clonedSourcePackagesDirPath "$xcode_package_path" \
+    -packageCachePath "$xcode_package_cache_path" \
+    CLANG_MODULE_CACHE_PATH="$clang_module_cache_path" \
+    SWIFT_MODULE_CACHE_PATH="$swift_module_cache_path" \
     CODE_SIGNING_ALLOWED=NO \
     test-without-building \
     -only-testing:BiliKitMacTests

--- a/docs/development/QUALITY-GATES.md
+++ b/docs/development/QUALITY-GATES.md
@@ -18,6 +18,39 @@ sh Scripts/run-quality-gates.sh app
 - `app`：包含 `package`，并执行 App build-for-testing 和 App 测试。
 - CI 使用同一个 App 入口，不维护第二套 lint 或测试规则。
 
+## 构建产物生命周期
+
+Gate 默认使用适合日常迭代的稳定缓存。缓存位于当前 checkout 的
+`.build/bilikit-quality-gates/<checkout-key>/`；`checkout-key` 来自 canonical checkout
+路径。同一 checkout 会复用 SwiftPM scratch、Xcode DerivedData、Xcode package checkout
+以及 Clang／Swift module cache，不同 worktree 不共享这些可变状态。删除 checkout 时，这些
+默认产物也随之进入同一清理边界。
+
+验收或排查缓存污染时使用 fresh 模式：
+
+```sh
+BILIKIT_GATE_FRESH=1 sh Scripts/run-quality-gates.sh app
+```
+
+fresh 模式把 SwiftPM、Xcode、module cache 和精简日志都放入一次唯一、权限为 `0700` 的
+临时根。脚本在成功、失败、`HUP`、`INT` 和 `TERM` 退出路径上验证 marker 与精确路径后清理
+该根。需要保留失败现场时，唯一保留开关为：
+
+```sh
+BILIKIT_GATE_FRESH=1 \
+BILIKIT_GATE_RETAIN_ARTIFACTS=1 \
+BILIKIT_COMPACT_LOGS=1 \
+sh Scripts/run-quality-gates.sh app
+```
+
+脚本会明确打印保留位置。保留目录包含构建产物和完整 gate 日志，需要由调用者在诊断后清理。
+普通 compact 日志随 gate 退出清理；失败摘要仍打印最后 40 行。
+
+`BILIKIT_DERIVED_DATA_PATH` 继续作为日常模式的调用方管理兼容入口；fresh 模式拒绝该覆盖，
+以保证所有产物都位于唯一临时根。路径诊断可设置 `BILIKIT_GATE_PRINT_PATHS_ONLY=1`，它只输出
+解析后的缓存路径，不运行 gate。所有模式都显式设置 SwiftPM scratch/package cache、Xcode
+DerivedData/package cache 和 Clang／Swift module cache，避免回退到用户级 module cache。
+
 异步测试必须用可观察事件、状态、continuation 或显式闸门判断工作开始和完成；固定时长
 只能作为超时，不能用来推断状态已经稳定。
 


### PR DESCRIPTION
## 变化

- 为统一 quality gate 增加日常迭代与 fresh 验收两种产物模式
- 按 canonical checkout path 生成稳定 key，隔离 SwiftPM scratch/cache、Xcode DerivedData/package cache、Clang/Swift module cache
- 为 fresh 模式建立唯一、私有临时根，并在成功、失败及可捕获中断路径上验证精确路径后清理
- 增加最小诊断保留开关，并让 compact 日志默认随 gate 退出清理
- CI 改用 fresh 模式，同时保留日常模式下 `BILIKIT_DERIVED_DATA_PATH` 的兼容入口
- 更新静态工程契约与开发文档

## 原因

此前 App gate 默认让不同 worktree 共同写入固定的 `/tmp/BiliKitMac-derived`，SwiftPM 与模块缓存也可能使用用户级共享位置；损坏或残缺的缓存会在 worktree 之间传播。compact 日志和外部 DerivedData 的清理边界同样不明确，工作树移除后可能仍遗留大量产物。

## 用户与开发影响

日常构建会复用当前 checkout 内的稳定缓存，保留增量速度；不同 worktree 不再共享可变构建状态。验收和缓存污染排查可以使用 fresh 模式获得唯一、可确定清理的构建根。此次没有修改生产代码、工程标识、签名、UI 或播放行为。

## 验证

- 独立 agent 只读审查：无 actionable finding
- 最终 `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer BILIKIT_COMPACT_LOGS=1 sh Scripts/run-quality-gates.sh app`：通过
- 同一 checkout cold app gate：94.02 秒
- 同一缓存根 warm app gate：12.69 秒
- 两个普通 checkout 副本解析为不同 cache key/root
- 完整 fresh app gate：通过，退出后唯一根已删除
- fresh 成功、失败、Ctrl-C 中断和 retain 行为：通过
- Swift/Xcode module cache 实际生成在 checkout/fresh 隔离根，`~/.cache/clang` 不存在
- compact 临时日志与 fresh 测试目录：无残留
- `git diff --check`：通过

## 未覆盖边界

本 PR 不声明签名、Keychain、真实 UI、播放或性能行为已验收。不可捕获的 `SIGKILL`、断电，以及 marker 写入前的强制终止无法由 shell trap 清理；安全策略在路径未验证时选择不删除。