### PR TITLE
feat(danmaku): 加入五档长度加权速度与尺寸连续呈现

### DIFF
--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -27,6 +27,7 @@ struct AppEnvironment {
     private let danmakuSession: DanmakuSession
     private let danmakuController: DanmakuPresentationController
     private let danmakuRenderer: CoreAnimationDanmakuRenderer
+    private let danmakuSpeedPreferencesStore: any DanmakuSpeedPreferencesStoring
     private let authenticationService: any AuthenticationServicing
     private let authenticationQRCodeProvider: any AuthenticationQRCodeProviding
 
@@ -38,6 +39,8 @@ struct AppEnvironment {
         danmakuRepository: any DanmakuSegmentRepository,
         playerEngine: AVPlayerEngine,
         playbackPreferencesController: PlaybackPreferencesController,
+        danmakuSpeedPreferencesStore: any DanmakuSpeedPreferencesStoring =
+            UserDefaultsDanmakuSpeedPreferencesStore(),
         authenticationService: any AuthenticationServicing,
         authenticationQRCodeProvider: any AuthenticationQRCodeProviding
     ) {
@@ -51,6 +54,7 @@ struct AppEnvironment {
         self.historyRepository = historyRepository
         self.playerEngine = playerEngine
         self.playbackPreferencesController = playbackPreferencesController
+        self.danmakuSpeedPreferencesStore = danmakuSpeedPreferencesStore
         let renderer = CoreAnimationDanmakuRenderer()
         let controller = DanmakuPresentationController(
             backend: renderer,
@@ -91,7 +95,14 @@ struct AppEnvironment {
     }
 
     func makeDanmakuViewModel() -> DanmakuControlsViewModel {
-        DanmakuControlsViewModel(presentation: danmakuSession)
+        let initialSpeedLevel = danmakuSpeedPreferencesStore.loadSpeedLevel()
+        return DanmakuControlsViewModel(
+            presentation: danmakuSession,
+            initialSpeedLevel: initialSpeedLevel,
+            saveSpeedLevel: { [danmakuSpeedPreferencesStore] speedLevel in
+                danmakuSpeedPreferencesStore.saveSpeedLevel(speedLevel)
+            }
+        )
     }
 
     func makePlayerView() -> AnyView {

--- a/BiliKitMac/Composition/UITestContentView.swift
+++ b/BiliKitMac/Composition/UITestContentView.swift
@@ -327,6 +327,7 @@
     private final class UITestDanmakuPresentation: DanmakuPresentationControlling {
         func start(for identity: PlaybackItemIdentity) {}
         func setEnabled(_ enabled: Bool) {}
+        func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {}
 
         func setModeVisibility(
             scrolling: Bool,

--- a/BiliKitMac/Platform/DanmakuOverlayHostView.swift
+++ b/BiliKitMac/Platform/DanmakuOverlayHostView.swift
@@ -32,9 +32,7 @@ final class DanmakuOverlayView: NSView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        if window == nil {
-            detachSurface()
-        } else {
+        if window != nil {
             attachSurfaceIfNeeded()
         }
     }
@@ -48,8 +46,9 @@ final class DanmakuOverlayView: NSView {
         nil
     }
 
-    /// 仅由当前 surface owner 发布布局尺寸；尺寸变化会清空无法安全迁移的活动弹幕。
+    /// 仅由当前 surface owner 发布布局尺寸；已有弹幕保留运动，新弹幕使用最新尺寸。
     func updateSurfaceIfNeeded() {
+        guard bounds.width > 0, bounds.height > 0 else { return }
         guard bounds.size != previousSize else { return }
         previousSize = bounds.size
         let width = max(Double(bounds.width), 0)

--- a/BiliKitMac/Platform/PlaybackPreferencesController.swift
+++ b/BiliKitMac/Platform/PlaybackPreferencesController.swift
@@ -1,4 +1,5 @@
 @preconcurrency import AVFoundation
+import BiliApplication
 import CoreFoundation
 import Foundation
 
@@ -80,6 +81,42 @@ final class UserDefaultsPlaybackPreferencesStore:
             CFGetTypeID(number) == CFBooleanGetTypeID()
         else { return nil }
         return number.boolValue
+    }
+}
+
+protocol DanmakuSpeedPreferencesStoring: AnyObject, Sendable {
+    func loadSpeedLevel() -> DanmakuSpeedLevel
+    func saveSpeedLevel(_ speedLevel: DanmakuSpeedLevel)
+}
+
+/// 只保存设备级弹幕速度意图，不保存视频 identity、正文或播放位置。
+final class UserDefaultsDanmakuSpeedPreferencesStore:
+    DanmakuSpeedPreferencesStoring, @unchecked Sendable
+{
+    private static let key = "danmaku.speedLevel"
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func loadSpeedLevel() -> DanmakuSpeedLevel {
+        guard let number = defaults.object(forKey: Self.key) as? NSNumber,
+            CFGetTypeID(number) != CFBooleanGetTypeID()
+        else {
+            return .three
+        }
+        let rawValue = number.intValue
+        guard number.doubleValue == Double(rawValue),
+            let speedLevel = DanmakuSpeedLevel(rawValue: rawValue)
+        else {
+            return .three
+        }
+        return speedLevel
+    }
+
+    func saveSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {
+        defaults.set(speedLevel.rawValue, forKey: Self.key)
     }
 }
 

--- a/BiliKitMacTests/PlaybackPreferencesControllerTests.swift
+++ b/BiliKitMacTests/PlaybackPreferencesControllerTests.swift
@@ -1,4 +1,5 @@
 @preconcurrency import AVFoundation
+import BiliApplication
 import Foundation
 import Testing
 
@@ -57,6 +58,27 @@ struct PlaybackPreferencesControllerTests {
             defaults.set(Double.nan, forKey: "player.volume")
             defaults.set(Double.infinity, forKey: "player.preferredRate")
             #expect(load(from: defaults) == .defaults)
+        }
+    }
+
+    @Test
+    @MainActor
+    func danmakuSpeedLevelPersistsAndInvalidValuesFallBackToLevelThree() {
+        withIsolatedDefaults { defaults in
+            let store = UserDefaultsDanmakuSpeedPreferencesStore(
+                defaults: defaults
+            )
+            #expect(store.loadSpeedLevel() == .three)
+
+            store.saveSpeedLevel(.five)
+            #expect(store.loadSpeedLevel() == .five)
+
+            defaults.set(2.5, forKey: "danmaku.speedLevel")
+            #expect(store.loadSpeedLevel() == .three)
+            defaults.set(true, forKey: "danmaku.speedLevel")
+            #expect(store.loadSpeedLevel() == .three)
+            defaults.set(6, forKey: "danmaku.speedLevel")
+            #expect(store.loadSpeedLevel() == .three)
         }
     }
 

--- a/BiliKitMacTests/PlayerHostViewIdentityTests.swift
+++ b/BiliKitMacTests/PlayerHostViewIdentityTests.swift
@@ -1,6 +1,8 @@
 import AVKit
 import AppKit
+import BiliApplication
 import BiliDanmaku
+import BiliModels
 import Observation
 import SwiftUI
 import Testing
@@ -9,6 +11,118 @@ import Testing
 
 @Suite(.serialized)
 struct PlayerHostViewIdentityTests {
+    @Test
+    @MainActor
+    func danmakuSurfaceSurvivesTemporaryWindowReparenting() throws {
+        let renderer = CoreAnimationDanmakuRenderer()
+        let controller = DanmakuPresentationController(
+            backend: renderer,
+            configuration: Self.emptyDanmakuConfiguration
+        )
+        let overlay = DanmakuOverlayView(
+            renderer: renderer,
+            controller: controller
+        )
+        overlay.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        let firstWindow = NSWindow(
+            contentRect: overlay.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        let secondWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1_200, height: 500),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+
+        firstWindow.contentView?.addSubview(overlay)
+        overlay.layoutSubtreeIfNeeded()
+        #expect(renderer.rootLayer.superlayer === overlay.layer)
+
+        let identity = PlaybackItemIdentity(bvid: "fixture", cid: 1)
+        controller.apply(
+            danmakuUpdate(
+                identity: identity,
+                position: 1,
+                eventID: "before-reparent",
+                mode: .scrolling
+            )
+        )
+        let firstLayer = try #require(renderer.rootLayer.sublayers?.first)
+        let epoch = renderer.renderEpoch
+        #expect(renderer.activeLayerCount == 1)
+        #expect(controller.statistics.active == 1)
+
+        overlay.removeFromSuperview()
+        #expect(overlay.window == nil)
+        #expect(renderer.rootLayer.superlayer === overlay.layer)
+        #expect(renderer.rootLayer.sublayers?.first === firstLayer)
+        #expect(renderer.renderEpoch == epoch)
+        #expect(renderer.activeLayerCount == 1)
+
+        overlay.frame = .zero
+        overlay.layoutSubtreeIfNeeded()
+        controller.apply(
+            danmakuUpdate(
+                identity: identity,
+                position: 2,
+                eventID: "during-reparent",
+                mode: .top
+            )
+        )
+        #expect(renderer.activeLayerCount == 2)
+        #expect(controller.statistics.active == 2)
+
+        overlay.frame = secondWindow.contentView?.bounds ?? .zero
+        secondWindow.contentView?.addSubview(overlay)
+        overlay.layoutSubtreeIfNeeded()
+        #expect(renderer.rootLayer.superlayer === overlay.layer)
+        #expect(renderer.rootLayer.sublayers?.first === firstLayer)
+        #expect(renderer.renderEpoch == epoch)
+        #expect(renderer.activeLayerCount == 2)
+
+        overlay.detachSurface()
+        #expect(renderer.rootLayer.superlayer == nil)
+        #expect(renderer.renderEpoch == epoch + 1)
+        #expect(renderer.activeLayerCount == 0)
+        #expect(controller.statistics.active == 0)
+    }
+
+    private func danmakuUpdate(
+        identity: PlaybackItemIdentity,
+        position: Double,
+        eventID: String,
+        mode: DanmakuPresentationMode
+    ) -> DanmakuPresentationUpdate {
+        let event = DanmakuEvent(
+            id: eventID,
+            timeSeconds: position,
+            mode: mode,
+            text: "reparent fixture",
+            fontSize: 24,
+            colorRGB: 0xFFFFFF,
+            weight: 1
+        )
+        return DanmakuPresentationUpdate(
+            snapshot: PlaybackTimelineSnapshot(
+                identity: identity,
+                positionSeconds: position,
+                durationSeconds: 100,
+                rate: 1,
+                state: .playing,
+                discontinuityGeneration: 1
+            ),
+            batch: DanmakuBatch(
+                identity: identity,
+                discontinuityGeneration: 1,
+                events: [event],
+                clearsExisting: false
+            )
+        )
+    }
+
     @Test
     @MainActor
     func playerSurfaceCaptureRoutesVerticalWheelWithoutLocalMonitor()

--- a/BiliKitMacTests/VideoDetailLifecycleTests.swift
+++ b/BiliKitMacTests/VideoDetailLifecycleTests.swift
@@ -1207,6 +1207,7 @@ private final class RecordingPresentation: DanmakuPresentationControlling {
     }
 
     func setEnabled(_ enabled: Bool) {}
+    func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {}
 
     func setModeVisibility(
         scrolling: Bool,

--- a/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuPresentationControlling.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuPresentationControlling.swift
@@ -1,3 +1,11 @@
+public enum DanmakuSpeedLevel: Int, CaseIterable, Sendable, Equatable {
+    case one = 1
+    case two
+    case three
+    case four
+    case five
+}
+
 @MainActor
 /// 让 Feature 驱动弹幕会话开始、可见性与完整停止，而不暴露 scheduler 或 renderer。
 public protocol DanmakuPresentationControlling: AnyObject {
@@ -8,5 +16,6 @@ public protocol DanmakuPresentationControlling: AnyObject {
         top: Bool,
         bottom: Bool
     )
+    func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel)
     func stop()
 }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsView.swift
@@ -1,3 +1,4 @@
+import BiliApplication
 import SwiftUI
 
 struct DanmakuControlsView: View {
@@ -40,6 +41,22 @@ struct DanmakuControlsView: View {
             }
             .disabled(!model.isEnabled)
             .accessibilityIdentifier("danmaku.modes")
+
+            Picker(
+                "滚动速度",
+                selection: Binding(
+                    get: { model.speedLevel },
+                    set: { model.setSpeedLevel($0) }
+                )
+            ) {
+                ForEach(DanmakuSpeedLevel.allCases, id: \.rawValue) { level in
+                    Text("Lv\(level.rawValue)").tag(level)
+                }
+            }
+            .pickerStyle(.menu)
+            .frame(width: 120)
+            .disabled(!model.isEnabled || !model.showsScrolling)
+            .accessibilityIdentifier("danmaku.speed")
 
             Spacer()
         }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsViewModel.swift
@@ -11,12 +11,22 @@ public final class DanmakuControlsViewModel {
     public private(set) var showsScrolling = true
     public private(set) var showsTop = true
     public private(set) var showsBottom = true
+    public private(set) var speedLevel: DanmakuSpeedLevel
 
     @ObservationIgnored
     private let presentation: any DanmakuPresentationControlling
+    @ObservationIgnored
+    private let saveSpeedLevel: @MainActor (DanmakuSpeedLevel) -> Void
 
-    public init(presentation: any DanmakuPresentationControlling) {
+    public init(
+        presentation: any DanmakuPresentationControlling,
+        initialSpeedLevel: DanmakuSpeedLevel = .three,
+        saveSpeedLevel: @escaping @MainActor (DanmakuSpeedLevel) -> Void = { _ in }
+    ) {
         self.presentation = presentation
+        self.speedLevel = initialSpeedLevel
+        self.saveSpeedLevel = saveSpeedLevel
+        presentation.setSpeedLevel(initialSpeedLevel)
     }
 
     public func selectVideo(_ identity: PlaybackItemIdentity) {
@@ -49,6 +59,13 @@ public final class DanmakuControlsViewModel {
         guard showsBottom != shows else { return }
         showsBottom = shows
         applyModeVisibility()
+    }
+
+    public func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {
+        guard self.speedLevel != speedLevel else { return }
+        self.speedLevel = speedLevel
+        presentation.setSpeedLevel(speedLevel)
+        saveSpeedLevel(speedLevel)
     }
 
     private func applyModeVisibility() {

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuRenderer.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuRenderer.swift
@@ -7,8 +7,8 @@ import QuartzCore
 @MainActor
 /// 有硬上限的 Core Animation 弹幕 backend，负责 layer identity、动画时钟与最终回收。
 ///
-/// `renderEpoch + objectIdentity` 使旧动画 completion 无法删除同 ID 的新 layer；清屏、
-/// resize 和 stop 都会推进 epoch 并同步移除活动对象。
+/// `renderEpoch + objectIdentity` 使旧动画 completion 无法删除同 ID 的新 layer；显式清屏
+/// 和 stop 会推进 epoch，resize 只更新 geometry 并保留活动对象。
 public final class CoreAnimationDanmakuRenderer:
     DanmakuRenderingBackend
 {
@@ -19,6 +19,7 @@ public final class CoreAnimationDanmakuRenderer:
 
     private struct Entry {
         let layer: CATextLayer
+        let placement: DanmakuLanePlacement
         let objectIdentity: UInt64
         let relay: AnimationCompletionRelay
     }
@@ -112,6 +113,7 @@ public final class CoreAnimationDanmakuRenderer:
         animation.delegate = relay
         entries[event.id] = Entry(
             layer: textLayer,
+            placement: placement,
             objectIdentity: objectIdentity,
             relay: relay
         )
@@ -151,8 +153,7 @@ public final class CoreAnimationDanmakuRenderer:
     }
 
     public func updateSurfaceSize(width: Double, height: Double) {
-        advanceEpoch()
-        removeAllEntries()
+        let oldSurfaceSize = surfaceSize
         surfaceSize = CGSize(
             width: max(width.isFinite ? width : 0, 0),
             height: max(height.isFinite ? height : 0, 0)
@@ -160,6 +161,12 @@ public final class CoreAnimationDanmakuRenderer:
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         rootLayer.frame = CGRect(origin: .zero, size: surfaceSize)
+        for entry in entries.values {
+            updateFixedGeometry(
+                for: entry,
+                heightDelta: surfaceSize.height - oldSurfaceSize.height
+            )
+        }
         CATransaction.commit()
     }
 
@@ -250,6 +257,21 @@ public final class CoreAnimationDanmakuRenderer:
         }
         animation.duration = placement.request.durationSeconds
         return animation
+    }
+
+    private func updateFixedGeometry(
+        for entry: Entry,
+        heightDelta: CGFloat
+    ) {
+        switch entry.placement.request.event.mode {
+        case .scrolling:
+            return
+        case .top:
+            entry.layer.position.x = surfaceSize.width / 2
+        case .bottom:
+            entry.layer.position.x = surfaceSize.width / 2
+            entry.layer.position.y += heightDelta
+        }
     }
 
     private func advanceEpoch() {

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneAllocator.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneAllocator.swift
@@ -26,12 +26,11 @@ public struct DanmakuLaneAllocator: Sendable {
 
     public var activeCount: Int { active.count }
 
+    /// 更新后续准入使用的 surface；已活动 placement 保留入场时的 geometry 与过期时间。
     public mutating func updateConfiguration(
         _ configuration: DanmakuLaneConfiguration
-    ) -> [DanmakuLanePlacement] {
-        let drained = clear()
+    ) {
         self.configuration = configuration
-        return drained
     }
 
     public mutating func clear() -> [DanmakuLanePlacement] {
@@ -119,8 +118,14 @@ public struct DanmakuLaneAllocator: Sendable {
         }
         let displayHeight =
             configuration.surfaceHeight * configuration.displayAreaFraction
+        let uncappedLaneCount = floor(
+            displayHeight / configuration.laneHeight
+        )
         let laneCount = Int(
-            floor(displayHeight / configuration.laneHeight)
+            min(
+                uncappedLaneCount,
+                Double(DanmakuLaneConfiguration.hardMaximumActiveCount)
+            )
         )
         guard laneCount > 0 else {
             return .failure(.noLane)
@@ -138,6 +143,7 @@ public struct DanmakuLaneAllocator: Sendable {
                     for: request.event.mode,
                     laneIndex: laneIndex
                 ),
+                surfaceWidthAtAdmission: configuration.surfaceWidth,
                 admittedAtSeconds: playbackTime,
                 expiresAtSeconds: playbackTime + request.durationSeconds
             )
@@ -201,14 +207,21 @@ public struct DanmakuLaneAllocator: Sendable {
         let elapsed = playbackTime - previous.admittedAtSeconds
         guard elapsed >= 0 else { return false }
         let surfaceWidth = configuration.surfaceWidth
+        let previousSurfaceWidth = previous.surfaceWidthAtAdmission
+        guard previousSurfaceWidth.isFinite,
+            previousSurfaceWidth > 0
+        else {
+            return false
+        }
         let previousSpeed =
-            (surfaceWidth + previousRequest.width)
+            (previousSurfaceWidth + previousRequest.width)
             / previousRequest.durationSeconds
         let newSpeed =
             (surfaceWidth + request.width)
             / request.durationSeconds
         let previousRightEdge =
-            surfaceWidth - previousSpeed * elapsed + previousRequest.width
+            previousSurfaceWidth - previousSpeed * elapsed
+            + previousRequest.width
         let availableGap = surfaceWidth - previousRightEdge
         guard availableGap >= configuration.minimumHorizontalGap else {
             return false

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneModels.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneModels.swift
@@ -82,6 +82,7 @@ public struct DanmakuLanePlacement: Sendable, Equatable {
     public let request: DanmakuLaneRequest
     public let laneIndex: Int
     public let originY: Double
+    public let surfaceWidthAtAdmission: Double
     public let admittedAtSeconds: Double
     public let expiresAtSeconds: Double
 }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentation.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentation.swift
@@ -21,6 +21,7 @@ public struct DanmakuPresentationUpdate: Sendable, Equatable {
 /// backend 动画时钟并丢弃 identity/discontinuity 状态。
 public protocol DanmakuPresentationSink: AnyObject {
     func apply(_ update: DanmakuPresentationUpdate)
+    func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel)
     func clearPresentation()
     func stopPresentation()
 }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
@@ -169,12 +169,11 @@ public final class DanmakuPresentationController:
         _ configuration: DanmakuLaneConfiguration
     ) {
         self.configuration = configuration
-        _ = allocator.updateConfiguration(configuration)
+        allocator.updateConfiguration(configuration)
         backend.updateSurfaceSize(
             width: configuration.surfaceWidth,
             height: configuration.surfaceHeight
         )
-        statistics.updateActive(0)
     }
 
     @discardableResult

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
@@ -39,8 +39,10 @@ public final class DanmakuPresentationController:
     public private(set) var statistics = DanmakuRendererStatistics()
 
     private let backend: any DanmakuRenderingBackend
-    private let durations: DanmakuRendererDurations
+    private let motionPolicy: DanmakuMotionPolicy
     private var allocator: DanmakuLaneAllocator
+    private var configuration: DanmakuLaneConfiguration
+    private var speedLevel = DanmakuSpeedLevel.three
     private var identity: PlaybackItemIdentity?
     private var discontinuityGeneration: UInt64?
     private var surfaceOwnerID: UUID?
@@ -48,15 +50,28 @@ public final class DanmakuPresentationController:
     public init(
         backend: any DanmakuRenderingBackend,
         configuration: DanmakuLaneConfiguration,
-        durations: DanmakuRendererDurations = DanmakuRendererDurations()
+        motionPolicy: DanmakuMotionPolicy = DanmakuMotionPolicy()
     ) {
         self.backend = backend
         self.allocator = DanmakuLaneAllocator(configuration: configuration)
-        self.durations = durations
+        self.configuration = configuration
+        self.motionPolicy = motionPolicy
         backend.delegate = self
         backend.updateSurfaceSize(
             width: configuration.surfaceWidth,
             height: configuration.surfaceHeight
+        )
+    }
+
+    public convenience init(
+        backend: any DanmakuRenderingBackend,
+        configuration: DanmakuLaneConfiguration,
+        durations: DanmakuRendererDurations
+    ) {
+        self.init(
+            backend: backend,
+            configuration: configuration,
+            motionPolicy: DanmakuMotionPolicy(fixedDurations: durations)
         )
     }
 
@@ -109,7 +124,12 @@ public final class DanmakuPresentationController:
                 event: event,
                 width: metrics.width,
                 height: metrics.height,
-                durationSeconds: durations.duration(for: event.mode)
+                durationSeconds: motionPolicy.duration(
+                    for: event.mode,
+                    textWidth: metrics.width,
+                    surfaceWidth: configuration.surfaceWidth,
+                    speedLevel: speedLevel
+                )
             )
         }
         statistics.recordCapacityDrops(
@@ -133,6 +153,10 @@ public final class DanmakuPresentationController:
         clearBackendAndAllocator()
     }
 
+    public func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {
+        self.speedLevel = speedLevel
+    }
+
     public func stopPresentation() {
         _ = allocator.clear()
         backend.stop()
@@ -144,6 +168,7 @@ public final class DanmakuPresentationController:
     func updateConfiguration(
         _ configuration: DanmakuLaneConfiguration
     ) {
+        self.configuration = configuration
         _ = allocator.updateConfiguration(configuration)
         backend.updateSurfaceSize(
             width: configuration.surfaceWidth,

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuRenderingBackend.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuRenderingBackend.swift
@@ -140,8 +140,8 @@ public protocol DanmakuRenderingBackendDelegate: AnyObject {
 @MainActor
 /// Renderer 的最小平台 port。
 ///
-/// `clearAll` 只移除活动对象；`stop` 还把播放速率归零。尺寸变化允许实现清空无法安全
-/// 迁移的对象，因此 controller 必须同步重置 lane allocator。
+/// `clearAll` 只移除活动对象；`stop` 还把播放速率归零。尺寸变化只更新 surface geometry；
+/// 已有对象保持自己的运动快照，新对象使用新尺寸。
 public protocol DanmakuRenderingBackend: AnyObject {
     var delegate: (any DanmakuRenderingBackendDelegate)? { get set }
 

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuRenderingBackend.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuRenderingBackend.swift
@@ -1,3 +1,4 @@
+import BiliApplication
 import BiliModels
 import Foundation
 
@@ -27,6 +28,106 @@ public struct DanmakuRendererDurations: Sendable, Equatable {
         switch mode {
         case .scrolling: scrollingSeconds
         case .top, .bottom: fixedSeconds
+        }
+    }
+}
+
+public struct DanmakuMotionPolicy: Sendable, Equatable {
+    public let basePointSpeed: Double
+    public let lengthReferenceWidth: Double
+    public let lengthCoefficient: Double
+    public let maximumLengthBonus: Double
+    public let minimumScrollingSeconds: Double
+    public let maximumScrollingSeconds: Double
+    public let fixedSeconds: Double
+
+    private let fixedScrollingSeconds: Double?
+
+    public init(
+        basePointSpeed: Double = 130,
+        lengthReferenceWidth: Double = 960,
+        lengthCoefficient: Double = 0.25,
+        maximumLengthBonus: Double = 0.45,
+        minimumScrollingSeconds: Double = 1.5,
+        maximumScrollingSeconds: Double = 60,
+        fixedSeconds: Double = 4
+    ) {
+        self.basePointSpeed = basePointSpeed
+        self.lengthReferenceWidth = lengthReferenceWidth
+        self.lengthCoefficient = lengthCoefficient
+        self.maximumLengthBonus = maximumLengthBonus
+        self.minimumScrollingSeconds = minimumScrollingSeconds
+        self.maximumScrollingSeconds = maximumScrollingSeconds
+        self.fixedSeconds = fixedSeconds
+        self.fixedScrollingSeconds = nil
+    }
+
+    init(fixedDurations: DanmakuRendererDurations) {
+        basePointSpeed = 130
+        lengthReferenceWidth = 960
+        lengthCoefficient = 0.25
+        maximumLengthBonus = 0.45
+        minimumScrollingSeconds = 4
+        maximumScrollingSeconds = 30
+        fixedSeconds = fixedDurations.fixedSeconds
+        fixedScrollingSeconds = fixedDurations.scrollingSeconds
+    }
+
+    func duration(
+        for mode: DanmakuPresentationMode,
+        textWidth: Double,
+        surfaceWidth: Double,
+        speedLevel: DanmakuSpeedLevel
+    ) -> Double {
+        switch mode {
+        case .top, .bottom:
+            return fixedSeconds
+        case .scrolling:
+            if let fixedScrollingSeconds {
+                return fixedScrollingSeconds
+            }
+            guard basePointSpeed.isFinite,
+                basePointSpeed > 0,
+                lengthReferenceWidth.isFinite,
+                lengthReferenceWidth > 0,
+                lengthCoefficient.isFinite,
+                lengthCoefficient >= 0,
+                maximumLengthBonus.isFinite,
+                maximumLengthBonus >= 0,
+                minimumScrollingSeconds.isFinite,
+                minimumScrollingSeconds > 0,
+                maximumScrollingSeconds.isFinite,
+                maximumScrollingSeconds >= minimumScrollingSeconds,
+                textWidth.isFinite,
+                textWidth > 0,
+                surfaceWidth.isFinite,
+                surfaceWidth > 0
+            else {
+                return .nan
+            }
+            let lengthBonus = min(
+                lengthCoefficient * textWidth / lengthReferenceWidth,
+                maximumLengthBonus
+            )
+            let mediaPointSpeed =
+                basePointSpeed
+                * speedMultiplier(for: speedLevel)
+                * (1 + lengthBonus)
+            let rawDuration = (surfaceWidth + textWidth) / mediaPointSpeed
+            return min(
+                max(rawDuration, minimumScrollingSeconds),
+                maximumScrollingSeconds
+            )
+        }
+    }
+
+    private func speedMultiplier(for level: DanmakuSpeedLevel) -> Double {
+        switch level {
+        case .one: 90 / 130
+        case .two: 110 / 130
+        case .three: 1
+        case .four: 155 / 130
+        case .five: 185 / 130
         }
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Session/DanmakuSession.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Session/DanmakuSession.swift
@@ -111,6 +111,10 @@ public final class DanmakuSession: DanmakuPresentationControlling {
         )
     }
 
+    public func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {
+        presentationSink?.setSpeedLevel(speedLevel)
+    }
+
     /// 幂等结束整个会话，而不只是隐藏弹幕图层。
     public func stop() {
         presentationSink?.stopPresentation()

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/DanmakuControlsViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/DanmakuControlsViewModelTests.swift
@@ -8,7 +8,12 @@ struct DanmakuControlsViewModelTests {
     @Test
     func selectionControlsAndResetReachApplicationPort() {
         let presentation = RecordingDanmakuPresentation()
-        let model = DanmakuControlsViewModel(presentation: presentation)
+        var savedSpeedLevels: [DanmakuSpeedLevel] = []
+        let model = DanmakuControlsViewModel(
+            presentation: presentation,
+            initialSpeedLevel: .two,
+            saveSpeedLevel: { savedSpeedLevels.append($0) }
+        )
         let identity = PlaybackItemIdentity(
             bvid: "BV1ControlsFixture",
             cid: 1
@@ -19,10 +24,13 @@ struct DanmakuControlsViewModelTests {
         model.setShowsScrolling(false)
         model.setShowsTop(false)
         model.setShowsBottom(false)
+        model.setSpeedLevel(.five)
         model.reset()
 
         #expect(presentation.startedIdentities == [identity])
         #expect(presentation.enabledValues == [false])
+        #expect(presentation.speedLevels == [.two, .five])
+        #expect(savedSpeedLevels == [.five])
         #expect(
             presentation.modeValues == [
                 ModeValues(scrolling: false, top: true, bottom: true),
@@ -35,6 +43,7 @@ struct DanmakuControlsViewModelTests {
         #expect(!model.showsScrolling)
         #expect(!model.showsTop)
         #expect(!model.showsBottom)
+        #expect(model.speedLevel == .five)
     }
 }
 
@@ -51,6 +60,7 @@ private final class RecordingDanmakuPresentation:
     private(set) var startedIdentities: [PlaybackItemIdentity] = []
     private(set) var enabledValues: [Bool] = []
     private(set) var modeValues: [ModeValues] = []
+    private(set) var speedLevels: [DanmakuSpeedLevel] = []
     private(set) var stopCount = 0
 
     func start(for identity: PlaybackItemIdentity) {
@@ -59,6 +69,10 @@ private final class RecordingDanmakuPresentation:
 
     func setEnabled(_ enabled: Bool) {
         enabledValues.append(enabled)
+    }
+
+    func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {
+        speedLevels.append(speedLevel)
     }
 
     func setModeVisibility(

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuLaneAllocatorTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuLaneAllocatorTests.swift
@@ -185,6 +185,31 @@ struct DanmakuLaneAllocatorTests {
     }
 
     @Test
+    func extremeFiniteHeightCapsLaneCountBeforeIntegerConversion() {
+        let maximumActiveCount =
+            DanmakuLaneConfiguration.hardMaximumActiveCount
+        var allocator = DanmakuLaneAllocator(
+            configuration: DanmakuLaneConfiguration(
+                surfaceWidth: 1_000,
+                surfaceHeight: .greatestFiniteMagnitude,
+                laneHeight: 1,
+                minimumHorizontalGap: 12,
+                maximumActiveCount: maximumActiveCount,
+                displayAreaFraction: 1
+            )
+        )
+        let requests = (0...maximumActiveCount).map {
+            request(id: "extreme-\($0)", mode: .top, height: 1)
+        }
+
+        let admission = allocator.admit(requests, at: 0)
+
+        #expect(admission.admitted.count == maximumActiveCount)
+        #expect(admission.dropCounts.capacity == 1)
+        #expect(allocator.activeCount == maximumActiveCount)
+    }
+
+    @Test
     func invalidGeometryHardLimitAndResizeStayBounded() {
         var allocator = DanmakuLaneAllocator(configuration: configuration())
         _ = allocator.admit([request(id: "active")], at: 0)
@@ -194,18 +219,18 @@ struct DanmakuLaneAllocatorTests {
         )
         #expect(tooTall.dropCounts.invalidRequest == 1)
 
-        let drained = allocator.updateConfiguration(
+        allocator.updateConfiguration(
             configuration(surfaceWidth: 0)
         )
-        #expect(drained.map(\.request.event.id) == ["active"])
-        #expect(allocator.activeCount == 0)
+        #expect(allocator.activeCount == 1)
         let unavailable = allocator.admit(
             [request(id: "unavailable")],
             at: 1
         )
         #expect(unavailable.dropCounts.invalidRequest == 1)
+        #expect(allocator.activeCount == 1)
 
-        _ = allocator.updateConfiguration(
+        allocator.updateConfiguration(
             configuration(
                 maximumActiveCount:
                     DanmakuLaneConfiguration.hardMaximumActiveCount + 1
@@ -216,9 +241,9 @@ struct DanmakuLaneAllocatorTests {
             at: 2
         )
         #expect(overHardLimit.dropCounts.invalidRequest == 1)
-        #expect(allocator.activeCount == 0)
+        #expect(allocator.activeCount == 1)
 
-        _ = allocator.updateConfiguration(
+        allocator.updateConfiguration(
             configuration(displayAreaFraction: 1.01)
         )
         let invalidCoverage = allocator.admit(
@@ -226,7 +251,49 @@ struct DanmakuLaneAllocatorTests {
             at: 3
         )
         #expect(invalidCoverage.dropCounts.invalidRequest == 1)
-        #expect(allocator.activeCount == 0)
+        #expect(allocator.activeCount == 1)
+
+        allocator.updateConfiguration(configuration())
+        let recovered = allocator.admit(
+            [request(id: "recovered")],
+            at: 8
+        )
+        #expect(recovered.expired.map(\.request.event.id) == ["active"])
+        #expect(recovered.admitted.map(\.request.event.id) == ["recovered"])
+    }
+
+    @Test
+    func resizePreservesActiveAndUsesEachAdmissionWidthForCollision() throws {
+        var allocator = DanmakuLaneAllocator(
+            configuration: configuration(
+                surfaceWidth: 800,
+                surfaceHeight: 20
+            )
+        )
+        let first = allocator.admit(
+            [request(id: "old-surface", duration: 10)],
+            at: 0
+        )
+        #expect(first.admitted.count == 1)
+        #expect(first.admitted.first?.surfaceWidthAtAdmission == 800)
+
+        allocator.updateConfiguration(
+            configuration(
+                surfaceWidth: 1_200,
+                surfaceHeight: 20
+            )
+        )
+        #expect(allocator.activeCount == 1)
+
+        let following = allocator.admit(
+            [request(id: "new-surface", duration: 20)],
+            at: 0.2
+        )
+        let placement = try #require(following.admitted.first)
+        #expect(following.dropCounts.total == 0)
+        #expect(placement.surfaceWidthAtAdmission == 1_200)
+        #expect(placement.laneIndex == first.admitted.first?.laneIndex)
+        #expect(allocator.activeCount == 2)
     }
 
     @Test

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
@@ -340,7 +340,7 @@ struct DanmakuPresentationControllerTests {
     }
 
     @Test
-    func surfaceLifecycleDrainsAllocatorAndStatistics() {
+    func surfaceResizePreservesActiveUntilOwnerReplacement() {
         let backend = RecordingRenderingBackend()
         let controller = DanmakuPresentationController(
             backend: backend,
@@ -361,35 +361,39 @@ struct DanmakuPresentationControllerTests {
         #expect(controller.statistics.active == 1)
         let clearCount = backend.clearCount
 
-        #expect(controller.attachSurface(ownerID: replacementOwner))
-
-        #expect(backend.clearCount == clearCount + 1)
-        #expect(controller.statistics.active == 0)
-        #expect(!controller.detachSurface(ownerID: firstOwner))
-        #expect(backend.clearCount == clearCount + 1)
-
         #expect(
             !controller.updateSurface(
                 zeroConfiguration(),
-                ownerID: firstOwner
+                ownerID: replacementOwner
             )
         )
         #expect(
             controller.updateSurface(
                 zeroConfiguration(),
-                ownerID: replacementOwner
+                ownerID: firstOwner
             )
         )
         #expect(
             backend.surfaceSizes.last
                 == DanmakuTextMetrics(width: 0, height: 0)
         )
+        #expect(backend.clearCount == clearCount)
+        #expect(controller.statistics.active == 1)
         #expect(
             controller.updateSurface(
                 configuration(maximumActiveCount: 1),
-                ownerID: replacementOwner
+                ownerID: firstOwner
             )
         )
+        #expect(backend.clearCount == clearCount)
+        #expect(controller.statistics.active == 1)
+
+        #expect(controller.attachSurface(ownerID: replacementOwner))
+        #expect(backend.clearCount == clearCount + 1)
+        #expect(controller.statistics.active == 0)
+        #expect(!controller.detachSurface(ownerID: firstOwner))
+        #expect(backend.clearCount == clearCount + 1)
+
         controller.apply(
             update(
                 identity: identity,
@@ -400,6 +404,83 @@ struct DanmakuPresentationControllerTests {
         )
         #expect(backend.renderedEventIDs.last == "after-attach")
         #expect(controller.statistics.active == 1)
+    }
+
+    @Test
+    func rendererResizeKeepsScrollingAnimationAndRelayoutsFixedModes() throws {
+        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
+        renderer.updateSurfaceSize(width: 800, height: 300)
+        let scrolling = event(id: "resize-scroll", mode: .scrolling)
+        let top = event(id: "resize-top", mode: .top)
+        let bottom = event(id: "resize-bottom", mode: .bottom)
+
+        for (fixture, originY) in [
+            (scrolling, 60.0),
+            (top, 0.0),
+            (bottom, 240.0),
+        ] {
+            let metrics = renderer.measure(fixture)
+            renderer.render(
+                placement(
+                    event: fixture,
+                    metrics: metrics,
+                    originY: originY
+                )
+            )
+        }
+
+        let scrollingLayer = try #require(
+            renderer.textLayer(forEventID: scrolling.id)
+        )
+        let topLayer = try #require(renderer.textLayer(forEventID: top.id))
+        let bottomLayer = try #require(
+            renderer.textLayer(forEventID: bottom.id)
+        )
+        let scrollingPosition = scrollingLayer.position
+        let topY = topLayer.position.y
+        let bottomY = bottomLayer.position.y
+        let epoch = renderer.renderEpoch
+        let scrollingAnimation = try #require(
+            scrollingLayer.animation(forKey: "danmaku") as? CABasicAnimation
+        )
+        let scrollingFrom = try #require(
+            scrollingAnimation.fromValue as? NSNumber
+        )
+        let scrollingTo = try #require(
+            scrollingAnimation.toValue as? NSNumber
+        )
+        let scrollingDuration = scrollingAnimation.duration
+        let rootTiming = (
+            beginTime: renderer.rootLayer.beginTime,
+            timeOffset: renderer.rootLayer.timeOffset,
+            speed: renderer.rootLayer.speed
+        )
+
+        renderer.updateSurfaceSize(width: 1_200, height: 500)
+
+        #expect(renderer.renderEpoch == epoch)
+        #expect(renderer.activeLayerCount == 3)
+        #expect(scrollingLayer.position == scrollingPosition)
+        let resizedAnimation = try #require(
+            scrollingLayer.animation(forKey: "danmaku") as? CABasicAnimation
+        )
+        #expect((resizedAnimation.fromValue as? NSNumber) == scrollingFrom)
+        #expect((resizedAnimation.toValue as? NSNumber) == scrollingTo)
+        #expect(resizedAnimation.duration == scrollingDuration)
+        #expect(renderer.rootLayer.beginTime == rootTiming.beginTime)
+        #expect(renderer.rootLayer.timeOffset == rootTiming.timeOffset)
+        #expect(renderer.rootLayer.speed == rootTiming.speed)
+        #expect(topLayer.position == CGPoint(x: 600, y: topY))
+        #expect(bottomLayer.position == CGPoint(x: 600, y: bottomY + 200))
+
+        renderer.updateSurfaceSize(width: 0, height: 0)
+        renderer.updateSurfaceSize(width: 1_200, height: 500)
+
+        #expect(renderer.renderEpoch == epoch)
+        #expect(renderer.activeLayerCount == 3)
+        #expect(scrollingLayer.position == scrollingPosition)
+        #expect(topLayer.position == CGPoint(x: 600, y: topY))
+        #expect(bottomLayer.position == CGPoint(x: 600, y: bottomY + 200))
     }
 
     @Test
@@ -746,6 +827,7 @@ struct DanmakuPresentationControllerTests {
             ),
             laneIndex: 0,
             originY: originY,
+            surfaceWidthAtAdmission: 800,
             admittedAtSeconds: 1,
             expiresAtSeconds: 5
         )

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
@@ -11,6 +11,150 @@ import Testing
 @Suite
 struct DanmakuPresentationControllerTests {
     @Test
+    func lengthWeightedMotionMatchesFivePointSpeedsAcrossRealViewports() {
+        let policy = DanmakuMotionPolicy()
+        let levelPointSpeeds = zip(
+            DanmakuSpeedLevel.allCases,
+            [90.0, 110.0, 130.0, 155.0, 185.0]
+        )
+        let scenarios = [
+            (surfaceWidth: 400.0, textWidth: 100.0),
+            (surfaceWidth: 1_100.0, textWidth: 429.0),
+            (surfaceWidth: 3_440.0, textWidth: 1_479.0),
+        ]
+
+        for scenario in scenarios {
+            let lengthFactor =
+                1
+                + min(
+                    0.25 * scenario.textWidth / 960,
+                    0.45
+                )
+            var actualSpeeds: [Double] = []
+            for (level, pointSpeed) in levelPointSpeeds {
+                let duration = policy.duration(
+                    for: .scrolling,
+                    textWidth: scenario.textWidth,
+                    surfaceWidth: scenario.surfaceWidth,
+                    speedLevel: level
+                )
+                let actualSpeed =
+                    (scenario.surfaceWidth + scenario.textWidth) / duration
+                actualSpeeds.append(actualSpeed)
+                #expect(abs(actualSpeed - pointSpeed * lengthFactor) < 0.001)
+            }
+            #expect(
+                zip(actualSpeeds, actualSpeeds.dropFirst()).allSatisfy {
+                    $0 < $1
+                }
+            )
+        }
+    }
+
+    @Test
+    func lengthBonusIsContinuousAtItsCap() {
+        let policy = DanmakuMotionPolicy()
+        let surfaceWidth = 1_100.0
+        let capWidth = 1_728.0
+        let epsilon = 0.001
+
+        func speed(textWidth: Double) -> Double {
+            let duration = policy.duration(
+                for: .scrolling,
+                textWidth: textWidth,
+                surfaceWidth: surfaceWidth,
+                speedLevel: .three
+            )
+            return (surfaceWidth + textWidth) / duration
+        }
+
+        #expect(abs(speed(textWidth: capWidth) - 188.5) < 0.001)
+        #expect(
+            abs(
+                speed(textWidth: capWidth - epsilon)
+                    - speed(textWidth: capWidth)
+            ) < 0.001
+        )
+        #expect(
+            abs(
+                speed(textWidth: capWidth + epsilon)
+                    - speed(textWidth: capWidth)
+            ) < 0.001
+        )
+        #expect(abs(speed(textWidth: 4_000) - 188.5) < 0.001)
+    }
+
+    @Test
+    func durationSafetyBoundsOnlyClampExtremeInputs() {
+        let policy = DanmakuMotionPolicy()
+
+        #expect(
+            policy.duration(
+                for: .scrolling,
+                textWidth: 1,
+                surfaceWidth: 1,
+                speedLevel: .five
+            ) == 1.5
+        )
+        #expect(
+            policy.duration(
+                for: .scrolling,
+                textWidth: 4_000,
+                surfaceWidth: 10_000,
+                speedLevel: .one
+            ) == 60
+        )
+        #expect(
+            policy.duration(
+                for: .top,
+                textWidth: 123,
+                surfaceWidth: 1_100,
+                speedLevel: .five
+            ) == 4
+        )
+    }
+
+    @Test
+    func speedLevelChangeKeepsExistingPlacementAndSupportsMixedLaneSpeeds() throws {
+        let backend = RecordingRenderingBackend()
+        let controller = DanmakuPresentationController(
+            backend: backend,
+            configuration: configuration(maximumActiveCount: 4)
+        )
+        let identity = PlaybackItemIdentity(bvid: "BV1SpeedFixture", cid: 1)
+
+        controller.setSpeedLevel(.five)
+        controller.apply(
+            update(
+                identity: identity,
+                position: 1,
+                generation: 1,
+                events: [event(id: "level-five", mode: .scrolling)]
+            )
+        )
+        let clearCount = backend.clearCount
+        controller.setSpeedLevel(.one)
+        #expect(backend.clearCount == clearCount)
+        controller.apply(
+            update(
+                identity: identity,
+                position: 2,
+                generation: 1,
+                events: [event(id: "level-one", mode: .scrolling)]
+            )
+        )
+
+        let first = try #require(backend.renderedPlacements.first)
+        let second = try #require(backend.renderedPlacements.last)
+        #expect(backend.renderedPlacements.count == 2)
+        #expect(first.request.event.id == "level-five")
+        #expect(second.request.event.id == "level-one")
+        #expect(first.laneIndex == second.laneIndex)
+        #expect(first.expiresAtSeconds > second.admittedAtSeconds)
+        #expect(first.request.durationSeconds < second.request.durationSeconds)
+    }
+
+    @Test
     func controllerRemovesExpiredBeforeRenderingNewAdmission() {
         let backend = RecordingRenderingBackend()
         let controller = DanmakuPresentationController(
@@ -619,6 +763,7 @@ private final class RecordingRenderingBackend: DanmakuRenderingBackend {
     weak var delegate: (any DanmakuRenderingBackendDelegate)?
     var operations: [Operation] = []
     private(set) var renderedEventIDs: [String] = []
+    private(set) var renderedPlacements: [DanmakuLanePlacement] = []
     private(set) var rates: [Double] = []
     private(set) var clearCount = 0
     private(set) var stopCount = 0
@@ -634,6 +779,7 @@ private final class RecordingRenderingBackend: DanmakuRenderingBackend {
         let eventID = placement.request.event.id
         operations.append(.render(eventID))
         renderedEventIDs.append(eventID)
+        renderedPlacements.append(placement)
     }
 
     func remove(eventID: String) {

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSessionTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSessionTests.swift
@@ -128,6 +128,10 @@ struct DanmakuSessionTests {
         )
         #expect(sink.clearCount == 2)
 
+        session.setSpeedLevel(.five)
+        #expect(sink.speedLevels == [.five])
+        #expect(sink.clearCount == 2)
+
         session.stop()
         #expect(sink.stopCount == 1)
     }
@@ -266,6 +270,7 @@ struct DanmakuSessionTests {
 @MainActor
 private final class SessionPresentationSink: DanmakuPresentationSink {
     private(set) var updates: [DanmakuPresentationUpdate] = []
+    private(set) var speedLevels: [DanmakuSpeedLevel] = []
     private(set) var clearCount = 0
     private(set) var stopCount = 0
     private var updateWaiters:
@@ -283,6 +288,10 @@ private final class SessionPresentationSink: DanmakuPresentationSink {
         for (id, waiter) in ready where updateWaiters.removeValue(forKey: id) != nil {
             waiter.continuation.resume()
         }
+    }
+
+    func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {
+        speedLevels.append(speedLevel)
     }
 
     func clearPresentation() {


### PR DESCRIPTION
## 变化

- 增加 Lv1–Lv5 五档滚动弹幕速度，并持久化用户选择。
- 使用“基础点速 × 连续文字长度系数 × 全局速度档位”计算滚动速度；固定弹幕驻留时长保持独立。
- resize 时保留屏内滚动弹幕的原动画与点速，新弹幕使用最新视口尺寸。
- 顶部弹幕随宽度居中，底部弹幕保持距底部位置。
- AVKit fullscreen 临时 reparent 不再被视为 surface 销毁；真正 dismantle、换视频、seek/replay 和 stop 仍按原生命周期清理。
- 忽略临时零尺寸 geometry，避免过渡期间的新弹幕被永久丢弃；lane 数在整数转换前限制到硬上限。
- 补齐速度公式、混合速度碰撞、resize geometry、surface owner、临时 window reparent 和极端尺寸测试。

## 原因

原实现把滚动弹幕的穿屏时长直接绑定到容器宽度，并在每次尺寸变化时清空活动弹幕，导致窗口与全屏切换时速度体验不稳定且出现明显空屏。五档速度也需要维持明确、连续的点速语义。

## 用户影响

- 普通窗口、窄窗口和全屏下的滚动速度更可预测。
- 长弹幕获得连续而有上限的速度补偿。
- 窗口 resize 与 fullscreen 过渡不再清空在途弹幕。
- 用户可通过“滚动速度”选择 Lv1–Lv5，默认 Lv3。

## 验证

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer sh Scripts/run-quality-gates.sh app`
- Swift Package：320 个测试通过。
- App build-for-testing 与 App 单元测试通过。
- 定向弹幕测试：30/30。
- `git diff --check` 通过。
- 已用签名 App 实际观察播放中窗口尺寸切换、进入全屏与退出全屏；弹幕层持续呈现，Keychain 登录恢复正常。

## 未覆盖边界

- CI 尚待本 PR 触发后确认。
- 单元测试锁定动画参数与 root timing；逐帧 presentation-layer 连续性仍主要由真实 UI 验收覆盖。