### PR TITLE
feat(danmaku): 统一使用 WBI 弹幕接口

### DIFF
--- a/BiliKitMac/App/AppRootView.swift
+++ b/BiliKitMac/App/AppRootView.swift
@@ -96,6 +96,12 @@ struct AppRootView: View {
             guard generation > previousGeneration else { return }
             authenticationModel.revalidate()
         }
+        .onChange(of: danmakuModel.authenticationRevalidationGeneration) {
+            previousGeneration,
+            generation in
+            guard generation > previousGeneration else { return }
+            authenticationModel.revalidate()
+        }
         .onChange(of: navigationCoordinator.searchDraft) { _, query in
             guard query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             else {

--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -140,8 +140,9 @@ struct AppEnvironment {
 
     /// 创建生产对象图，并保持游客、媒体与字幕正文请求不自动继承登录 Cookie。
     ///
-    /// 只有显式声明为已认证的 API 请求才经过 authorizer；登出还会替换 API 的
-    /// ephemeral transport，使旧认证会话中的在途请求失效。
+    /// 只有精确白名单内的认证 API、playurl 与 WBI 弹幕分段才经过 authorizer；后两者在
+    /// 明确无本地凭据时仍请求同一个 endpoint。登出还会替换 API 的 ephemeral transport，
+    /// 使旧认证会话中的在途请求失效。
     static func live() -> AppEnvironment {
         let requestAuthorizer = BiliCredentialRequestAuthorizer()
         let transportFactory: @Sendable () -> any HTTPTransport = {

--- a/BiliKitMacTests/DanmakuPoolProbeTests.swift
+++ b/BiliKitMacTests/DanmakuPoolProbeTests.swift
@@ -62,6 +62,7 @@ import XCTest
             XCTContext.runActivity(named: summary) { _ in }
         }
 
+        @MainActor
         private static func outcome(
             _ operation: () async throws -> DanmakuPoolProbeSummary
         ) async -> String {

--- a/BiliKitMacTests/DanmakuPoolProbeTests.swift
+++ b/BiliKitMacTests/DanmakuPoolProbeTests.swift
@@ -1,0 +1,122 @@
+import BiliApplication
+import BiliModels
+import BiliNetworking
+import Foundation
+import XCTest
+
+#if DEBUG
+    @testable import BiliAPI
+    @testable import BiliAuth
+
+    final class DanmakuPoolProbeTests: XCTestCase {
+        @MainActor
+        func testPoolVariantsWhenExplicitlyConfigured() async throws {
+            guard let input = try LocalProbeInput.load(),
+                let bvid = input["bvid"],
+                Self.isValidBVID(bvid)
+            else {
+                throw XCTSkip("仅在显式提供安全本机输入文件时运行弹幕池探针")
+            }
+            Self.recordStage("input-ready")
+
+            let anonymousTransport = Self.ephemeralTransport()
+            defer { anonymousTransport.invalidateAndCancel() }
+            let anonymousClient = BiliAPIClient(transport: anonymousTransport)
+            let pages = try await anonymousClient.pages(for: bvid)
+            guard let cid = pages.first?.cid else {
+                throw ProbeFailure.missingVideoPage
+            }
+            let identity = PlaybackItemIdentity(bvid: bvid, cid: cid)
+
+            let wbiAnonymous = await Self.outcome {
+                try await anonymousClient.danmakuPoolProbe(
+                    index: 1,
+                    for: identity
+                )
+            }
+            Self.recordStage("anonymous-complete")
+
+            let authorizer = BiliCredentialRequestAuthorizer()
+            guard case .signedIn = try await authorizer.restoreAccountSession() else {
+                throw ProbeFailure.missingAuthenticatedSession
+            }
+            let authenticatedTransport = Self.ephemeralTransport()
+            defer { authenticatedTransport.invalidateAndCancel() }
+            let authenticatedClient = BiliAPIClient(
+                transport: authenticatedTransport,
+                requestAuthorizer: authorizer
+            )
+            let wbiAuthenticated = await Self.outcome {
+                try await authenticatedClient.danmakuPoolProbe(
+                    index: 1,
+                    for: identity
+                )
+            }
+            Self.recordStage("authenticated-complete")
+
+            let summary = [
+                "danmaku-pool-spike",
+                "wbi-anonymous=\(wbiAnonymous)",
+                "wbi-authenticated=\(wbiAuthenticated)",
+            ].joined(separator: " ")
+            XCTContext.runActivity(named: summary) { _ in }
+        }
+
+        private static func outcome(
+            _ operation: () async throws -> DanmakuPoolProbeSummary
+        ) async -> String {
+            do {
+                let summary = try await operation()
+                let modes = summary.rawModeCounts
+                    .sorted { $0.key < $1.key }
+                    .map { "\($0.key)x\($0.value)" }
+                    .joined(separator: "_")
+                return [
+                    "ready",
+                    "bytes-\(summary.bytes)",
+                    "raw-\(summary.rawEventCount)",
+                    "basic-\(summary.basicEventCount)",
+                    "modes-\(modes.isEmpty ? "none" : modes)",
+                ].joined(separator: "_")
+            } catch let error as BiliAPIError {
+                return error.description
+            } catch is CancellationError {
+                return "cancelled"
+            } catch {
+                return "unexpected-error"
+            }
+        }
+
+        @MainActor
+        private static func recordStage(_ stage: String) {
+            let value = "danmaku-pool-stage stage=\(stage)"
+            FileHandle.standardError.write(Data("\(value)\n".utf8))
+            XCTContext.runActivity(named: value) { _ in }
+        }
+
+        private static func ephemeralTransport() -> URLSessionTransport {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.httpShouldSetCookies = false
+            configuration.httpCookieStorage = nil
+            configuration.urlCache = nil
+            configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+            configuration.timeoutIntervalForRequest = 15
+            configuration.timeoutIntervalForResource = 30
+            return URLSessionTransport(
+                configuration: configuration,
+                redirectPolicy: .reject
+            )
+        }
+
+        private static func isValidBVID(_ value: String) -> Bool {
+            value.count == 12
+                && value.hasPrefix("BV")
+                && value.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber) }
+        }
+
+        private enum ProbeFailure: Error {
+            case missingVideoPage
+            case missingAuthenticatedSession
+        }
+    }
+#endif

--- a/Packages/BiliKitCore/Package.swift
+++ b/Packages/BiliKitCore/Package.swift
@@ -73,7 +73,12 @@ let package = Package(
         .target(name: "BiliUI"),
         .executableTarget(
             name: "BiliAPIProbe",
-            dependencies: ["BiliAPI", "BiliNetworking"]
+            dependencies: [
+                "BiliAPI",
+                "BiliApplication",
+                "BiliModels",
+                "BiliNetworking",
+            ]
         ),
         .executableTarget(
             name: "BiliAuthProbe",

--- a/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliDanmakuRepository.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliDanmakuRepository.swift
@@ -44,8 +44,10 @@ public struct BiliDanmakuRepository: DanmakuSegmentRepository, Sendable {
             .invalidResponse
         case .httpStatus, .apiRejected:
             .unavailable
-        case .authorizationRequired, .authenticationInvalid,
-            .authorizationUnavailable, .nonJSONResponse, .invalidWBIKey,
+        case .authenticationInvalid:
+            .authenticationInvalid
+        case .authorizationRequired, .authorizationUnavailable,
+            .nonJSONResponse, .invalidWBIKey,
             .signingFailed, .invalidMediaData, .invalidSubtitleData,
             .untrustedSubtitleOrigin, .noAVCVideo, .noAACAudio:
             .invalidResponse

--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
@@ -5,10 +5,10 @@ import Foundation
 
 /// Bilibili endpoint/DTO adapter；把远端协议限制在 `BiliAPI`，并返回稳定模型。
 ///
-/// 匿名请求永不经过 authorizer。只有显式认证 endpoint 与精确 legacy playurl 才临时授权；
-/// playurl 也只有在本地明确无凭据时保持匿名。响应在解码前还要满足状态、大小与
-/// Content-Type 边界。actor 隔离可变 transport/WBI cache；跨 `await` 可重入，用户意图的
-/// 取消与写回代次仍由上层 owner 管理。
+/// 游客专用请求永不经过 authorizer。只有显式认证 endpoint、精确 playurl 与 WBI 弹幕分段
+/// 才临时授权；后两者也只有在本地明确无凭据时保持匿名，并继续使用同一个 endpoint。
+/// 响应在解码前还要满足状态、大小与 Content-Type 边界。actor 隔离可变
+/// transport/WBI cache；跨 `await` 可重入，用户意图的取消与写回代次仍由上层 owner 管理。
 public actor BiliAPIClient: AuthenticatedSessionInvalidating {
     private enum AuthorizationProvenance: Sendable {
         case anonymous
@@ -398,49 +398,25 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
         else {
             throw BiliAPIError.invalidRequest
         }
-        let url = try endpoint(
-            path: "/x/v2/dm/web/seg.so",
-            queryItems: [
-                URLQueryItem(name: "type", value: "1"),
-                URLQueryItem(name: "oid", value: String(identity.cid)),
-                URLQueryItem(name: "segment_index", value: String(index)),
-            ]
-        )
-        let request = HTTPRequest(
-            url: url,
-            headers: [
-                "Accept": "application/octet-stream",
-                "Referer": Self.videoReferer(identity.bvid),
-                "User-Agent": userAgent,
-            ]
-        )
-        let response: HTTPResponse
         do {
-            response = try await httpClient.send(request)
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch let error as HTTPClientError {
-            switch error {
-            case .unacceptableStatusCode(let status):
-                throw BiliAPIError.httpStatus(status)
-            case .nonHTTPResponse:
-                throw BiliAPIError.transportFailure
-            }
-        } catch {
-            throw BiliAPIError.transportFailure
+            return try await signedDanmakuSegmentData(
+                index: index,
+                for: identity,
+                forceKeyRefresh: false
+            )
+        } catch BiliAPIError.apiRejected(let code, _) where code == -403 {
+            return try await signedDanmakuSegmentData(
+                index: index,
+                for: identity,
+                forceKeyRefresh: true
+            )
+        } catch BiliAPIError.httpStatus(403) {
+            return try await signedDanmakuSegmentData(
+                index: index,
+                for: identity,
+                forceKeyRefresh: true
+            )
         }
-        guard !response.body.isEmpty,
-            response.body.count <= Self.maximumDanmakuSegmentSize
-        else {
-            if response.body.isEmpty {
-                throw BiliAPIError.invalidDanmakuData
-            }
-            throw BiliAPIError.responseTooLarge(response.body.count)
-        }
-        guard Self.looksLikeProtobuf(response) else {
-            throw BiliAPIError.nonProtobufResponse
-        }
-        return response.body
     }
 
     public func watchHistory(
@@ -628,6 +604,24 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
                 "User-Agent": userAgent,
             ]
         )
+        let response = try await response(
+            baseRequest: baseRequest,
+            requiresAuthentication: requiresAuthentication,
+            permitsMissingCredentialFallback: permitsMissingCredentialFallback,
+            maximumResponseSize: maximumResponseSize
+        )
+        guard Self.looksLikeJSON(response.response) else {
+            throw BiliAPIError.nonJSONResponse
+        }
+        return response
+    }
+
+    private func response(
+        baseRequest: HTTPRequest,
+        requiresAuthentication: Bool,
+        permitsMissingCredentialFallback: Bool = false,
+        maximumResponseSize: Int
+    ) async throws -> AuthorizedHTTPResponse {
         let requestClient = httpClient
         let requestSessionEpoch =
             requiresAuthentication ? authenticatedSessionEpoch : nil
@@ -648,7 +642,6 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
                 }
                 switch error.authorizationFailureKind {
                 case .missingCredential where permitsMissingCredentialFallback:
-                    try Task.checkCancellation()
                     request = baseRequest
                     authorizationProvenance = .anonymous
                 case .invalidCredential:
@@ -668,6 +661,7 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
             request = baseRequest
             authorizationProvenance = .anonymous
         }
+        try Task.checkCancellation()
         if let requestSessionEpoch,
             requestSessionEpoch != authenticatedSessionEpoch
         {
@@ -707,9 +701,6 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
 
         guard response.body.count <= maximumResponseSize else {
             throw BiliAPIError.responseTooLarge(response.body.count)
-        }
-        guard Self.looksLikeJSON(response) else {
-            throw BiliAPIError.nonJSONResponse
         }
         return AuthorizedHTTPResponse(
             response: response,
@@ -756,6 +747,63 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
             maximumResponseSize: Self.maximumSubtitleCatalogSize
         )
         return try payload.resources()
+    }
+
+    private func signedDanmakuSegmentData(
+        index: Int,
+        for identity: PlaybackItemIdentity,
+        forceKeyRefresh: Bool
+    ) async throws -> Data {
+        let keys = try await wbiKey(forceRefresh: forceKeyRefresh)
+        let query = try wbiSigner.sign(
+            parameters: [
+                "type": "1",
+                "oid": String(identity.cid),
+                "segment_index": String(index),
+            ],
+            keys: keys,
+            timestamp: timestampProvider()
+        )
+        let url = try endpoint(
+            path: "/x/v2/dm/wbi/web/seg.so",
+            percentEncodedQuery: query
+        )
+        let response = try await response(
+            baseRequest: HTTPRequest(
+                url: url,
+                headers: [
+                    "Accept": "application/octet-stream",
+                    "Referer": Self.videoReferer(identity.bvid),
+                    "User-Agent": userAgent,
+                ]
+            ),
+            requiresAuthentication: requestAuthorizer != nil,
+            permitsMissingCredentialFallback: true,
+            maximumResponseSize: Self.maximumDanmakuSegmentSize
+        ).response
+        guard !response.body.isEmpty else {
+            throw BiliAPIError.invalidDanmakuData
+        }
+        guard Self.looksLikeProtobuf(response) else {
+            if Self.isKnownNonProtobufBody(response.body),
+                let status = try? decoder.decode(
+                    APIStatusEnvelope.self,
+                    from: response.body
+                )
+            {
+                if status.code == -101 {
+                    throw BiliAPIError.authenticationInvalid
+                }
+                if status.code != 0 {
+                    throw BiliAPIError.apiRejected(
+                        code: status.code,
+                        message: status.message ?? ""
+                    )
+                }
+            }
+            throw BiliAPIError.nonProtobufResponse
+        }
+        return response.body
     }
 
     private func wbiKey(forceRefresh: Bool) async throws -> WBIKeyMaterial {
@@ -909,6 +957,21 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
             || normalized.hasPrefix("<!doctype")
     }
 }
+
+#if DEBUG
+    extension BiliAPIClient {
+        func danmakuPoolProbe(
+            index: Int,
+            for identity: PlaybackItemIdentity
+        ) async throws -> DanmakuPoolProbeSummary {
+            let data = try await danmakuSegmentData(
+                index: index,
+                for: identity
+            )
+            return try DanmakuPoolProbeSummary.make(from: data)
+        }
+    }
+#endif
 
 private struct CachedWBIKey: Sendable {
     let key: WBIKeyMaterial

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/DanmakuPayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/DanmakuPayloads.swift
@@ -81,3 +81,32 @@ enum DanmakuPayloadDecoder {
         Double(min(max(value, 12), 64))
     }
 }
+
+#if DEBUG
+    struct DanmakuPoolProbeSummary: Sendable, Equatable {
+        let bytes: Int
+        let rawEventCount: Int
+        let basicEventCount: Int
+        let rawModeCounts: [Int32: Int]
+
+        static func make(from data: Data) throws -> Self {
+            let payload: Bilikit_Danmaku_SegmentReply
+            do {
+                payload = try Bilikit_Danmaku_SegmentReply(serializedBytes: data)
+            } catch {
+                throw BiliAPIError.invalidDanmakuData
+            }
+            let events = try DanmakuPayloadDecoder.events(from: data)
+            let modeCounts = Dictionary(
+                grouping: payload.elements,
+                by: \Bilikit_Danmaku_Element.mode
+            ).mapValues(\.count)
+            return Self(
+                bytes: data.count,
+                rawEventCount: payload.elements.count,
+                basicEventCount: events.count,
+                rawModeCounts: modeCounts
+            )
+        }
+    }
+#endif

--- a/Packages/BiliKitCore/Sources/BiliAPIProbe/main.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPIProbe/main.swift
@@ -1,4 +1,6 @@
 import BiliAPI
+import BiliApplication
+import BiliModels
 import BiliNetworking
 import Foundation
 
@@ -113,10 +115,16 @@ private actor SearchProbeTransport: HTTPTransport {
         configuration.httpCookieStorage = nil
         configuration.urlCache = nil
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
-        transport = URLSessionTransport(
-            configuration: configuration,
-            redirectPolicy: .reject
+        self.init(
+            transport: URLSessionTransport(
+                configuration: configuration,
+                redirectPolicy: .reject
+            )
         )
+    }
+
+    init(transport: URLSessionTransport) {
+        self.transport = transport
     }
 
     func send(_ request: HTTPRequest) async throws -> HTTPResponse {
@@ -130,9 +138,8 @@ private actor SearchProbeTransport: HTTPTransport {
 
 private struct M4ContractProbe {
     private static let danmakuViewLimit = 256 * 1_024
-    private static let danmakuSegmentLimit = 2 * 1_024 * 1_024
 
-    private let transport: URLSessionTransport
+    private let transport: SearchProbeTransport
 
     init() {
         let configuration = URLSessionConfiguration.ephemeral
@@ -142,9 +149,11 @@ private struct M4ContractProbe {
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
         configuration.timeoutIntervalForRequest = 15
         configuration.timeoutIntervalForResource = 30
-        transport = URLSessionTransport(
-            configuration: configuration,
-            redirectPolicy: .reject
+        transport = SearchProbeTransport(
+            transport: URLSessionTransport(
+                configuration: configuration,
+                redirectPolicy: .reject
+            )
         )
     }
 
@@ -165,20 +174,15 @@ private struct M4ContractProbe {
             maximumSize: Self.danmakuViewLimit
         )
 
-        let segment = try await request(
-            path: "/x/v2/dm/web/seg.so",
-            queryItems: [
-                URLQueryItem(name: "type", value: "1"),
-                URLQueryItem(name: "oid", value: String(cid)),
-                URLQueryItem(name: "segment_index", value: "1"),
-            ],
-            accept: "application/octet-stream",
-            referer: referer
+        let segment = try await BiliDanmakuRepository(
+            client: BiliAPIClient(transport: transport)
+        ).segment(
+            index: 1,
+            for: PlaybackItemIdentity(bvid: bvid, cid: cid)
         )
-        try observeBinary(
-            segment,
-            name: "danmaku-segment",
-            maximumSize: Self.danmakuSegmentLimit
+        print(
+            "contract=danmaku-segment-wbi production-decoder=ready "
+                + "events=\(segment.events.count)"
         )
     }
 

--- a/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuContracts.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuContracts.swift
@@ -2,6 +2,7 @@ import BiliModels
 
 public enum DanmakuApplicationError: Error, Sendable, Equatable {
     case invalidRequest
+    case authenticationInvalid
     case requestRestricted
     case transportFailure
     case invalidResponse

--- a/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuPresentationControlling.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuPresentationControlling.swift
@@ -27,6 +27,9 @@ public struct DanmakuOpacity: Sendable, Equatable {
 @MainActor
 /// 让 Feature 驱动弹幕会话开始、可见性与完整停止，而不暴露 scheduler 或 renderer。
 public protocol DanmakuPresentationControlling: AnyObject {
+    func setAuthenticationInvalidationHandler(
+        _ handler: @escaping @MainActor () -> Void
+    )
     func start(for identity: PlaybackItemIdentity)
     func setEnabled(_ enabled: Bool)
     func setModeVisibility(
@@ -37,4 +40,10 @@ public protocol DanmakuPresentationControlling: AnyObject {
     func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel)
     func setOpacity(_ opacity: DanmakuOpacity)
     func stop()
+}
+
+extension DanmakuPresentationControlling {
+    public func setAuthenticationInvalidationHandler(
+        _ handler: @escaping @MainActor () -> Void
+    ) {}
 }

--- a/Packages/BiliKitCore/Sources/BiliAuth/Credential/BiliCredentialRequestAuthorizer.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/Credential/BiliCredentialRequestAuthorizer.swift
@@ -198,9 +198,42 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
             return isAllowedPlaybackQuery(components.queryItems)
         case "/x/player/wbi/v2":
             return isAllowedPlayerWBIQuery(components.queryItems)
+        case "/x/v2/dm/wbi/web/seg.so":
+            return isAllowedDanmakuWBIQuery(components.queryItems)
         default:
             return false
         }
+    }
+
+    private static func isAllowedDanmakuWBIQuery(
+        _ queryItems: [URLQueryItem]?
+    ) -> Bool {
+        guard let queryItems, queryItems.count == 5 else { return false }
+        var values: [String: String] = [:]
+        for item in queryItems {
+            guard values.updateValue(item.value ?? "", forKey: item.name) == nil else {
+                return false
+            }
+        }
+        guard values.count == 5,
+            Set(values.keys) == ["type", "oid", "segment_index", "w_rid", "wts"],
+            values["type"] == "1",
+            let oid = values["oid"].flatMap(Int64.init),
+            oid > 0,
+            let segmentIndex = values["segment_index"].flatMap(Int.init),
+            (1...10_000).contains(segmentIndex),
+            let timestamp = values["wts"].flatMap(Int64.init),
+            timestamp > 0,
+            let signature = values["w_rid"],
+            signature.count == 32,
+            signature.allSatisfy({
+                $0.isASCII
+                    && ($0.isNumber || ("a"..."f").contains($0))
+            })
+        else {
+            return false
+        }
+        return true
     }
 
     private static func isAllowedPlaybackQuery(

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsViewModel.swift
@@ -13,6 +13,7 @@ public final class DanmakuControlsViewModel {
     public private(set) var showsBottom = true
     public private(set) var speedLevel: DanmakuSpeedLevel
     public private(set) var opacity: DanmakuOpacity
+    public private(set) var authenticationRevalidationGeneration = 0
 
     @ObservationIgnored
     private let presentation: any DanmakuPresentationControlling
@@ -35,6 +36,9 @@ public final class DanmakuControlsViewModel {
         self.saveOpacity = saveOpacity
         presentation.setSpeedLevel(initialSpeedLevel)
         presentation.setOpacity(initialOpacity)
+        presentation.setAuthenticationInvalidationHandler { [weak self] in
+            self?.authenticationRevalidationGeneration &+= 1
+        }
     }
 
     public func selectVideo(_ identity: PlaybackItemIdentity) {

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Session/DanmakuSession.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Session/DanmakuSession.swift
@@ -20,6 +20,7 @@ public final class DanmakuSession: DanmakuPresentationControlling {
     private let useCase: DanmakuSegmentUseCase
     private let timeline: any PlaybackTimelineProviding
     private weak var presentationSink: (any DanmakuPresentationSink)?
+    private var authenticationInvalidationHandler: @MainActor () -> Void = {}
     private var scheduler = DanmakuScheduler()
     private var presentationEnabled = true
     private var presentationFilter = DanmakuFilter()
@@ -28,6 +29,7 @@ public final class DanmakuSession: DanmakuPresentationControlling {
     private var timelineTask: Task<Void, Never>?
     private var loadTasks: [Int: Task<Void, Never>] = [:]
     private var failedSegmentIndices: Set<Int> = []
+    private var authenticationInvalidationReported = false
     private var continuations: [UUID: AsyncStream<DanmakuBatch>.Continuation] = [:]
 
     public init(
@@ -81,6 +83,12 @@ public final class DanmakuSession: DanmakuPresentationControlling {
         }
     }
 
+    public func setAuthenticationInvalidationHandler(
+        _ handler: @escaping @MainActor () -> Void
+    ) {
+        authenticationInvalidationHandler = handler
+    }
+
     public func setEnabled(_ enabled: Bool) {
         guard presentationEnabled != enabled else { return }
         presentationEnabled = enabled
@@ -130,6 +138,7 @@ public final class DanmakuSession: DanmakuPresentationControlling {
         }
         loadTasks.removeAll(keepingCapacity: false)
         failedSegmentIndices.removeAll(keepingCapacity: false)
+        authenticationInvalidationReported = false
         identity = nil
         scheduler.reset()
         state = .idle
@@ -201,6 +210,12 @@ public final class DanmakuSession: DanmakuPresentationControlling {
                 self.loadTasks[index] = nil
                 self.failedSegmentIndices.insert(index)
                 self.state = .failed(identity, error)
+                if error == .authenticationInvalid,
+                    !self.authenticationInvalidationReported
+                {
+                    self.authenticationInvalidationReported = true
+                    self.authenticationInvalidationHandler()
+                }
             } catch {
                 guard let self,
                     self.generation == requestGeneration,

--- a/Packages/BiliKitCore/Sources/BiliDanmakuProbe/BiliDanmakuProbe.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmakuProbe/BiliDanmakuProbe.swift
@@ -108,6 +108,7 @@ struct BiliDanmakuProbe {
     private static func safeName(_ error: DanmakuApplicationError) -> String {
         switch error {
         case .invalidRequest: "invalid-request"
+        case .authenticationInvalid: "authentication-invalid"
         case .requestRestricted: "request-restricted"
         case .transportFailure: "transport-failure"
         case .invalidResponse: "invalid-response"

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliDanmakuRepositoryTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliDanmakuRepositoryTests.swift
@@ -14,13 +14,18 @@ struct BiliDanmakuRepositoryTests {
     )
 
     @Test
-    func productionDecoderMapsMinimalFixtureAndBuildsAnonymousRequest() async throws {
+    func productionDecoderMapsMinimalFixtureAndBuildsWBIAnonymousRequest() async throws {
         let transport = DanmakuRecordingTransport(
-            responses: [try binaryFixtureResponse("danmaku-segment-minimal")]
+            responses: [
+                try jsonFixtureResponse("nav"),
+                try binaryFixtureResponse("danmaku-segment-minimal"),
+            ]
         )
-        let repository = BiliDanmakuRepository(
-            client: BiliAPIClient(transport: transport)
+        let client = BiliAPIClient(
+            transport: transport,
+            timestampProvider: { 1_700_000_000 }
         )
+        let repository = BiliDanmakuRepository(client: client)
 
         let segment = try await repository.segment(index: 1, for: identity)
         let event = try #require(segment.events.first)
@@ -36,18 +41,232 @@ struct BiliDanmakuRepositoryTests {
         #expect(event.weight == 5)
         #expect(event.description == "DanmakuEvent(redacted)")
 
-        let request = try #require(await transport.requests().first)
-        #expect(request.url.path == "/x/v2/dm/web/seg.so")
-        #expect(request.url.query?.contains("type=1") == true)
-        #expect(request.url.query?.contains("oid=700001") == true)
-        #expect(request.url.query?.contains("segment_index=1") == true)
+        let requests = await transport.requests()
+        #expect(
+            requests.map(\.url.path) == [
+                "/x/web-interface/nav",
+                "/x/v2/dm/wbi/web/seg.so",
+            ]
+        )
+        #expect(requests[0].headers["Cookie"] == nil)
+        let request = requests[1]
+        let query = try #require(
+            URLComponents(
+                url: request.url,
+                resolvingAgainstBaseURL: false
+            )?.queryItems
+        )
+        #expect(
+            Set(query.map(\.name)) == [
+                "type", "oid", "segment_index", "wts", "w_rid",
+            ]
+        )
+        #expect(query.first(where: { $0.name == "type" })?.value == "1")
+        #expect(query.first(where: { $0.name == "oid" })?.value == "700001")
+        #expect(query.first(where: { $0.name == "segment_index" })?.value == "1")
+        #expect(query.first(where: { $0.name == "wts" })?.value == "1700000000")
+        #expect(query.first(where: { $0.name == "w_rid" })?.value?.count == 32)
         #expect(request.headers["Accept"] == "application/octet-stream")
         #expect(request.headers["Cookie"] == nil)
     }
 
     @Test
+    func productionAuthorizesOnlyTheWBIRequestWhenCredentialIsAvailable()
+        async throws
+    {
+        let transport = DanmakuRecordingTransport(
+            responses: [
+                try jsonFixtureResponse("nav"),
+                try binaryFixtureResponse("danmaku-segment-minimal"),
+            ]
+        )
+        let authorizer = DanmakuRecordingAuthorizer()
+        let repository = BiliDanmakuRepository(
+            client: BiliAPIClient(
+                transport: transport,
+                requestAuthorizer: authorizer,
+                timestampProvider: { 1_700_000_000 }
+            )
+        )
+
+        let segment = try await repository.segment(index: 1, for: identity)
+
+        #expect(segment.events.count == 1)
+        #expect(await authorizer.capturedPaths() == ["/x/v2/dm/wbi/web/seg.so"])
+        let requests = await transport.requests()
+        #expect(requests[0].headers["Cookie"] == nil)
+        #expect(requests[1].headers["Cookie"] == "FIXTURE_AUTHORIZED")
+    }
+
+    @Test
+    func productionFallsBackToTheSameWBIRequestWhenCredentialIsMissing()
+        async throws
+    {
+        let transport = DanmakuRecordingTransport(
+            responses: [
+                try jsonFixtureResponse("nav"),
+                try binaryFixtureResponse("danmaku-segment-minimal"),
+            ]
+        )
+        let authorizer = DanmakuRecordingAuthorizer(failureKind: .missingCredential)
+        let repository = BiliDanmakuRepository(
+            client: BiliAPIClient(
+                transport: transport,
+                requestAuthorizer: authorizer,
+                timestampProvider: { 1_700_000_000 }
+            )
+        )
+
+        let segment = try await repository.segment(index: 1, for: identity)
+
+        #expect(segment.events.count == 1)
+        #expect(await authorizer.capturedPaths() == ["/x/v2/dm/wbi/web/seg.so"])
+        let requests = await transport.requests()
+        #expect(
+            requests.map(\.url.path) == [
+                "/x/web-interface/nav",
+                "/x/v2/dm/wbi/web/seg.so",
+            ]
+        )
+        #expect(requests.allSatisfy { $0.headers["Cookie"] == nil })
+    }
+
+    @Test
+    func invalidCredentialFailsBeforeTheWBIRequestIsSent() async throws {
+        let transport = DanmakuRecordingTransport(
+            responses: [try jsonFixtureResponse("nav")]
+        )
+        let authorizer = DanmakuRecordingAuthorizer(failureKind: .invalidCredential)
+        let client = BiliAPIClient(
+            transport: transport,
+            requestAuthorizer: authorizer,
+            timestampProvider: { 1_700_000_000 }
+        )
+
+        await #expect(throws: BiliAPIError.authenticationInvalid) {
+            try await client.danmakuSegmentData(index: 1, for: identity)
+        }
+
+        #expect(await transport.requests().map(\.url.path) == ["/x/web-interface/nav"])
+    }
+
+    @Test
+    func cancellationDuringAuthorizationStopsBeforeTheWBIRequestIsSent() async throws {
+        let transport = DanmakuRecordingTransport(
+            responses: [
+                try jsonFixtureResponse("nav"),
+                try binaryFixtureResponse("danmaku-segment-minimal"),
+            ]
+        )
+        let authorizer = DanmakuSuspendingAuthorizer()
+        let client = BiliAPIClient(
+            transport: transport,
+            requestAuthorizer: authorizer,
+            timestampProvider: { 1_700_000_000 }
+        )
+        let task = Task {
+            try await client.danmakuSegmentData(index: 1, for: identity)
+        }
+        await authorizer.waitUntilAuthorizationStarts()
+
+        task.cancel()
+        await authorizer.resumeAuthorization()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(
+            await transport.requests().map(\.url.path) == ["/x/web-interface/nav"]
+        )
+    }
+
+    @Test
+    func remoteAuthenticationInvalidationIsRecognizedBeforeProtobufDecoding()
+        async throws
+    {
+        let repository = BiliDanmakuRepository(
+            client: BiliAPIClient(
+                transport: DanmakuRecordingTransport(
+                    responses: [
+                        try jsonFixtureResponse("nav"),
+                        HTTPResponse(
+                            statusCode: 200,
+                            headers: ["Content-Type": "application/json"],
+                            body: Data(#"{"code":-101,"message":"fixture"}"#.utf8)
+                        ),
+                    ]
+                ),
+                timestampProvider: { 1_700_000_000 }
+            )
+        )
+
+        await #expect(throws: DanmakuApplicationError.authenticationInvalid) {
+            try await repository.segment(index: 1, for: identity)
+        }
+    }
+
+    @Test
+    func wbiRejectionRefreshesTheKeyOnce() async throws {
+        let transport = DanmakuRecordingTransport(
+            responses: [
+                try jsonFixtureResponse("nav"),
+                HTTPResponse(
+                    statusCode: 200,
+                    headers: ["Content-Type": "application/json"],
+                    body: Data(#"{"code":-403,"message":"fixture"}"#.utf8)
+                ),
+                try jsonFixtureResponse("nav-refreshed"),
+                try binaryFixtureResponse("danmaku-segment-minimal"),
+            ]
+        )
+        let repository = BiliDanmakuRepository(
+            client: BiliAPIClient(
+                transport: transport,
+                timestampProvider: { 1_700_000_000 }
+            )
+        )
+
+        let segment = try await repository.segment(index: 1, for: identity)
+
+        #expect(segment.events.count == 1)
+        #expect(
+            await transport.requests().map(\.url.path) == [
+                "/x/web-interface/nav",
+                "/x/v2/dm/wbi/web/seg.so",
+                "/x/web-interface/nav",
+                "/x/v2/dm/wbi/web/seg.so",
+            ]
+        )
+    }
+
+    #if DEBUG
+        @Test
+        func debugPoolProbeSummarizesTheProductionResponse() async throws {
+            let client = BiliAPIClient(
+                transport: DanmakuRecordingTransport(
+                    responses: [
+                        try jsonFixtureResponse("nav"),
+                        try binaryFixtureResponse("danmaku-segment-minimal"),
+                    ]
+                ),
+                timestampProvider: { 1_700_000_000 }
+            )
+
+            let summary = try await client.danmakuPoolProbe(
+                index: 1,
+                for: identity
+            )
+
+            #expect(summary.rawEventCount == 1)
+            #expect(summary.basicEventCount == 1)
+            #expect(summary.rawModeCounts == [1: 1])
+            #expect(summary.bytes > 0)
+        }
+    #endif
+
+    @Test
     func truncatedFixtureFailsClosed() async throws {
-        let repository = repository(
+        let repository = try repository(
             response: try binaryFixtureResponse("danmaku-segment-truncated")
         )
 
@@ -75,7 +294,7 @@ struct BiliDanmakuRepositoryTests {
                 body: Data(" \n<!doctype html><title>blocked</title>".utf8)
             ),
         ] {
-            let repository = repository(response: response)
+            let repository = try repository(response: response)
             await #expect(throws: DanmakuApplicationError.requestRestricted) {
                 try await repository.segment(index: 1, for: identity)
             }
@@ -102,20 +321,21 @@ struct BiliDanmakuRepositoryTests {
         let body = try payload.serializedData()
         #expect(body.starts(with: [0x0A, 0x7B]))
 
-        let segment = try await repository(
+        let repository = try repository(
             response: HTTPResponse(
                 statusCode: 200,
                 headers: ["Content-Type": "application/octet-stream"],
                 body: body
             )
-        ).segment(index: 1, for: identity)
+        )
+        let segment = try await repository.segment(index: 1, for: identity)
 
         #expect(segment.events.count == 1)
         #expect(segment.events.first?.id == "fixture")
     }
 
     @Test
-    func emptyAndOversizedResponsesFailClosed() async {
+    func emptyAndOversizedResponsesFailClosed() async throws {
         let responses = [
             HTTPResponse(
                 statusCode: 200,
@@ -130,7 +350,7 @@ struct BiliDanmakuRepositoryTests {
         ]
 
         for response in responses {
-            let repository = repository(response: response)
+            let repository = try repository(response: response)
             await #expect(throws: DanmakuApplicationError.invalidResponse) {
                 try await repository.segment(index: 1, for: identity)
             }
@@ -222,10 +442,16 @@ struct BiliDanmakuRepositoryTests {
         }
     }
 
-    private func repository(response: HTTPResponse) -> BiliDanmakuRepository {
+    private func repository(response: HTTPResponse) throws -> BiliDanmakuRepository {
         BiliDanmakuRepository(
             client: BiliAPIClient(
-                transport: DanmakuRecordingTransport(responses: [response])
+                transport: DanmakuRecordingTransport(
+                    responses: [
+                        try jsonFixtureResponse("nav"),
+                        response,
+                    ]
+                ),
+                timestampProvider: { 1_700_000_000 }
             )
         )
     }
@@ -252,6 +478,21 @@ struct BiliDanmakuRepositoryTests {
             statusCode: 200,
             headers: ["Content-Type": "application/octet-stream"],
             body: body
+        )
+    }
+
+    private func jsonFixtureResponse(_ name: String) throws -> HTTPResponse {
+        let url = try #require(
+            Bundle.module.url(
+                forResource: name,
+                withExtension: "json",
+                subdirectory: "Fixtures"
+            )
+        )
+        return HTTPResponse(
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"],
+            body: try Data(contentsOf: url)
         )
     }
 }
@@ -282,6 +523,77 @@ private actor DanmakuCancellationTransport: HTTPTransport {
         try await Task.sleep(for: .seconds(30))
         throw DanmakuTestError.missingResponse
     }
+}
+
+private actor DanmakuRecordingAuthorizer: HTTPRequestAuthorizing {
+    private let failureKind: HTTPRequestAuthorizationFailureKind?
+    private var paths: [String] = []
+
+    init(failureKind: HTTPRequestAuthorizationFailureKind? = nil) {
+        self.failureKind = failureKind
+    }
+
+    func authorize(_ request: HTTPRequest) throws -> HTTPRequest {
+        paths.append(request.url.path)
+        if let failureKind {
+            throw DanmakuAuthorizationFailure(
+                authorizationFailureKind: failureKind
+            )
+        }
+        var headers = request.headers
+        headers["Cookie"] = "FIXTURE_AUTHORIZED"
+        return HTTPRequest(
+            url: request.url,
+            method: request.method,
+            headers: headers,
+            body: request.body
+        )
+    }
+
+    func capturedPaths() -> [String] {
+        paths
+    }
+}
+
+private actor DanmakuSuspendingAuthorizer: HTTPRequestAuthorizing {
+    private var authorizationStarted = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var authorizationContinuation: CheckedContinuation<Void, Never>?
+
+    func authorize(_ request: HTTPRequest) async -> HTTPRequest {
+        authorizationStarted = true
+        for waiter in startWaiters {
+            waiter.resume()
+        }
+        startWaiters.removeAll()
+        await withCheckedContinuation { continuation in
+            authorizationContinuation = continuation
+        }
+        var headers = request.headers
+        headers["Cookie"] = "FIXTURE_AUTHORIZED"
+        return HTTPRequest(
+            url: request.url,
+            method: request.method,
+            headers: headers,
+            body: request.body
+        )
+    }
+
+    func waitUntilAuthorizationStarts() async {
+        guard !authorizationStarted else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func resumeAuthorization() {
+        authorizationContinuation?.resume()
+        authorizationContinuation = nil
+    }
+}
+
+private struct DanmakuAuthorizationFailure: HTTPRequestAuthorizationFailure {
+    let authorizationFailureKind: HTTPRequestAuthorizationFailureKind
 }
 
 private enum DanmakuTestError: Error {

--- a/Packages/BiliKitCore/Tests/BiliAuthTests/Credential/BiliCredentialRequestAuthorizerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthTests/Credential/BiliCredentialRequestAuthorizerTests.swift
@@ -45,6 +45,17 @@ struct BiliCredentialRequestAuthorizerTests {
         let authorizedPlayer = try await authorizer.authorize(playerRequest)
         #expect(authorizedPlayer.headers["Cookie"] == credential.cookieHeader)
 
+        let danmakuRequest = HTTPRequest(
+            url: try #require(
+                URL(
+                    string:
+                        "https://api.bilibili.com/x/v2/dm/wbi/web/seg.so?type=1&oid=900001&segment_index=1&wts=1700000000&w_rid=0123456789abcdef0123456789abcdef"
+                )
+            )
+        )
+        let authorizedDanmaku = try await authorizer.authorize(danmakuRequest)
+        #expect(authorizedDanmaku.headers["Cookie"] == credential.cookieHeader)
+
         let playbackRequest = HTTPRequest(
             url: try #require(
                 URL(
@@ -182,6 +193,38 @@ struct BiliCredentialRequestAuthorizerTests {
             ("https://api.bilibili.com/x/web-interface/nav", .post),
             ("https://user@api.bilibili.com/x/web-interface/nav", .get),
             ("https://api.bilibili.com/x/web-interface/nav#fragment", .get),
+            (
+                "https://api.bilibili.com/x/v2/dm/wbi/web/seg.so?type=2&oid=900001&segment_index=1&wts=1700000000&w_rid=0123456789abcdef0123456789abcdef",
+                .get
+            ),
+            (
+                "https://api.bilibili.com/x/v2/dm/wbi/web/seg.so?type=1&oid=0&segment_index=1&wts=1700000000&w_rid=0123456789abcdef0123456789abcdef",
+                .get
+            ),
+            (
+                "https://api.bilibili.com/x/v2/dm/wbi/web/seg.so?type=1&oid=900001&segment_index=0&wts=1700000000&w_rid=0123456789abcdef0123456789abcdef",
+                .get
+            ),
+            (
+                "https://api.bilibili.com/x/v2/dm/wbi/web/seg.so?type=1&oid=900001&segment_index=10001&wts=1700000000&w_rid=0123456789abcdef0123456789abcdef",
+                .get
+            ),
+            (
+                "https://api.bilibili.com/x/v2/dm/wbi/web/seg.so?type=1&oid=900001&segment_index=1&wts=0&w_rid=0123456789abcdef0123456789abcdef",
+                .get
+            ),
+            (
+                "https://api.bilibili.com/x/v2/dm/wbi/web/seg.so?type=1&oid=900001&segment_index=1&wts=1700000000&w_rid=0123456789abcdef0123456789abcdeF",
+                .get
+            ),
+            (
+                "https://api.bilibili.com/x/v2/dm/wbi/web/seg.so?type=1&oid=900001&segment_index=1&wts=1700000000&w_rid=0123456789abcdef0123456789abcdef&extra=1",
+                .get
+            ),
+            (
+                "https://api.bilibili.com/x/v2/dm/wbi/web/seg.so?type=1&oid=900001&oid=900002&segment_index=1&wts=1700000000&w_rid=0123456789abcdef0123456789abcdef",
+                .get
+            ),
         ]
 
         for (urlString, method) in cases {

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/DanmakuControlsViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/DanmakuControlsViewModelTests.swift
@@ -32,6 +32,7 @@ struct DanmakuControlsViewModelTests {
         model.setOpacity(0.4)
         model.setOpacity(0.1)
         model.setOpacity(.nan)
+        presentation.reportAuthenticationInvalidation()
         model.reset()
 
         #expect(presentation.startedIdentities == [identity])
@@ -54,6 +55,7 @@ struct DanmakuControlsViewModelTests {
         #expect(!model.showsBottom)
         #expect(model.speedLevel == .five)
         #expect(model.opacity == DanmakuOpacity(0.4))
+        #expect(model.authenticationRevalidationGeneration == 1)
     }
 }
 
@@ -73,6 +75,17 @@ private final class RecordingDanmakuPresentation:
     private(set) var speedLevels: [DanmakuSpeedLevel] = []
     private(set) var opacities: [DanmakuOpacity] = []
     private(set) var stopCount = 0
+    private var authenticationInvalidationHandler: (@MainActor () -> Void)?
+
+    func setAuthenticationInvalidationHandler(
+        _ handler: @escaping @MainActor () -> Void
+    ) {
+        authenticationInvalidationHandler = handler
+    }
+
+    func reportAuthenticationInvalidation() {
+        authenticationInvalidationHandler?()
+    }
 
     func start(for identity: PlaybackItemIdentity) {
         startedIdentities.append(identity)

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSessionTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSessionTests.swift
@@ -188,6 +188,42 @@ struct DanmakuSessionTests {
     }
 
     @Test
+    func authenticationInvalidationIsReportedOncePerSession() async throws {
+        let identity = PlaybackItemIdentity(
+            bvid: "BV1AuthDanmakuFixture",
+            cid: 40
+        )
+        let repository = AlwaysFailingDanmakuRepository(
+            error: .authenticationInvalid
+        )
+        let timeline = SessionTimeline()
+        let session = DanmakuSession(
+            useCase: DanmakuSegmentUseCase(repository: repository),
+            timeline: timeline
+        )
+        var invalidationCount = 0
+        session.setAuthenticationInvalidationHandler {
+            invalidationCount += 1
+        }
+
+        session.start(for: identity)
+        timeline.publish(snapshot(identity: identity, position: 0, generation: 1))
+        try await repository.waitForRequestCount(2, identity: identity)
+        await session.waitForLoads()
+
+        #expect(invalidationCount == 1)
+        #expect(session.state == .failed(identity, .authenticationInvalid))
+
+        session.stop()
+        session.start(for: identity)
+        timeline.publish(snapshot(identity: identity, position: 0, generation: 2))
+        try await repository.waitForRequestCount(4, identity: identity)
+        await session.waitForLoads()
+
+        #expect(invalidationCount == 2)
+    }
+
+    @Test
     func failedSegmentMemoryIsClearedForReplacementAndStop() async throws {
         let first = PlaybackItemIdentity(
             bvid: "BV1FirstFailureFixture",
@@ -407,8 +443,13 @@ private struct ImmediateDanmakuRepository: DanmakuSegmentRepository {
 }
 
 private actor AlwaysFailingDanmakuRepository: DanmakuSegmentRepository {
+    private let error: DanmakuApplicationError
     private var counts: [PlaybackItemIdentity: Int] = [:]
     private var events: [PlaybackItemIdentity: TestEventCounter] = [:]
+
+    init(error: DanmakuApplicationError = .unavailable) {
+        self.error = error
+    }
 
     func segment(
         index _: Int,
@@ -416,7 +457,7 @@ private actor AlwaysFailingDanmakuRepository: DanmakuSegmentRepository {
     ) async throws -> DanmakuSegment {
         counts[identity, default: 0] += 1
         await event(for: identity).signal()
-        throw DanmakuApplicationError.unavailable
+        throw error
     }
 
     func requestCount(for identity: PlaybackItemIdentity) -> Int {

--- a/Scripts/run-danmaku-pool-spike.sh
+++ b/Scripts/run-danmaku-pool-spike.sh
@@ -1,0 +1,129 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+script_directory=${0:A:h}
+repository_root=${script_directory:h}
+probe_directory=""
+xctestrun_file=""
+environment_path=":TestConfigurations:0:TestTargets:0:EnvironmentVariables"
+
+cleanup() {
+    if [[ -n "$xctestrun_file" && -f "$xctestrun_file" ]]; then
+        /usr/libexec/PlistBuddy \
+            -c "Delete ${environment_path}:BILIKIT_LOCAL_PROBE_INPUT_FILE" \
+            "$xctestrun_file" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "$probe_directory"
+        && "$probe_directory" == /tmp/BiliKitMac-danmaku-pool-spike.*
+        && -d "$probe_directory" ]]; then
+        rm -rf -- "$probe_directory"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+print -n -u2 -- '请输入用于弹幕池对照的 BVID：'
+if [[ -t 0 ]]; then
+    stty -echo
+    trap 'stty echo; cleanup' EXIT INT TERM
+fi
+IFS= read -r probe_bvid
+if [[ -t 0 ]]; then
+    stty echo
+    trap cleanup EXIT INT TERM
+fi
+print -u2
+if [[ "$probe_bvid" != BV?????????? || "$probe_bvid" == *[^A-Za-z0-9]* ]]; then
+    print -u2 'BVID 格式无效。'
+    exit 2
+fi
+
+probe_directory=$(mktemp -d /tmp/BiliKitMac-danmaku-pool-spike.XXXXXX)
+chmod 700 "$probe_directory"
+input_file="$probe_directory/input.plist"
+derived_data="$probe_directory/DerivedData"
+test_log="$probe_directory/raw-test.log"
+result_bundle="$probe_directory/DanmakuPool.xcresult"
+/usr/bin/plutil -create xml1 "$input_file"
+/usr/bin/plutil -insert bvid -string "$probe_bvid" "$input_file"
+chmod 600 "$input_file"
+
+cd "$repository_root"
+print '正在构建签名测试宿主……'
+if ! DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+    /usr/bin/perl -e '$seconds = shift @ARGV; alarm $seconds; exec @ARGV' 240 \
+    xcodebuild \
+    -project BiliKitMac.xcodeproj \
+    -scheme BiliKitMac \
+    -configuration Debug \
+    -destination 'platform=macOS,arch=arm64' \
+    -derivedDataPath "$derived_data" \
+    build-for-testing > "$test_log" 2>&1; then
+    print -u2 '签名测试宿主构建失败或超时；原始输出已清理。'
+    exit 1
+fi
+
+xctestrun_files=("$derived_data"/Build/Products/*.xctestrun(N))
+if [[ ${#xctestrun_files} -ne 1 ]]; then
+    print -u2 '没有找到唯一的 xctestrun 文件，无法安全注入临时探针参数。'
+    exit 1
+fi
+xctestrun_file=${xctestrun_files[1]}
+/usr/libexec/PlistBuddy \
+    -c "Add ${environment_path}:BILIKIT_LOCAL_PROBE_INPUT_FILE string $input_file" \
+    "$xctestrun_file"
+
+print '正在对比同一生产 WBI 接口的匿名与登录态弹幕池……'
+set +e
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+    /usr/bin/perl -e '$seconds = shift @ARGV; alarm $seconds; exec @ARGV' 150 \
+    xcodebuild \
+    -xctestrun "$xctestrun_file" \
+    -destination 'platform=macOS,arch=arm64' \
+    -resultBundlePath "$result_bundle" \
+    -test-timeouts-enabled YES \
+    -default-test-execution-time-allowance 60 \
+    -maximum-test-execution-time-allowance 90 \
+    test-without-building \
+    -only-testing:BiliKitMacTests/DanmakuPoolProbeTests/testPoolVariantsWhenExplicitlyConfigured \
+    >> "$test_log" 2>&1
+probe_status=$?
+set -e
+
+if [[ -d "$result_bundle" ]]; then
+    DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+        xcrun xcresulttool get test-results activities \
+        --path "$result_bundle" \
+        --test-id 'DanmakuPoolProbeTests/testPoolVariantsWhenExplicitlyConfigured()' \
+        >> "$test_log" 2>&1 || true
+fi
+
+if rg -q \
+    '(SESSDATA=[A-Za-z0-9%_-]{20,}|bili_jct=[A-Fa-f0-9]{32}|refresh_token.{0,16}[=:][^[:space:]]*[A-Za-z0-9_-]{20,})' \
+    "$test_log"; then
+    print -u2 'classification=secret-scan-failed'
+    print -u2 '探针输出出现疑似秘密；已停止且原始输出将清理。'
+    exit 1
+fi
+if rg -F -q -- "$probe_bvid" "$test_log"; then
+    print -u2 'classification=identity-scan-failed'
+    print -u2 '探针输出出现输入 identity；已停止且原始输出将清理。'
+    exit 1
+fi
+unset probe_bvid
+
+summary=$(rg -m 1 -o \
+    'danmaku-pool-spike wbi-anonymous=[A-Za-z0-9._-]+ wbi-authenticated=[A-Za-z0-9._-]+' \
+    "$test_log" || true)
+if [[ $probe_status -ne 0 || -z "$summary" ]]; then
+    stage_summary=$(rg -o \
+        'danmaku-pool-stage stage=[a-z-]+' \
+        "$test_log" | tail -n 1 || true)
+    [[ -z "$stage_summary" ]] || print -u2 -r -- "$stage_summary"
+    [[ $probe_status -ne 142 ]] || print -u2 'classification=timeout.inconclusive'
+    print -u2 '弹幕池探针失败；未重试，原始输出将清理。'
+    exit 1
+fi
+
+print -r -- "$summary"
+print '探针完成；BVID/CID、账号身份、URL、Cookie、弹幕正文与原始产物均未保留。'

--- a/docs/security/M4-data-privacy.md
+++ b/docs/security/M4-data-privacy.md
@@ -41,6 +41,7 @@ Cookie、token、二维码 key 和 refresh token 继续只由 `BiliAuth` 管理�
 
 - 字幕目录和弹幕接口只能使用精确 HTTPS host/path/method/query allowlist；需要登录时由 `BiliAuth` 的授权器添加 Cookie，Feature 不接触凭据。
 - 当前字幕目录只允许 `GET https://api.bilibili.com/x/player/wbi/v2`。query 必须且只能包含合法 BVID、正 CID、正整数 `wts` 和 32 位小写十六进制 `w_rid`；其他 host/path/method/query、重复参数和额外参数全部拒绝。WBI key 仍通过无认证 `/x/web-interface/nav` 获取，只有签名后的字幕目录请求可由授权器附加 Cookie。
+- 当前弹幕分段统一使用 `GET https://api.bilibili.com/x/v2/dm/wbi/web/seg.so`。query 必须且只能包含固定 `type=1`、正 CID、`1...10000` 的 segment index、正整数 `wts` 和 32 位小写十六进制 `w_rid`。WBI key 仍匿名取得；本地存在有效凭据时仅该精确请求可附加 Cookie，明确没有凭据时仍请求同一 WBI endpoint，凭据损坏、不可用或拒绝时不得匿名降级。
 - 字幕正文 URL 必须单独验证 scheme、userinfo、端口、允许的主机和每次重定向；不得复用媒体 CDN 或游客图片的宽泛策略。M4.0 现场证据当前只确认 `aisubtitle.hdslb.com`，新增主机必须先失败关闭并取得同等级脱敏证据。
 - 目录、正文、弹幕元数据和分段分别设置 Content-Type 与大小上限。JSON、protobuf、HTML 错误页和空响应不能互相降级解析。
 - 取消、超时和换集必须终止网络与解码 Task；未知接口状态默认失败关闭。


### PR DESCRIPTION
## 变化

- 将生产弹幕分段统一迁移到 WBI segment endpoint，游客与登录态使用同一请求族。
- 为该 endpoint 增加精确认证 allowlist；仅缺少凭据时在同一 endpoint 匿名发送，其余认证错误 fail closed。
- 保留 WBI key 的有界刷新、取消与 session epoch 隔离，并把远端认证失效传回 App 触发既有会话复核。
- 让生产、Package probe 与显式签名 pool probe 共用同一实现，不保存 Cookie、完整 URL 或远端正文。
- 补齐二进制响应、状态码、错误 Content-Type、认证与取消路径测试。

## 原因

旧匿名 segment endpoint 与登录态 WBI endpoint 并存容易发生协议和失败语义漂移，也无法稳定取得高弹幕量视频的完整候选池。本 PR 先统一数据入口与安全边界，不包含显示区域或密度 UI。

## 用户影响

游客和登录用户采用一致的弹幕获取协议；高弹幕量视频能够取得更完整的候选池。认证无效时会复用现有登录态复核流程，不会静默携带错误凭据继续请求。

## 验证

- Xcode 26.6 / macOS，fresh 隔离缓存。
- 静态架构、秘密扫描和 Swift format 通过。
- Swift Package：359 tests / 45 suites 通过。
- App build-for-testing 通过。
- App 全并发单测中仅 `VideoDetailLifecycleTests.replacementKeepsPlayerSurfaceUntilReset` 在 1 秒等待边界失败；使用全新 DerivedData 单独重跑通过。PR 保持 draft，未将放宽该无关测试超时混入本 PR。
- 重排前相同 WBI 生产 patch 已通过签名匿名/登录 probe，并由真实 App 播放确认。

## 未覆盖边界

- 本 PR 不包含弹幕显示区域、密度或重叠策略；这些将在后续 stacked PR 中独立审查。
- 显式签名 probe 需要本机 Keychain 与人工提供公开 BVID，普通门禁默认跳过。