### PR TITLE
feat(danmaku): 支持彩色弹幕与透明度设置

### DIFF
--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -27,7 +27,7 @@ struct AppEnvironment {
     private let danmakuSession: DanmakuSession
     private let danmakuController: DanmakuPresentationController
     private let danmakuRenderer: CoreAnimationDanmakuRenderer
-    private let danmakuSpeedPreferencesStore: any DanmakuSpeedPreferencesStoring
+    private let danmakuPreferencesStore: any DanmakuPreferencesStoring
     private let authenticationService: any AuthenticationServicing
     private let authenticationQRCodeProvider: any AuthenticationQRCodeProviding
 
@@ -39,8 +39,8 @@ struct AppEnvironment {
         danmakuRepository: any DanmakuSegmentRepository,
         playerEngine: AVPlayerEngine,
         playbackPreferencesController: PlaybackPreferencesController,
-        danmakuSpeedPreferencesStore: any DanmakuSpeedPreferencesStoring =
-            UserDefaultsDanmakuSpeedPreferencesStore(),
+        danmakuPreferencesStore: any DanmakuPreferencesStoring =
+            UserDefaultsDanmakuPreferencesStore(),
         authenticationService: any AuthenticationServicing,
         authenticationQRCodeProvider: any AuthenticationQRCodeProviding
     ) {
@@ -54,7 +54,7 @@ struct AppEnvironment {
         self.historyRepository = historyRepository
         self.playerEngine = playerEngine
         self.playbackPreferencesController = playbackPreferencesController
-        self.danmakuSpeedPreferencesStore = danmakuSpeedPreferencesStore
+        self.danmakuPreferencesStore = danmakuPreferencesStore
         let renderer = CoreAnimationDanmakuRenderer()
         let controller = DanmakuPresentationController(
             backend: renderer,
@@ -95,12 +95,16 @@ struct AppEnvironment {
     }
 
     func makeDanmakuViewModel() -> DanmakuControlsViewModel {
-        let initialSpeedLevel = danmakuSpeedPreferencesStore.loadSpeedLevel()
+        let preferences = danmakuPreferencesStore.load()
         return DanmakuControlsViewModel(
             presentation: danmakuSession,
-            initialSpeedLevel: initialSpeedLevel,
-            saveSpeedLevel: { [danmakuSpeedPreferencesStore] speedLevel in
-                danmakuSpeedPreferencesStore.saveSpeedLevel(speedLevel)
+            initialSpeedLevel: preferences.speedLevel,
+            initialOpacity: preferences.opacity,
+            saveSpeedLevel: { [danmakuPreferencesStore] speedLevel in
+                danmakuPreferencesStore.saveSpeedLevel(speedLevel)
+            },
+            saveOpacity: { [danmakuPreferencesStore] opacity in
+                danmakuPreferencesStore.saveOpacity(opacity)
             }
         )
     }

--- a/BiliKitMac/Composition/UITestContentView.swift
+++ b/BiliKitMac/Composition/UITestContentView.swift
@@ -328,6 +328,7 @@
         func start(for identity: PlaybackItemIdentity) {}
         func setEnabled(_ enabled: Bool) {}
         func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {}
+        func setOpacity(_ opacity: DanmakuOpacity) {}
 
         func setModeVisibility(
             scrolling: Bool,

--- a/BiliKitMac/Platform/PlaybackPreferencesController.swift
+++ b/BiliKitMac/Platform/PlaybackPreferencesController.swift
@@ -84,39 +84,75 @@ final class UserDefaultsPlaybackPreferencesStore:
     }
 }
 
-protocol DanmakuSpeedPreferencesStoring: AnyObject, Sendable {
-    func loadSpeedLevel() -> DanmakuSpeedLevel
-    func saveSpeedLevel(_ speedLevel: DanmakuSpeedLevel)
+struct DanmakuPreferences: Equatable, Sendable {
+    static let defaults = DanmakuPreferences(
+        speedLevel: .three,
+        opacity: .fullyOpaque
+    )
+
+    let speedLevel: DanmakuSpeedLevel
+    let opacity: DanmakuOpacity
 }
 
-/// 只保存设备级弹幕速度意图，不保存视频 identity、正文或播放位置。
-final class UserDefaultsDanmakuSpeedPreferencesStore:
-    DanmakuSpeedPreferencesStoring, @unchecked Sendable
+protocol DanmakuPreferencesStoring: AnyObject, Sendable {
+    func load() -> DanmakuPreferences
+    func saveSpeedLevel(_ speedLevel: DanmakuSpeedLevel)
+    func saveOpacity(_ opacity: DanmakuOpacity)
+}
+
+/// 只保存设备级弹幕显示意图，不保存视频 identity、正文或播放位置。
+final class UserDefaultsDanmakuPreferencesStore:
+    DanmakuPreferencesStoring, @unchecked Sendable
 {
-    private static let key = "danmaku.speedLevel"
+    private enum Key {
+        static let speedLevel = "danmaku.speedLevel"
+        static let opacity = "danmaku.opacity"
+    }
+
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
     }
 
-    func loadSpeedLevel() -> DanmakuSpeedLevel {
-        guard let number = defaults.object(forKey: Self.key) as? NSNumber,
+    func load() -> DanmakuPreferences {
+        DanmakuPreferences(
+            speedLevel: loadSpeedLevel(),
+            opacity: loadOpacity()
+        )
+    }
+
+    func saveSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {
+        defaults.set(speedLevel.rawValue, forKey: Key.speedLevel)
+    }
+
+    func saveOpacity(_ opacity: DanmakuOpacity) {
+        defaults.set(opacity.value, forKey: Key.opacity)
+    }
+
+    private func loadSpeedLevel() -> DanmakuSpeedLevel {
+        guard let number = defaults.object(forKey: Key.speedLevel) as? NSNumber,
             CFGetTypeID(number) != CFBooleanGetTypeID()
         else {
-            return .three
+            return DanmakuPreferences.defaults.speedLevel
         }
         let rawValue = number.intValue
         guard number.doubleValue == Double(rawValue),
             let speedLevel = DanmakuSpeedLevel(rawValue: rawValue)
         else {
-            return .three
+            return DanmakuPreferences.defaults.speedLevel
         }
         return speedLevel
     }
 
-    func saveSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {
-        defaults.set(speedLevel.rawValue, forKey: Self.key)
+    private func loadOpacity() -> DanmakuOpacity {
+        guard let number = defaults.object(forKey: Key.opacity) as? NSNumber,
+            CFGetTypeID(number) != CFBooleanGetTypeID(),
+            let opacity = DanmakuOpacity(number.doubleValue)
+        else {
+            return DanmakuPreferences.defaults.opacity
+        }
+        return opacity
     }
 }
 

--- a/BiliKitMacTests/PlaybackPreferencesControllerTests.swift
+++ b/BiliKitMacTests/PlaybackPreferencesControllerTests.swift
@@ -63,29 +63,45 @@ struct PlaybackPreferencesControllerTests {
 
     @Test
     @MainActor
-    func danmakuSpeedLevelPersistsAndInvalidValuesFallBackToLevelThree() {
-        withIsolatedDefaults { defaults in
-            let store = UserDefaultsDanmakuSpeedPreferencesStore(
+    func danmakuDisplayPreferencesPersistAndInvalidValuesFallBack() throws {
+        try withIsolatedDefaults { defaults in
+            let store = UserDefaultsDanmakuPreferencesStore(
                 defaults: defaults
             )
-            #expect(store.loadSpeedLevel() == .three)
+            #expect(store.load() == .defaults)
 
             store.saveSpeedLevel(.five)
-            #expect(store.loadSpeedLevel() == .five)
+            let opacity = try #require(DanmakuOpacity(0.55))
+            store.saveOpacity(opacity)
+            #expect(
+                store.load()
+                    == DanmakuPreferences(
+                        speedLevel: .five,
+                        opacity: opacity
+                    )
+            )
 
             defaults.set(2.5, forKey: "danmaku.speedLevel")
-            #expect(store.loadSpeedLevel() == .three)
+            #expect(store.load().speedLevel == .three)
+            #expect(store.load().opacity == opacity)
             defaults.set(true, forKey: "danmaku.speedLevel")
-            #expect(store.loadSpeedLevel() == .three)
+            #expect(store.load().speedLevel == .three)
             defaults.set(6, forKey: "danmaku.speedLevel")
-            #expect(store.loadSpeedLevel() == .three)
+            #expect(store.load().speedLevel == .three)
+
+            for invalidOpacity in [Double.nan, 0.1, 1.1] {
+                defaults.set(invalidOpacity, forKey: "danmaku.opacity")
+                #expect(store.load().opacity == .fullyOpaque)
+            }
+            defaults.set(true, forKey: "danmaku.opacity")
+            #expect(store.load().opacity == .fullyOpaque)
         }
     }
 
     @MainActor
     private func withIsolatedDefaults(
-        _ body: (UserDefaults) -> Void
-    ) {
+        _ body: (UserDefaults) throws -> Void
+    ) rethrows {
         let suiteName = "PlaybackPreferencesControllerTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             Issue.record("无法创建隔离的 UserDefaults suite")
@@ -93,7 +109,7 @@ struct PlaybackPreferencesControllerTests {
         }
         defaults.removePersistentDomain(forName: suiteName)
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        body(defaults)
+        try body(defaults)
     }
 
     private func load(from defaults: UserDefaults) -> PlaybackPreferences {

--- a/BiliKitMacTests/VideoDetailLifecycleTests.swift
+++ b/BiliKitMacTests/VideoDetailLifecycleTests.swift
@@ -1208,6 +1208,7 @@ private final class RecordingPresentation: DanmakuPresentationControlling {
 
     func setEnabled(_ enabled: Bool) {}
     func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {}
+    func setOpacity(_ opacity: DanmakuOpacity) {}
 
     func setModeVisibility(
         scrolling: Bool,

--- a/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuPresentationControlling.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuPresentationControlling.swift
@@ -6,6 +6,24 @@ public enum DanmakuSpeedLevel: Int, CaseIterable, Sendable, Equatable {
     case five
 }
 
+public struct DanmakuOpacity: Sendable, Equatable {
+    public static let allowedRange = 0.2...1.0
+    public static let fullyOpaque = DanmakuOpacity(validatedValue: 1)
+
+    public let value: Double
+
+    public init?(_ value: Double) {
+        guard value.isFinite, Self.allowedRange.contains(value) else {
+            return nil
+        }
+        self.init(validatedValue: value)
+    }
+
+    private init(validatedValue: Double) {
+        value = validatedValue
+    }
+}
+
 @MainActor
 /// 让 Feature 驱动弹幕会话开始、可见性与完整停止，而不暴露 scheduler 或 renderer。
 public protocol DanmakuPresentationControlling: AnyObject {
@@ -17,5 +35,6 @@ public protocol DanmakuPresentationControlling: AnyObject {
         bottom: Bool
     )
     func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel)
+    func setOpacity(_ opacity: DanmakuOpacity)
     func stop()
 }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsView.swift
@@ -3,9 +3,10 @@ import SwiftUI
 
 struct DanmakuControlsView: View {
     let model: DanmakuControlsViewModel
+    @State private var showsSettings = false
 
     var body: some View {
-        HStack(spacing: 16) {
+        HStack(spacing: 10) {
             Toggle(
                 "弹幕",
                 isOn: Binding(
@@ -14,52 +15,253 @@ struct DanmakuControlsView: View {
                 )
             )
             .toggleStyle(.switch)
+            .fixedSize()
             .accessibilityIdentifier("danmaku.enabled")
 
-            Menu("显示类型") {
-                Toggle(
-                    "滚动",
-                    isOn: Binding(
-                        get: { model.showsScrolling },
-                        set: { model.setShowsScrolling($0) }
-                    )
-                )
-                Toggle(
-                    "顶部",
-                    isOn: Binding(
-                        get: { model.showsTop },
-                        set: { model.setShowsTop($0) }
-                    )
-                )
-                Toggle(
-                    "底部",
-                    isOn: Binding(
-                        get: { model.showsBottom },
-                        set: { model.setShowsBottom($0) }
-                    )
-                )
+            Button {
+                showsSettings.toggle()
+            } label: {
+                Label("弹幕设置", systemImage: "slider.horizontal.3")
+                    .labelStyle(.iconOnly)
             }
-            .disabled(!model.isEnabled)
-            .accessibilityIdentifier("danmaku.modes")
-
-            Picker(
-                "滚动速度",
-                selection: Binding(
-                    get: { model.speedLevel },
-                    set: { model.setSpeedLevel($0) }
-                )
-            ) {
-                ForEach(DanmakuSpeedLevel.allCases, id: \.rawValue) { level in
-                    Text("Lv\(level.rawValue)").tag(level)
-                }
+            .buttonStyle(.bordered)
+            .help("弹幕设置")
+            .accessibilityIdentifier("danmaku.settings")
+            .popover(isPresented: $showsSettings, arrowEdge: .bottom) {
+                DanmakuSettingsPopover(model: model)
             }
-            .pickerStyle(.menu)
-            .frame(width: 120)
-            .disabled(!model.isEnabled || !model.showsScrolling)
-            .accessibilityIdentifier("danmaku.speed")
 
             Spacer()
         }
         .font(.title3)
+    }
+}
+
+private struct DanmakuSettingsPopover: View {
+    private enum Mode {
+        case scrolling
+        case top
+        case bottom
+    }
+
+    let model: DanmakuControlsViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("弹幕设置")
+                .font(.headline)
+
+            modeSettings
+
+            Divider()
+
+            speedSettings
+
+            Divider()
+
+            opacitySettings
+        }
+        .padding(16)
+        .frame(width: 340)
+        .font(.body)
+        .accessibilityIdentifier("danmaku.settings.popover")
+    }
+
+    private var modeSettings: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("显示类型")
+                .font(.subheadline.weight(.semibold))
+
+            HStack(spacing: 18) {
+                modeToggle(
+                    "滚动",
+                    isOn: model.showsScrolling,
+                    isLastVisibleMode: model.showsScrolling
+                        && !model.showsTop
+                        && !model.showsBottom,
+                    identifier: "danmaku.mode.scrolling",
+                    mode: .scrolling
+                )
+                modeToggle(
+                    "顶部",
+                    isOn: model.showsTop,
+                    isLastVisibleMode: model.showsTop
+                        && !model.showsScrolling
+                        && !model.showsBottom,
+                    identifier: "danmaku.mode.top",
+                    mode: .top
+                )
+                modeToggle(
+                    "底部",
+                    isOn: model.showsBottom,
+                    isLastVisibleMode: model.showsBottom
+                        && !model.showsScrolling
+                        && !model.showsTop,
+                    identifier: "danmaku.mode.bottom",
+                    mode: .bottom
+                )
+            }
+
+            Text("至少保留一种显示类型")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var speedSettings: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("滚动速度")
+                    .font(.subheadline.weight(.semibold))
+
+                Spacer()
+
+                Text(model.speedLevel.displayName)
+                    .font(.subheadline.weight(.semibold))
+            }
+
+            Slider(
+                value: Binding(
+                    get: { Double(model.speedLevel.rawValue) },
+                    set: { rawValue in
+                        let levelValue = Int(rawValue.rounded())
+                        guard
+                            let level = DanmakuSpeedLevel(
+                                rawValue: levelValue
+                            )
+                        else {
+                            return
+                        }
+                        model.setSpeedLevel(level)
+                    }
+                ),
+                in: Double(
+                    DanmakuSpeedLevel.one.rawValue
+                )...Double(
+                    DanmakuSpeedLevel.five.rawValue
+                ),
+                step: 1
+            ) {
+                Text("滚动速度")
+            }
+            .labelsHidden()
+            .accessibilityValue(Text(model.speedLevel.displayName))
+            .disabled(!model.showsScrolling)
+            .accessibilityIdentifier("danmaku.speed")
+
+            HStack(spacing: 0) {
+                ForEach(DanmakuSpeedLevel.allCases, id: \.rawValue) { level in
+                    Text(level.displayName)
+                        .font(.caption2)
+                        .fontWeight(
+                            level == model.speedLevel ? .semibold : .regular
+                        )
+                        .foregroundStyle(
+                            level == model.speedLevel
+                                ? Color.primary
+                                : Color.secondary
+                        )
+                        .frame(maxWidth: .infinity)
+                }
+            }
+        }
+    }
+
+    private var opacitySettings: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("透明度")
+                    .font(.subheadline.weight(.semibold))
+
+                Spacer()
+
+                Text(
+                    model.opacity.value,
+                    format: .percent.precision(.fractionLength(0))
+                )
+                .font(.subheadline.weight(.semibold))
+                .monospacedDigit()
+            }
+
+            Slider(
+                value: Binding(
+                    get: { model.opacity.value },
+                    set: { model.setOpacity($0) }
+                ),
+                in: DanmakuOpacity.allowedRange,
+                step: 0.05
+            ) {
+                Text("透明度")
+            }
+            .labelsHidden()
+            .accessibilityValue(
+                Text(
+                    model.opacity.value,
+                    format: .percent.precision(.fractionLength(0))
+                )
+            )
+            .accessibilityIdentifier("danmaku.opacity")
+
+            HStack {
+                Text(
+                    DanmakuOpacity.allowedRange.lowerBound,
+                    format: .percent.precision(.fractionLength(0))
+                )
+
+                Spacer()
+
+                Text(
+                    DanmakuOpacity.allowedRange.upperBound,
+                    format: .percent.precision(.fractionLength(0))
+                )
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private func modeToggle(
+        _ title: String,
+        isOn: Bool,
+        isLastVisibleMode: Bool,
+        identifier: String,
+        mode: Mode
+    ) -> some View {
+        Toggle(
+            title,
+            isOn: Binding(
+                get: { isOn },
+                set: { newValue in
+                    switch mode {
+                    case .scrolling:
+                        model.setShowsScrolling(newValue)
+                    case .top:
+                        model.setShowsTop(newValue)
+                    case .bottom:
+                        model.setShowsBottom(newValue)
+                    }
+                }
+            )
+        )
+        .toggleStyle(.checkbox)
+        .disabled(isLastVisibleMode)
+        .accessibilityIdentifier(identifier)
+    }
+}
+
+extension DanmakuSpeedLevel {
+    fileprivate var displayName: String {
+        switch self {
+        case .one:
+            "极慢"
+        case .two:
+            "较慢"
+        case .three:
+            "适中"
+        case .four:
+            "较快"
+        case .five:
+            "极快"
+        }
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsViewModel.swift
@@ -12,21 +12,29 @@ public final class DanmakuControlsViewModel {
     public private(set) var showsTop = true
     public private(set) var showsBottom = true
     public private(set) var speedLevel: DanmakuSpeedLevel
+    public private(set) var opacity: DanmakuOpacity
 
     @ObservationIgnored
     private let presentation: any DanmakuPresentationControlling
     @ObservationIgnored
     private let saveSpeedLevel: @MainActor (DanmakuSpeedLevel) -> Void
+    @ObservationIgnored
+    private let saveOpacity: @MainActor (DanmakuOpacity) -> Void
 
     public init(
         presentation: any DanmakuPresentationControlling,
         initialSpeedLevel: DanmakuSpeedLevel = .three,
-        saveSpeedLevel: @escaping @MainActor (DanmakuSpeedLevel) -> Void = { _ in }
+        initialOpacity: DanmakuOpacity = .fullyOpaque,
+        saveSpeedLevel: @escaping @MainActor (DanmakuSpeedLevel) -> Void = { _ in },
+        saveOpacity: @escaping @MainActor (DanmakuOpacity) -> Void = { _ in }
     ) {
         self.presentation = presentation
         self.speedLevel = initialSpeedLevel
+        self.opacity = initialOpacity
         self.saveSpeedLevel = saveSpeedLevel
+        self.saveOpacity = saveOpacity
         presentation.setSpeedLevel(initialSpeedLevel)
+        presentation.setOpacity(initialOpacity)
     }
 
     public func selectVideo(_ identity: PlaybackItemIdentity) {
@@ -66,6 +74,15 @@ public final class DanmakuControlsViewModel {
         self.speedLevel = speedLevel
         presentation.setSpeedLevel(speedLevel)
         saveSpeedLevel(speedLevel)
+    }
+
+    public func setOpacity(_ value: Double) {
+        guard let opacity = DanmakuOpacity(value), self.opacity != opacity else {
+            return
+        }
+        self.opacity = opacity
+        presentation.setOpacity(opacity)
+        saveOpacity(opacity)
     }
 
     private func applyModeVisibility() {

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuRenderer.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuRenderer.swift
@@ -1,4 +1,5 @@
 import AppKit
+import BiliApplication
 import BiliModels
 import CoreText
 import Foundation
@@ -16,6 +17,7 @@ public final class CoreAnimationDanmakuRenderer:
     private static let maximumTextWidthPixels: CGFloat = 8_192
     private static let maximumTextHeightPixels: CGFloat = 512
     private static let maximumTextUTF16Length = 512
+    private static let lightInkRelativeLuminanceThreshold = 0.179
 
     private struct Entry {
         let layer: CATextLayer
@@ -32,9 +34,16 @@ public final class CoreAnimationDanmakuRenderer:
 
     private let contentsScale: CGFloat
     private let font = NSFont.systemFont(ofSize: 24, weight: .semibold)
-    private let heavyInkShadow: NSShadow = {
+    private let darkInkShadow: NSShadow = {
         let shadow = NSShadow()
         shadow.shadowColor = NSColor.black
+        shadow.shadowOffset = .zero
+        shadow.shadowBlurRadius = 1.5
+        return shadow
+    }()
+    private let lightInkShadow: NSShadow = {
+        let shadow = NSShadow()
+        shadow.shadowColor = NSColor.white
         shadow.shadowOffset = .zero
         shadow.shadowBlurRadius = 1.5
         return shadow
@@ -152,6 +161,13 @@ public final class CoreAnimationDanmakuRenderer:
         rootLayer.speed = Float(newRate)
     }
 
+    public func setOpacity(_ opacity: DanmakuOpacity) {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        rootLayer.opacity = Float(opacity.value)
+        CATransaction.commit()
+    }
+
     public func updateSurfaceSize(width: Double, height: Double) {
         let oldSurfaceSize = surfaceSize
         surfaceSize = CGSize(
@@ -202,16 +218,57 @@ public final class CoreAnimationDanmakuRenderer:
     private func attributedString(
         for event: DanmakuEvent
     ) -> NSAttributedString {
-        NSAttributedString(
+        let components = rgbComponents(for: event.colorRGB)
+        var attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor(
+                srgbRed: components.red,
+                green: components.green,
+                blue: components.blue,
+                alpha: 1
+            ),
+            NSAttributedString.Key(kCTLanguageAttributeName as String):
+                Self.simplifiedChineseLanguage,
+        ]
+        attributes[.shadow] = adaptiveShadow(for: components)
+        return NSAttributedString(
             string: event.text,
-            attributes: [
-                .font: font,
-                .foregroundColor: NSColor.white,
-                .shadow: heavyInkShadow,
-                NSAttributedString.Key(kCTLanguageAttributeName as String):
-                    Self.simplifiedChineseLanguage,
-            ]
+            attributes: attributes
         )
+    }
+
+    private func rgbComponents(
+        for colorRGB: UInt32
+    ) -> (red: CGFloat, green: CGFloat, blue: CGFloat) {
+        let baseRGB = colorRGB & 0x00FF_FFFF
+        return (
+            red: CGFloat((baseRGB >> 16) & 0xFF) / 255,
+            green: CGFloat((baseRGB >> 8) & 0xFF) / 255,
+            blue: CGFloat(baseRGB & 0xFF) / 255
+        )
+    }
+
+    private func adaptiveShadow(
+        for components: (red: CGFloat, green: CGFloat, blue: CGFloat)
+    ) -> NSShadow {
+        Double(relativeLuminance(for: components))
+            < Self.lightInkRelativeLuminanceThreshold
+            ? lightInkShadow
+            : darkInkShadow
+    }
+
+    private func relativeLuminance(
+        for components: (red: CGFloat, green: CGFloat, blue: CGFloat)
+    ) -> CGFloat {
+        0.2126 * linearized(components.red)
+            + 0.7152 * linearized(components.green)
+            + 0.0722 * linearized(components.blue)
+    }
+
+    private func linearized(_ component: CGFloat) -> CGFloat {
+        component <= 0.04045
+            ? component / 12.92
+            : pow((component + 0.055) / 1.055, 2.4)
     }
 
     private func makeTextLayer(

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentation.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentation.swift
@@ -22,6 +22,7 @@ public struct DanmakuPresentationUpdate: Sendable, Equatable {
 public protocol DanmakuPresentationSink: AnyObject {
     func apply(_ update: DanmakuPresentationUpdate)
     func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel)
+    func setOpacity(_ opacity: DanmakuOpacity)
     func clearPresentation()
     func stopPresentation()
 }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
@@ -157,6 +157,10 @@ public final class DanmakuPresentationController:
         self.speedLevel = speedLevel
     }
 
+    public func setOpacity(_ opacity: DanmakuOpacity) {
+        backend.setOpacity(opacity)
+    }
+
     public func stopPresentation() {
         _ = allocator.clear()
         backend.stop()

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuRenderingBackend.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuRenderingBackend.swift
@@ -150,6 +150,7 @@ public protocol DanmakuRenderingBackend: AnyObject {
     func remove(eventID: String)
     func clearAll()
     func setPlaybackRate(_ rate: Double)
+    func setOpacity(_ opacity: DanmakuOpacity)
     func updateSurfaceSize(width: Double, height: Double)
     func stop()
 }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Session/DanmakuSession.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Session/DanmakuSession.swift
@@ -115,6 +115,10 @@ public final class DanmakuSession: DanmakuPresentationControlling {
         presentationSink?.setSpeedLevel(speedLevel)
     }
 
+    public func setOpacity(_ opacity: DanmakuOpacity) {
+        presentationSink?.setOpacity(opacity)
+    }
+
     /// 幂等结束整个会话，而不只是隐藏弹幕图层。
     public func stop() {
         presentationSink?.stopPresentation()

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/DanmakuControlsViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/DanmakuControlsViewModelTests.swift
@@ -6,13 +6,17 @@ import Testing
 @Suite
 struct DanmakuControlsViewModelTests {
     @Test
-    func selectionControlsAndResetReachApplicationPort() {
+    func selectionControlsAndResetReachApplicationPort() throws {
         let presentation = RecordingDanmakuPresentation()
         var savedSpeedLevels: [DanmakuSpeedLevel] = []
+        var savedOpacities: [DanmakuOpacity] = []
+        let initialOpacity = try #require(DanmakuOpacity(0.65))
         let model = DanmakuControlsViewModel(
             presentation: presentation,
             initialSpeedLevel: .two,
-            saveSpeedLevel: { savedSpeedLevels.append($0) }
+            initialOpacity: initialOpacity,
+            saveSpeedLevel: { savedSpeedLevels.append($0) },
+            saveOpacity: { savedOpacities.append($0) }
         )
         let identity = PlaybackItemIdentity(
             bvid: "BV1ControlsFixture",
@@ -25,12 +29,17 @@ struct DanmakuControlsViewModelTests {
         model.setShowsTop(false)
         model.setShowsBottom(false)
         model.setSpeedLevel(.five)
+        model.setOpacity(0.4)
+        model.setOpacity(0.1)
+        model.setOpacity(.nan)
         model.reset()
 
         #expect(presentation.startedIdentities == [identity])
         #expect(presentation.enabledValues == [false])
         #expect(presentation.speedLevels == [.two, .five])
+        #expect(presentation.opacities == [initialOpacity, DanmakuOpacity(0.4)])
         #expect(savedSpeedLevels == [.five])
+        #expect(savedOpacities == [DanmakuOpacity(0.4)])
         #expect(
             presentation.modeValues == [
                 ModeValues(scrolling: false, top: true, bottom: true),
@@ -44,6 +53,7 @@ struct DanmakuControlsViewModelTests {
         #expect(!model.showsTop)
         #expect(!model.showsBottom)
         #expect(model.speedLevel == .five)
+        #expect(model.opacity == DanmakuOpacity(0.4))
     }
 }
 
@@ -61,6 +71,7 @@ private final class RecordingDanmakuPresentation:
     private(set) var enabledValues: [Bool] = []
     private(set) var modeValues: [ModeValues] = []
     private(set) var speedLevels: [DanmakuSpeedLevel] = []
+    private(set) var opacities: [DanmakuOpacity] = []
     private(set) var stopCount = 0
 
     func start(for identity: PlaybackItemIdentity) {
@@ -73,6 +84,10 @@ private final class RecordingDanmakuPresentation:
 
     func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {
         speedLevels.append(speedLevel)
+    }
+
+    func setOpacity(_ opacity: DanmakuOpacity) {
+        opacities.append(opacity)
     }
 
     func setModeVisibility(

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
@@ -261,6 +261,9 @@ struct DanmakuPresentationControllerTests {
         )
         let identity = PlaybackItemIdentity(bvid: "BV1LifecycleFixture", cid: 3)
 
+        let opacity = DanmakuOpacity(0.45) ?? .fullyOpaque
+        controller.setOpacity(opacity)
+
         controller.apply(
             update(
                 identity: identity,
@@ -292,6 +295,7 @@ struct DanmakuPresentationControllerTests {
         controller.stopPresentation()
 
         #expect(backend.rates == [0, 2, 1])
+        #expect(backend.opacities == [opacity])
         #expect(backend.clearCount == 2)
         #expect(backend.stopCount == 2)
         #expect(controller.statistics.active == 0)
@@ -511,6 +515,134 @@ struct DanmakuPresentationControllerTests {
         #expect(shadow.shadowBlurRadius == 1.5)
         #expect(shadow.shadowOffset == .zero)
         #expect(renderer.activeLayerCount == 1)
+    }
+
+    @Test
+    func coreAnimationUsesEventRGBAndAppliesOpacityWithoutReplacingLayers() throws {
+        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
+        renderer.updateSurfaceSize(width: 800, height: 200)
+        let colorful = event(
+            id: "colorful",
+            mode: .scrolling,
+            colorRGB: 0xAB_D0_E0_F0
+        )
+        let dark = event(id: "dark", mode: .top, colorRGB: 0x000000)
+
+        for (fixture, originY) in [(colorful, 20.0), (dark, 60.0)] {
+            let metrics = renderer.measure(fixture)
+            renderer.render(
+                placement(
+                    event: fixture,
+                    metrics: metrics,
+                    originY: originY
+                )
+            )
+        }
+
+        let colorfulLayer = try #require(
+            renderer.textLayer(forEventID: colorful.id)
+        )
+        let colorfulIdentity = try #require(
+            renderer.objectIdentity(forEventID: colorful.id)
+        )
+        let colorfulText = try #require(
+            colorfulLayer.string as? NSAttributedString
+        )
+        let foreground = try #require(
+            colorfulText.attribute(
+                .foregroundColor,
+                at: 0,
+                effectiveRange: nil
+            ) as? NSColor
+        )
+        let sRGB = try #require(foreground.usingColorSpace(.sRGB))
+        let colorfulShadow = try #require(
+            colorfulText.attribute(.shadow, at: 0, effectiveRange: nil)
+                as? NSShadow
+        )
+        let colorfulShadowColor = try #require(
+            colorfulShadow.shadowColor?.usingColorSpace(.sRGB)
+        )
+
+        #expect(abs(sRGB.redComponent - 0xD0 / 255) < 0.001)
+        #expect(abs(sRGB.greenComponent - 0xE0 / 255) < 0.001)
+        #expect(abs(sRGB.blueComponent - 0xF0 / 255) < 0.001)
+        #expect(colorfulShadowColor.redComponent == 0)
+
+        let darkLayer = try #require(renderer.textLayer(forEventID: dark.id))
+        let darkText = try #require(darkLayer.string as? NSAttributedString)
+        let darkShadow = try #require(
+            darkText.attribute(.shadow, at: 0, effectiveRange: nil) as? NSShadow
+        )
+        let darkShadowColor = try #require(
+            darkShadow.shadowColor?.usingColorSpace(.sRGB)
+        )
+        #expect(darkShadowColor.redComponent == 1)
+
+        let opacity = try #require(DanmakuOpacity(0.45))
+        renderer.setOpacity(opacity)
+
+        #expect(abs(Double(renderer.rootLayer.opacity) - opacity.value) < 0.001)
+        #expect(renderer.activeLayerCount == 2)
+        #expect(
+            renderer.objectIdentity(forEventID: colorful.id)
+                == colorfulIdentity
+        )
+        #expect(renderer.textLayer(forEventID: colorful.id) === colorfulLayer)
+    }
+
+    @Test
+    func adaptiveHeavyInkUsesFixedRelativeLuminanceThreshold() throws {
+        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
+        renderer.updateSurfaceSize(width: 800, height: 200)
+        let belowThreshold = event(
+            id: "ink-below-threshold",
+            mode: .scrolling,
+            colorRGB: 0x757575
+        )
+        let aboveThreshold = event(
+            id: "ink-above-threshold",
+            mode: .top,
+            colorRGB: 0x767676
+        )
+
+        for (fixture, originY) in [
+            (belowThreshold, 20.0),
+            (aboveThreshold, 60.0),
+        ] {
+            renderer.render(
+                placement(
+                    event: fixture,
+                    metrics: renderer.measure(fixture),
+                    originY: originY
+                )
+            )
+        }
+
+        func attributes(for eventID: String) throws -> NSAttributedString {
+            let layer = try #require(renderer.textLayer(forEventID: eventID))
+            return try #require(layer.string as? NSAttributedString)
+        }
+
+        func shadowRedComponent(for eventID: String) throws -> CGFloat {
+            let text = try attributes(for: eventID)
+            let shadow = try #require(
+                text.attribute(.shadow, at: 0, effectiveRange: nil) as? NSShadow
+            )
+            let color = try #require(
+                shadow.shadowColor?.usingColorSpace(.sRGB)
+            )
+            #expect(
+                text.attribute(.strokeColor, at: 0, effectiveRange: nil) == nil
+            )
+            #expect(
+                text.attribute(.strokeWidth, at: 0, effectiveRange: nil) == nil
+            )
+            return color.redComponent
+        }
+
+        #expect(try shadowRedComponent(for: belowThreshold.id) == 1)
+        #expect(try shadowRedComponent(for: aboveThreshold.id) == 0)
     }
 
     @Test
@@ -800,7 +932,8 @@ struct DanmakuPresentationControllerTests {
 
     private func event(
         id: String,
-        mode: DanmakuPresentationMode
+        mode: DanmakuPresentationMode,
+        colorRGB: UInt32 = 0xFFFFFF
     ) -> DanmakuEvent {
         DanmakuEvent(
             id: id,
@@ -808,7 +941,7 @@ struct DanmakuPresentationControllerTests {
             mode: mode,
             text: "中文 日本語 한국어 Latin 😀 #",
             fontSize: 24,
-            colorRGB: 0xFFFFFF,
+            colorRGB: colorRGB,
             weight: 1
         )
     }
@@ -847,6 +980,7 @@ private final class RecordingRenderingBackend: DanmakuRenderingBackend {
     private(set) var renderedEventIDs: [String] = []
     private(set) var renderedPlacements: [DanmakuLanePlacement] = []
     private(set) var rates: [Double] = []
+    private(set) var opacities: [DanmakuOpacity] = []
     private(set) var clearCount = 0
     private(set) var stopCount = 0
     private(set) var measureCount = 0
@@ -875,6 +1009,10 @@ private final class RecordingRenderingBackend: DanmakuRenderingBackend {
     func setPlaybackRate(_ rate: Double) {
         operations.append(.rate(rate))
         rates.append(rate)
+    }
+
+    func setOpacity(_ opacity: DanmakuOpacity) {
+        opacities.append(opacity)
     }
 
     func updateSurfaceSize(width: Double, height: Double) {

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSessionTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSessionTests.swift
@@ -110,7 +110,7 @@ struct DanmakuSessionTests {
     }
 
     @Test
-    func controlsClearOrStopPresentationSynchronously() {
+    func controlsClearOrStopPresentationSynchronously() throws {
         let repository = ImmediateDanmakuRepository()
         let timeline = SessionTimeline()
         let sink = SessionPresentationSink()
@@ -130,6 +130,11 @@ struct DanmakuSessionTests {
 
         session.setSpeedLevel(.five)
         #expect(sink.speedLevels == [.five])
+        #expect(sink.clearCount == 2)
+
+        let opacity = try #require(DanmakuOpacity(0.55))
+        session.setOpacity(opacity)
+        #expect(sink.opacities == [opacity])
         #expect(sink.clearCount == 2)
 
         session.stop()
@@ -271,6 +276,7 @@ struct DanmakuSessionTests {
 private final class SessionPresentationSink: DanmakuPresentationSink {
     private(set) var updates: [DanmakuPresentationUpdate] = []
     private(set) var speedLevels: [DanmakuSpeedLevel] = []
+    private(set) var opacities: [DanmakuOpacity] = []
     private(set) var clearCount = 0
     private(set) var stopCount = 0
     private var updateWaiters:
@@ -292,6 +298,10 @@ private final class SessionPresentationSink: DanmakuPresentationSink {
 
     func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {
         speedLevels.append(speedLevel)
+    }
+
+    func setOpacity(_ opacity: DanmakuOpacity) {
+        opacities.append(opacity)
     }
 
     func clearPresentation() {


### PR DESCRIPTION
## 变化

- 按弹幕事件的 RGB 颜色渲染滚动、顶部和底部弹幕
- 使用固定相对亮度阈值选择黑色或白色“重墨”阴影，提升不同颜色在视频背景上的可读性
- 新增全局弹幕透明度设置（20%–100%），持久化到 UserDefaults，并立即作用于屏内已有弹幕和后续弹幕
- 将弹幕控制收敛为总开关与设置按钮，在原生 Popover 中统一管理类型、五档速度和透明度
- 五档速度使用“极慢、较慢、适中、较快、极快”的离散滑条表达
- 移除调试期描边实验入口和相关生产接口，最终仅保留既有重墨形态

## 原因

彩色弹幕需要在复杂视频背景上保持稳定可读，同时播放器控制区不应因设置项增加而变得拥挤。本次实现保留用户已确认的重墨视觉语言，用确定、可测试的亮度规则选择黑白阴影，并将低频设置集中到紧凑 Popover。

## 用户影响

- 弹幕可显示来源颜色
- 用户可以全局调节透明度，并在后续窗口重建时恢复设置
- 速度档位的语义更直观，设置区排版更统一
- 修改透明度不会替换活动弹幕层或重启动画；速度修改按既有语义影响后续入场弹幕

## 验证

- 三个独立 reviewer 分别复核颜色渲染、偏好与生命周期、弹幕设置 UI，未发现 P0–P3/blocker
- `swift test --filter Danmaku`：58 tests / 7 suites 通过
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer sh Scripts/run-quality-gates.sh app` 通过
- 本地 UI fixture 验收设置 Popover、速度与透明度交互，并确认描边实验入口不存在
- `git diff --check` 通过

## 未覆盖边界

- HDR/EDR 与极端复杂背景下的彩色弹幕对比度仍以真实内容肉眼验收为准
- VoiceOver/FKA 的完整遍历，以及签名 Release 环境的端到端 UI 行为未在本 PR 中单独自动化覆盖
