### PR TITLE
feat(danmaku): 支持显示区域与密度调节

### DIFF
--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -100,11 +100,19 @@ struct AppEnvironment {
             presentation: danmakuSession,
             initialSpeedLevel: preferences.speedLevel,
             initialOpacity: preferences.opacity,
+            initialDisplayArea: preferences.displayArea,
+            initialDensity: preferences.density,
             saveSpeedLevel: { [danmakuPreferencesStore] speedLevel in
                 danmakuPreferencesStore.saveSpeedLevel(speedLevel)
             },
             saveOpacity: { [danmakuPreferencesStore] opacity in
                 danmakuPreferencesStore.saveOpacity(opacity)
+            },
+            saveDisplayArea: { [danmakuPreferencesStore] displayArea in
+                danmakuPreferencesStore.saveDisplayArea(displayArea)
+            },
+            saveDensity: { [danmakuPreferencesStore] density in
+                danmakuPreferencesStore.saveDensity(density)
             }
         )
     }
@@ -194,7 +202,7 @@ struct AppEnvironment {
         surfaceWidth: 0,
         surfaceHeight: 0,
         laneHeight: 36,
-        minimumHorizontalGap: 12,
+        minimumHorizontalGap: 24,
         maximumActiveCount:
             DanmakuLaneConfiguration.hardMaximumActiveCount,
         displayAreaFraction: 1

--- a/BiliKitMac/Composition/UITestContentView.swift
+++ b/BiliKitMac/Composition/UITestContentView.swift
@@ -329,6 +329,8 @@
         func setEnabled(_ enabled: Bool) {}
         func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {}
         func setOpacity(_ opacity: DanmakuOpacity) {}
+        func setDisplayArea(_ displayArea: DanmakuDisplayArea) {}
+        func setDensity(_ density: DanmakuDensity) {}
 
         func setModeVisibility(
             scrolling: Bool,

--- a/BiliKitMac/Platform/DanmakuOverlayHostView.swift
+++ b/BiliKitMac/Platform/DanmakuOverlayHostView.swift
@@ -54,15 +54,8 @@ final class DanmakuOverlayView: NSView {
         let width = max(Double(bounds.width), 0)
         let height = max(Double(bounds.height), 0)
         controller.updateSurface(
-            DanmakuLaneConfiguration(
-                surfaceWidth: width,
-                surfaceHeight: height,
-                laneHeight: 36,
-                minimumHorizontalGap: 12,
-                maximumActiveCount:
-                    DanmakuLaneConfiguration.hardMaximumActiveCount,
-                displayAreaFraction: 1
-            ),
+            width: width,
+            height: height,
             ownerID: ownerID
         )
     }

--- a/BiliKitMac/Platform/PlaybackPreferencesController.swift
+++ b/BiliKitMac/Platform/PlaybackPreferencesController.swift
@@ -87,17 +87,23 @@ final class UserDefaultsPlaybackPreferencesStore:
 struct DanmakuPreferences: Equatable, Sendable {
     static let defaults = DanmakuPreferences(
         speedLevel: .three,
-        opacity: .fullyOpaque
+        opacity: .fullyOpaque,
+        displayArea: .full,
+        density: .normal
     )
 
     let speedLevel: DanmakuSpeedLevel
     let opacity: DanmakuOpacity
+    let displayArea: DanmakuDisplayArea
+    let density: DanmakuDensity
 }
 
 protocol DanmakuPreferencesStoring: AnyObject, Sendable {
     func load() -> DanmakuPreferences
     func saveSpeedLevel(_ speedLevel: DanmakuSpeedLevel)
     func saveOpacity(_ opacity: DanmakuOpacity)
+    func saveDisplayArea(_ displayArea: DanmakuDisplayArea)
+    func saveDensity(_ density: DanmakuDensity)
 }
 
 /// 只保存设备级弹幕显示意图，不保存视频 identity、正文或播放位置。
@@ -107,6 +113,8 @@ final class UserDefaultsDanmakuPreferencesStore:
     private enum Key {
         static let speedLevel = "danmaku.speedLevel"
         static let opacity = "danmaku.opacity"
+        static let displayArea = "danmaku.displayArea"
+        static let density = "danmaku.density"
     }
 
     private let defaults: UserDefaults
@@ -118,7 +126,9 @@ final class UserDefaultsDanmakuPreferencesStore:
     func load() -> DanmakuPreferences {
         DanmakuPreferences(
             speedLevel: loadSpeedLevel(),
-            opacity: loadOpacity()
+            opacity: loadOpacity(),
+            displayArea: loadDisplayArea(),
+            density: loadDensity()
         )
     }
 
@@ -128,6 +138,14 @@ final class UserDefaultsDanmakuPreferencesStore:
 
     func saveOpacity(_ opacity: DanmakuOpacity) {
         defaults.set(opacity.value, forKey: Key.opacity)
+    }
+
+    func saveDisplayArea(_ displayArea: DanmakuDisplayArea) {
+        defaults.set(displayArea.rawValue, forKey: Key.displayArea)
+    }
+
+    func saveDensity(_ density: DanmakuDensity) {
+        defaults.set(density.rawValue, forKey: Key.density)
     }
 
     private func loadSpeedLevel() -> DanmakuSpeedLevel {
@@ -153,6 +171,34 @@ final class UserDefaultsDanmakuPreferencesStore:
             return DanmakuPreferences.defaults.opacity
         }
         return opacity
+    }
+
+    private func loadDisplayArea() -> DanmakuDisplayArea {
+        guard let rawValue = integer(forKey: Key.displayArea),
+            let displayArea = DanmakuDisplayArea(rawValue: rawValue)
+        else {
+            return DanmakuPreferences.defaults.displayArea
+        }
+        return displayArea
+    }
+
+    private func loadDensity() -> DanmakuDensity {
+        guard let rawValue = integer(forKey: Key.density),
+            let density = DanmakuDensity(rawValue: rawValue)
+        else {
+            return DanmakuPreferences.defaults.density
+        }
+        return density
+    }
+
+    private func integer(forKey key: String) -> Int? {
+        guard let number = defaults.object(forKey: key) as? NSNumber,
+            CFGetTypeID(number) != CFBooleanGetTypeID()
+        else {
+            return nil
+        }
+        let value = number.intValue
+        return number.doubleValue == Double(value) ? value : nil
     }
 }
 

--- a/BiliKitMacTests/PlaybackPreferencesControllerTests.swift
+++ b/BiliKitMacTests/PlaybackPreferencesControllerTests.swift
@@ -73,11 +73,15 @@ struct PlaybackPreferencesControllerTests {
             store.saveSpeedLevel(.five)
             let opacity = try #require(DanmakuOpacity(0.55))
             store.saveOpacity(opacity)
+            store.saveDisplayArea(.threeQuarters)
+            store.saveDensity(.overlapping)
             #expect(
                 store.load()
                     == DanmakuPreferences(
                         speedLevel: .five,
-                        opacity: opacity
+                        opacity: opacity,
+                        displayArea: .threeQuarters,
+                        density: .overlapping
                     )
             )
 
@@ -95,6 +99,20 @@ struct PlaybackPreferencesControllerTests {
             }
             defaults.set(true, forKey: "danmaku.opacity")
             #expect(store.load().opacity == .fullyOpaque)
+
+            for invalidDisplayArea in [0, 50.5, 101] {
+                defaults.set(invalidDisplayArea, forKey: "danmaku.displayArea")
+                #expect(store.load().displayArea == .full)
+            }
+            defaults.set(true, forKey: "danmaku.displayArea")
+            #expect(store.load().displayArea == .full)
+
+            for invalidDensity in [-1, 1.5, 3] {
+                defaults.set(invalidDensity, forKey: "danmaku.density")
+                #expect(store.load().density == .normal)
+            }
+            defaults.set(true, forKey: "danmaku.density")
+            #expect(store.load().density == .normal)
         }
     }
 

--- a/BiliKitMacTests/VideoDetailLifecycleTests.swift
+++ b/BiliKitMacTests/VideoDetailLifecycleTests.swift
@@ -1209,6 +1209,8 @@ private final class RecordingPresentation: DanmakuPresentationControlling {
     func setEnabled(_ enabled: Bool) {}
     func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel) {}
     func setOpacity(_ opacity: DanmakuOpacity) {}
+    func setDisplayArea(_ displayArea: DanmakuDisplayArea) {}
+    func setDensity(_ density: DanmakuDensity) {}
 
     func setModeVisibility(
         scrolling: Bool,

--- a/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuPresentationControlling.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Danmaku/DanmakuPresentationControlling.swift
@@ -6,6 +6,24 @@ public enum DanmakuSpeedLevel: Int, CaseIterable, Sendable, Equatable {
     case five
 }
 
+public enum DanmakuDisplayArea: Int, CaseIterable, Sendable, Equatable {
+    case ten = 10
+    case quarter = 25
+    case half = 50
+    case threeQuarters = 75
+    case full = 100
+
+    public var fraction: Double {
+        Double(rawValue) / 100
+    }
+}
+
+public enum DanmakuDensity: Int, CaseIterable, Sendable, Equatable {
+    case normal
+    case increased
+    case overlapping
+}
+
 public struct DanmakuOpacity: Sendable, Equatable {
     public static let allowedRange = 0.2...1.0
     public static let fullyOpaque = DanmakuOpacity(validatedValue: 1)
@@ -39,6 +57,8 @@ public protocol DanmakuPresentationControlling: AnyObject {
     )
     func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel)
     func setOpacity(_ opacity: DanmakuOpacity)
+    func setDisplayArea(_ displayArea: DanmakuDisplayArea)
+    func setDensity(_ density: DanmakuDensity)
     func stop()
 }
 

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsView.swift
@@ -55,6 +55,10 @@ private struct DanmakuSettingsPopover: View {
 
             Divider()
 
+            densitySettings
+
+            Divider()
+
             speedSettings
 
             Divider()
@@ -62,9 +66,89 @@ private struct DanmakuSettingsPopover: View {
             opacitySettings
         }
         .padding(16)
-        .frame(width: 340)
+        .frame(width: 360)
         .font(.body)
         .accessibilityIdentifier("danmaku.settings.popover")
+    }
+
+    private var densitySettings: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("显示区域")
+                        .font(.subheadline.weight(.semibold))
+
+                    Spacer()
+
+                    Text(model.displayArea.displayName)
+                        .font(.subheadline.weight(.semibold))
+                        .monospacedDigit()
+                }
+
+                Slider(
+                    value: Binding(
+                        get: {
+                            Double(
+                                DanmakuDisplayArea.allCases.firstIndex(
+                                    of: model.displayArea
+                                ) ?? 0
+                            )
+                        },
+                        set: { value in
+                            let index = Int(value.rounded())
+                            guard DanmakuDisplayArea.allCases.indices.contains(index) else {
+                                return
+                            }
+                            model.setDisplayArea(
+                                DanmakuDisplayArea.allCases[index]
+                            )
+                        }
+                    ),
+                    in: 0...Double(DanmakuDisplayArea.allCases.count - 1),
+                    step: 1
+                ) {
+                    Text("显示区域")
+                }
+                .labelsHidden()
+                .accessibilityValue(Text(model.displayArea.displayName))
+                .accessibilityIdentifier("danmaku.display-area")
+
+                SliderScaleLabels(
+                    labels: DanmakuDisplayArea.allCases.map(\.displayName),
+                    selectedIndex: DanmakuDisplayArea.allCases.firstIndex(
+                        of: model.displayArea
+                    )
+                )
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("同屏密度")
+                    .font(.subheadline.weight(.semibold))
+
+                Picker(
+                    "同屏密度",
+                    selection: Binding(
+                        get: { model.density },
+                        set: { model.setDensity($0) }
+                    )
+                ) {
+                    ForEach(DanmakuDensity.allCases, id: \.rawValue) { density in
+                        Text(density.displayName).tag(density)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .disabled(!model.canAdjustDensity)
+                .accessibilityValue(Text(model.density.displayName))
+                .accessibilityIdentifier("danmaku.density")
+
+                if !model.canAdjustDensity {
+                    Text("同屏密度仅在显示区域为 100% 时生效")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
     }
 
     private var modeSettings: some View {
@@ -149,21 +233,12 @@ private struct DanmakuSettingsPopover: View {
             .disabled(!model.showsScrolling)
             .accessibilityIdentifier("danmaku.speed")
 
-            HStack(spacing: 0) {
-                ForEach(DanmakuSpeedLevel.allCases, id: \.rawValue) { level in
-                    Text(level.displayName)
-                        .font(.caption2)
-                        .fontWeight(
-                            level == model.speedLevel ? .semibold : .regular
-                        )
-                        .foregroundStyle(
-                            level == model.speedLevel
-                                ? Color.primary
-                                : Color.secondary
-                        )
-                        .frame(maxWidth: .infinity)
-                }
-            }
+            SliderScaleLabels(
+                labels: DanmakuSpeedLevel.allCases.map(\.displayName),
+                selectedIndex: DanmakuSpeedLevel.allCases.firstIndex(
+                    of: model.speedLevel
+                )
+            )
         }
     }
 
@@ -202,21 +277,16 @@ private struct DanmakuSettingsPopover: View {
             )
             .accessibilityIdentifier("danmaku.opacity")
 
-            HStack {
-                Text(
-                    DanmakuOpacity.allowedRange.lowerBound,
-                    format: .percent.precision(.fractionLength(0))
-                )
-
-                Spacer()
-
-                Text(
-                    DanmakuOpacity.allowedRange.upperBound,
-                    format: .percent.precision(.fractionLength(0))
-                )
-            }
-            .font(.caption2)
-            .foregroundStyle(.secondary)
+            SliderScaleLabels(
+                labels: [
+                    DanmakuOpacity.allowedRange.lowerBound.formatted(
+                        .percent.precision(.fractionLength(0))
+                    ),
+                    DanmakuOpacity.allowedRange.upperBound.formatted(
+                        .percent.precision(.fractionLength(0))
+                    ),
+                ]
+            )
         }
     }
 
@@ -249,6 +319,53 @@ private struct DanmakuSettingsPopover: View {
     }
 }
 
+private struct SliderScaleLabels: View {
+    private let trackInset: CGFloat = 8
+
+    let labels: [String]
+    var selectedIndex: Int?
+
+    init(labels: [String], selectedIndex: Int? = nil) {
+        self.labels = labels
+        self.selectedIndex = selectedIndex
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            let trackWidth = max(geometry.size.width - trackInset * 2, 0)
+
+            ZStack(alignment: .topLeading) {
+                ForEach(labels.indices, id: \.self) { index in
+                    Text(labels[index])
+                        .font(.caption2)
+                        .fontWeight(
+                            index == selectedIndex ? .semibold : .regular
+                        )
+                        .foregroundStyle(
+                            index == selectedIndex
+                                ? Color.primary
+                                : Color.secondary
+                        )
+                        .fixedSize()
+                        .position(
+                            x: trackInset + trackWidth * progress(at: index),
+                            y: geometry.size.height / 2
+                        )
+                }
+            }
+        }
+        .frame(height: 13)
+        .accessibilityHidden(true)
+    }
+
+    private func progress(at index: Int) -> CGFloat {
+        guard labels.count > 1 else {
+            return 0.5
+        }
+        return CGFloat(index) / CGFloat(labels.count - 1)
+    }
+}
+
 extension DanmakuSpeedLevel {
     fileprivate var displayName: String {
         switch self {
@@ -262,6 +379,25 @@ extension DanmakuSpeedLevel {
             "较快"
         case .five:
             "极快"
+        }
+    }
+}
+
+extension DanmakuDisplayArea {
+    fileprivate var displayName: String {
+        "\(rawValue)%"
+    }
+}
+
+extension DanmakuDensity {
+    fileprivate var displayName: String {
+        switch self {
+        case .normal:
+            "正常"
+        case .increased:
+            "较多"
+        case .overlapping:
+            "重叠"
         }
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsViewModel.swift
@@ -13,7 +13,13 @@ public final class DanmakuControlsViewModel {
     public private(set) var showsBottom = true
     public private(set) var speedLevel: DanmakuSpeedLevel
     public private(set) var opacity: DanmakuOpacity
+    public private(set) var displayArea: DanmakuDisplayArea
+    public private(set) var density: DanmakuDensity
     public private(set) var authenticationRevalidationGeneration = 0
+
+    public var canAdjustDensity: Bool {
+        displayArea == .full
+    }
 
     @ObservationIgnored
     private let presentation: any DanmakuPresentationControlling
@@ -21,21 +27,35 @@ public final class DanmakuControlsViewModel {
     private let saveSpeedLevel: @MainActor (DanmakuSpeedLevel) -> Void
     @ObservationIgnored
     private let saveOpacity: @MainActor (DanmakuOpacity) -> Void
+    @ObservationIgnored
+    private let saveDisplayArea: @MainActor (DanmakuDisplayArea) -> Void
+    @ObservationIgnored
+    private let saveDensity: @MainActor (DanmakuDensity) -> Void
 
     public init(
         presentation: any DanmakuPresentationControlling,
         initialSpeedLevel: DanmakuSpeedLevel = .three,
         initialOpacity: DanmakuOpacity = .fullyOpaque,
+        initialDisplayArea: DanmakuDisplayArea = .full,
+        initialDensity: DanmakuDensity = .normal,
         saveSpeedLevel: @escaping @MainActor (DanmakuSpeedLevel) -> Void = { _ in },
-        saveOpacity: @escaping @MainActor (DanmakuOpacity) -> Void = { _ in }
+        saveOpacity: @escaping @MainActor (DanmakuOpacity) -> Void = { _ in },
+        saveDisplayArea: @escaping @MainActor (DanmakuDisplayArea) -> Void = { _ in },
+        saveDensity: @escaping @MainActor (DanmakuDensity) -> Void = { _ in }
     ) {
         self.presentation = presentation
         self.speedLevel = initialSpeedLevel
         self.opacity = initialOpacity
+        self.displayArea = initialDisplayArea
+        self.density = initialDensity
         self.saveSpeedLevel = saveSpeedLevel
         self.saveOpacity = saveOpacity
+        self.saveDisplayArea = saveDisplayArea
+        self.saveDensity = saveDensity
         presentation.setSpeedLevel(initialSpeedLevel)
         presentation.setOpacity(initialOpacity)
+        presentation.setDisplayArea(initialDisplayArea)
+        presentation.setDensity(initialDensity)
         presentation.setAuthenticationInvalidationHandler { [weak self] in
             self?.authenticationRevalidationGeneration &+= 1
         }
@@ -87,6 +107,20 @@ public final class DanmakuControlsViewModel {
         self.opacity = opacity
         presentation.setOpacity(opacity)
         saveOpacity(opacity)
+    }
+
+    public func setDisplayArea(_ displayArea: DanmakuDisplayArea) {
+        guard self.displayArea != displayArea else { return }
+        self.displayArea = displayArea
+        presentation.setDisplayArea(displayArea)
+        saveDisplayArea(displayArea)
+    }
+
+    public func setDensity(_ density: DanmakuDensity) {
+        guard canAdjustDensity, self.density != density else { return }
+        self.density = density
+        presentation.setDensity(density)
+        saveDensity(density)
     }
 
     private func applyModeVisibility() {

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneAllocator.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneAllocator.swift
@@ -14,10 +14,16 @@ public struct DanmakuLaneAllocator: Sendable {
         let index: Int
     }
 
+    private struct LaneSlotKey: Hashable, Sendable {
+        let lane: LaneKey
+        let overlapDepth: Int
+    }
+
     private var configuration: DanmakuLaneConfiguration
     private var active: [String: ActivePlacement] = [:]
-    private var fixedLaneOccupants: [LaneKey: ActivePlacement] = [:]
-    private var scrollingLaneTails: [Int: ActivePlacement] = [:]
+    private var fixedLaneOccupants: [LaneSlotKey: ActivePlacement] = [:]
+    private var scrollingLaneTails: [LaneSlotKey: ActivePlacement] = [:]
+    private var activeLaneCounts: [LaneKey: Int] = [:]
     public private(set) var peakActiveCount = 0
 
     public init(configuration: DanmakuLaneConfiguration) {
@@ -38,6 +44,7 @@ public struct DanmakuLaneAllocator: Sendable {
         active.removeAll(keepingCapacity: false)
         fixedLaneOccupants.removeAll(keepingCapacity: false)
         scrollingLaneTails.removeAll(keepingCapacity: false)
+        activeLaneCounts.removeAll(keepingCapacity: false)
         return drained
     }
 
@@ -49,21 +56,31 @@ public struct DanmakuLaneAllocator: Sendable {
             return nil
         }
         let placement = removed.placement
+        let laneKey = LaneKey(
+            mode: placement.request.event.mode,
+            index: placement.laneIndex
+        )
+        let slotKey = LaneSlotKey(
+            lane: laneKey,
+            overlapDepth: placement.overlapDepth
+        )
         switch placement.request.event.mode {
         case .scrolling:
-            if scrollingLaneTails[placement.laneIndex]?
+            if scrollingLaneTails[slotKey]?
                 .placement.request.event.id == eventID
             {
-                scrollingLaneTails[placement.laneIndex] = nil
+                scrollingLaneTails[slotKey] = nil
             }
         case .top, .bottom:
-            let key = LaneKey(
-                mode: placement.request.event.mode,
-                index: placement.laneIndex
-            )
-            if fixedLaneOccupants[key]?.placement.request.event.id == eventID {
-                fixedLaneOccupants[key] = nil
+            if fixedLaneOccupants[slotKey]?.placement.request.event.id == eventID {
+                fixedLaneOccupants[slotKey] = nil
             }
+        }
+        let remainingCount = (activeLaneCounts[laneKey] ?? 1) - 1
+        if remainingCount > 0 {
+            activeLaneCounts[laneKey] = remainingCount
+        } else {
+            activeLaneCounts[laneKey] = nil
         }
         return placement
     }
@@ -130,37 +147,81 @@ public struct DanmakuLaneAllocator: Sendable {
         guard laneCount > 0 else {
             return .failure(.noLane)
         }
-        for laneIndex in 0..<laneCount
-        where laneIsAvailable(
-            laneIndex,
-            for: request,
-            at: playbackTime
-        ) {
-            let placement = DanmakuLanePlacement(
-                request: request,
-                laneIndex: laneIndex,
-                originY: originY(
-                    for: request.event.mode,
-                    laneIndex: laneIndex
-                ),
-                surfaceWidthAtAdmission: configuration.surfaceWidth,
-                admittedAtSeconds: playbackTime,
-                expiresAtSeconds: playbackTime + request.durationSeconds
+        if let safeLane = (0..<laneCount).first(where: {
+            laneIsSafeWithoutOverlap(
+                $0,
+                for: request,
+                at: playbackTime
             )
-            let activePlacement = ActivePlacement(placement: placement)
-            active[request.event.id] = activePlacement
-            switch request.event.mode {
-            case .scrolling:
-                scrollingLaneTails[laneIndex] = activePlacement
-            case .top, .bottom:
-                fixedLaneOccupants[
-                    LaneKey(mode: request.event.mode, index: laneIndex)
-                ] = activePlacement
+        }) {
+            return .success(
+                place(
+                    request,
+                    laneIndex: safeLane,
+                    overlapDepth: 0,
+                    at: playbackTime
+                )
+            )
+        }
+        guard configuration.maximumOverlapDepth > 1 else {
+            return .failure(.noLane)
+        }
+        for overlapDepth in 0..<configuration.maximumOverlapDepth {
+            if let availableLane = (0..<laneCount).first(where: {
+                laneIsAvailable(
+                    $0,
+                    overlapDepth: overlapDepth,
+                    for: request,
+                    at: playbackTime
+                )
+            }) {
+                return .success(
+                    place(
+                        request,
+                        laneIndex: availableLane,
+                        overlapDepth: overlapDepth,
+                        at: playbackTime
+                    )
+                )
             }
-            peakActiveCount = max(peakActiveCount, active.count)
-            return .success(placement)
         }
         return .failure(.noLane)
+    }
+
+    private mutating func place(
+        _ request: DanmakuLaneRequest,
+        laneIndex: Int,
+        overlapDepth: Int,
+        at playbackTime: Double
+    ) -> DanmakuLanePlacement {
+        let placement = DanmakuLanePlacement(
+            request: request,
+            laneIndex: laneIndex,
+            originY: originY(
+                for: request.event.mode,
+                laneIndex: laneIndex
+            ),
+            surfaceWidthAtAdmission: configuration.surfaceWidth,
+            admittedAtSeconds: playbackTime,
+            expiresAtSeconds: playbackTime + request.durationSeconds,
+            overlapDepth: overlapDepth
+        )
+        let activePlacement = ActivePlacement(placement: placement)
+        let laneKey = LaneKey(mode: request.event.mode, index: laneIndex)
+        let slotKey = LaneSlotKey(
+            lane: laneKey,
+            overlapDepth: overlapDepth
+        )
+        active[request.event.id] = activePlacement
+        activeLaneCounts[laneKey, default: 0] += 1
+        switch request.event.mode {
+        case .scrolling:
+            scrollingLaneTails[slotKey] = activePlacement
+        case .top, .bottom:
+            fixedLaneOccupants[slotKey] = activePlacement
+        }
+        peakActiveCount = max(peakActiveCount, active.count)
+        return placement
     }
 
     private func originY(
@@ -178,16 +239,19 @@ public struct DanmakuLaneAllocator: Sendable {
 
     private func laneIsAvailable(
         _ laneIndex: Int,
+        overlapDepth: Int,
         for request: DanmakuLaneRequest,
         at playbackTime: Double
     ) -> Bool {
+        let slotKey = LaneSlotKey(
+            lane: LaneKey(mode: request.event.mode, index: laneIndex),
+            overlapDepth: overlapDepth
+        )
         switch request.event.mode {
         case .top, .bottom:
-            return fixedLaneOccupants[
-                LaneKey(mode: request.event.mode, index: laneIndex)
-            ] == nil
+            return fixedLaneOccupants[slotKey] == nil
         case .scrolling:
-            guard let previous = scrollingLaneTails[laneIndex] else {
+            guard let previous = scrollingLaneTails[slotKey] else {
                 return true
             }
             return scrollingRequest(
@@ -195,6 +259,30 @@ public struct DanmakuLaneAllocator: Sendable {
                 canFollow: previous.placement,
                 at: playbackTime
             )
+        }
+    }
+
+    private func laneIsSafeWithoutOverlap(
+        _ laneIndex: Int,
+        for request: DanmakuLaneRequest,
+        at playbackTime: Double
+    ) -> Bool {
+        let laneKey = LaneKey(
+            mode: request.event.mode,
+            index: laneIndex
+        )
+        switch request.event.mode {
+        case .top, .bottom:
+            return activeLaneCounts[laneKey] == nil
+        case .scrolling:
+            return scrollingLaneTails.allSatisfy { slotKey, previous in
+                guard slotKey.lane == laneKey else { return true }
+                return scrollingRequest(
+                    request,
+                    canFollow: previous.placement,
+                    at: playbackTime
+                )
+            }
         }
     }
 

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneModels.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneModels.swift
@@ -10,6 +10,7 @@ public struct DanmakuLaneConfiguration: Sendable, Equatable {
     public let minimumHorizontalGap: Double
     public let maximumActiveCount: Int
     public let displayAreaFraction: Double
+    public let maximumOverlapDepth: Int
 
     public init(
         surfaceWidth: Double,
@@ -17,7 +18,8 @@ public struct DanmakuLaneConfiguration: Sendable, Equatable {
         laneHeight: Double,
         minimumHorizontalGap: Double,
         maximumActiveCount: Int,
-        displayAreaFraction: Double
+        displayAreaFraction: Double,
+        maximumOverlapDepth: Int = 1
     ) {
         self.surfaceWidth = surfaceWidth
         self.surfaceHeight = surfaceHeight
@@ -25,6 +27,7 @@ public struct DanmakuLaneConfiguration: Sendable, Equatable {
         self.minimumHorizontalGap = minimumHorizontalGap
         self.maximumActiveCount = maximumActiveCount
         self.displayAreaFraction = displayAreaFraction
+        self.maximumOverlapDepth = maximumOverlapDepth
     }
 
     var isValid: Bool {
@@ -41,7 +44,9 @@ public struct DanmakuLaneConfiguration: Sendable, Equatable {
             laneHeight > 0,
             minimumHorizontalGap >= 0,
             maximumActiveCount > 0,
-            maximumActiveCount <= Self.hardMaximumActiveCount
+            maximumActiveCount <= Self.hardMaximumActiveCount,
+            maximumOverlapDepth > 0,
+            maximumOverlapDepth <= Self.hardMaximumActiveCount
         else {
             return false
         }
@@ -85,6 +90,25 @@ public struct DanmakuLanePlacement: Sendable, Equatable {
     public let surfaceWidthAtAdmission: Double
     public let admittedAtSeconds: Double
     public let expiresAtSeconds: Double
+    public let overlapDepth: Int
+
+    public init(
+        request: DanmakuLaneRequest,
+        laneIndex: Int,
+        originY: Double,
+        surfaceWidthAtAdmission: Double,
+        admittedAtSeconds: Double,
+        expiresAtSeconds: Double,
+        overlapDepth: Int = 0
+    ) {
+        self.request = request
+        self.laneIndex = laneIndex
+        self.originY = originY
+        self.surfaceWidthAtAdmission = surfaceWidthAtAdmission
+        self.admittedAtSeconds = admittedAtSeconds
+        self.expiresAtSeconds = expiresAtSeconds
+        self.overlapDepth = overlapDepth
+    }
 }
 
 public enum DanmakuLaneDropReason: Error, Sendable, Equatable {

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentation.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentation.swift
@@ -23,6 +23,8 @@ public protocol DanmakuPresentationSink: AnyObject {
     func apply(_ update: DanmakuPresentationUpdate)
     func setSpeedLevel(_ speedLevel: DanmakuSpeedLevel)
     func setOpacity(_ opacity: DanmakuOpacity)
+    func setDisplayArea(_ displayArea: DanmakuDisplayArea)
+    func setDensity(_ density: DanmakuDensity)
     func clearPresentation()
     func stopPresentation()
 }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
@@ -2,6 +2,25 @@ import BiliApplication
 import BiliModels
 import Foundation
 
+struct DanmakuDensityAdmissionPolicy: Sendable, Equatable {
+    let minimumHorizontalGap: Double
+    let maximumOverlapDepth: Int
+
+    init(_ density: DanmakuDensity) {
+        switch density {
+        case .normal:
+            minimumHorizontalGap = 24
+            maximumOverlapDepth = 1
+        case .increased:
+            minimumHorizontalGap = 12
+            maximumOverlapDepth = 1
+        case .overlapping:
+            minimumHorizontalGap = 0
+            maximumOverlapDepth = 3
+        }
+    }
+}
+
 public struct DanmakuRendererStatistics: Sendable, Equatable {
     public private(set) var admitted = 0
     public private(set) var droppedNoLane = 0
@@ -43,6 +62,8 @@ public final class DanmakuPresentationController:
     private var allocator: DanmakuLaneAllocator
     private var configuration: DanmakuLaneConfiguration
     private var speedLevel = DanmakuSpeedLevel.three
+    private var displayArea = DanmakuDisplayArea.full
+    private var density = DanmakuDensity.normal
     private var identity: PlaybackItemIdentity?
     private var discontinuityGeneration: UInt64?
     private var surfaceOwnerID: UUID?
@@ -161,6 +182,16 @@ public final class DanmakuPresentationController:
         backend.setOpacity(opacity)
     }
 
+    public func setDisplayArea(_ displayArea: DanmakuDisplayArea) {
+        self.displayArea = displayArea
+        updateAdmissionPolicy()
+    }
+
+    public func setDensity(_ density: DanmakuDensity) {
+        self.density = density
+        updateAdmissionPolicy()
+    }
+
     public func stopPresentation() {
         _ = allocator.clear()
         backend.stop()
@@ -169,14 +200,23 @@ public final class DanmakuPresentationController:
         statistics.updateActive(0)
     }
 
-    func updateConfiguration(
-        _ configuration: DanmakuLaneConfiguration
+    private func updateSurfaceSize(
+        width: Double,
+        height: Double
     ) {
-        self.configuration = configuration
+        configuration = DanmakuLaneConfiguration(
+            surfaceWidth: width,
+            surfaceHeight: height,
+            laneHeight: configuration.laneHeight,
+            minimumHorizontalGap: configuration.minimumHorizontalGap,
+            maximumActiveCount: configuration.maximumActiveCount,
+            displayAreaFraction: configuration.displayAreaFraction,
+            maximumOverlapDepth: configuration.maximumOverlapDepth
+        )
         allocator.updateConfiguration(configuration)
         backend.updateSurfaceSize(
-            width: configuration.surfaceWidth,
-            height: configuration.surfaceHeight
+            width: width,
+            height: height
         )
     }
 
@@ -198,11 +238,12 @@ public final class DanmakuPresentationController:
 
     @discardableResult
     public func updateSurface(
-        _ configuration: DanmakuLaneConfiguration,
+        width: Double,
+        height: Double,
         ownerID: UUID
     ) -> Bool {
         guard surfaceOwnerID == ownerID else { return false }
-        updateConfiguration(configuration)
+        updateSurfaceSize(width: width, height: height)
         return true
     }
 
@@ -215,5 +256,21 @@ public final class DanmakuPresentationController:
         _ = allocator.clear()
         backend.clearAll()
         statistics.updateActive(0)
+    }
+
+    private func updateAdmissionPolicy() {
+        let effectiveDensity: DanmakuDensity =
+            displayArea == .full ? density : .normal
+        let policy = DanmakuDensityAdmissionPolicy(effectiveDensity)
+        configuration = DanmakuLaneConfiguration(
+            surfaceWidth: configuration.surfaceWidth,
+            surfaceHeight: configuration.surfaceHeight,
+            laneHeight: configuration.laneHeight,
+            minimumHorizontalGap: policy.minimumHorizontalGap,
+            maximumActiveCount: configuration.maximumActiveCount,
+            displayAreaFraction: displayArea.fraction,
+            maximumOverlapDepth: policy.maximumOverlapDepth
+        )
+        allocator.updateConfiguration(configuration)
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Session/DanmakuSession.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Session/DanmakuSession.swift
@@ -127,6 +127,14 @@ public final class DanmakuSession: DanmakuPresentationControlling {
         presentationSink?.setOpacity(opacity)
     }
 
+    public func setDisplayArea(_ displayArea: DanmakuDisplayArea) {
+        presentationSink?.setDisplayArea(displayArea)
+    }
+
+    public func setDensity(_ density: DanmakuDensity) {
+        presentationSink?.setDensity(density)
+    }
+
     /// 幂等结束整个会话，而不只是隐藏弹幕图层。
     public func stop() {
         presentationSink?.stopPresentation()

--- a/Packages/BiliKitCore/Sources/BiliDanmakuProbe/RendererLoadProbe.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmakuProbe/RendererLoadProbe.swift
@@ -34,7 +34,11 @@ enum RendererLoadProbe {
         )
 
         controller.attachSurface(ownerID: ownerID)
-        controller.updateSurface(laneConfiguration, ownerID: ownerID)
+        controller.updateSurface(
+            width: laneConfiguration.surfaceWidth,
+            height: laneConfiguration.surfaceHeight,
+            ownerID: ownerID
+        )
         window.makeKeyAndOrderFront(nil as Any?)
         NSApplication.shared.activate(ignoringOtherApps: true)
 

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/DanmakuControlsViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/DanmakuControlsViewModelTests.swift
@@ -10,13 +10,19 @@ struct DanmakuControlsViewModelTests {
         let presentation = RecordingDanmakuPresentation()
         var savedSpeedLevels: [DanmakuSpeedLevel] = []
         var savedOpacities: [DanmakuOpacity] = []
+        var savedDisplayAreas: [DanmakuDisplayArea] = []
+        var savedDensities: [DanmakuDensity] = []
         let initialOpacity = try #require(DanmakuOpacity(0.65))
         let model = DanmakuControlsViewModel(
             presentation: presentation,
             initialSpeedLevel: .two,
             initialOpacity: initialOpacity,
+            initialDisplayArea: .half,
+            initialDensity: .overlapping,
             saveSpeedLevel: { savedSpeedLevels.append($0) },
-            saveOpacity: { savedOpacities.append($0) }
+            saveOpacity: { savedOpacities.append($0) },
+            saveDisplayArea: { savedDisplayAreas.append($0) },
+            saveDensity: { savedDensities.append($0) }
         )
         let identity = PlaybackItemIdentity(
             bvid: "BV1ControlsFixture",
@@ -32,6 +38,11 @@ struct DanmakuControlsViewModelTests {
         model.setOpacity(0.4)
         model.setOpacity(0.1)
         model.setOpacity(.nan)
+        model.setDensity(.increased)
+        model.setDisplayArea(.full)
+        model.setDensity(.increased)
+        model.setDisplayArea(.half)
+        model.setDensity(.normal)
         presentation.reportAuthenticationInvalidation()
         model.reset()
 
@@ -39,8 +50,12 @@ struct DanmakuControlsViewModelTests {
         #expect(presentation.enabledValues == [false])
         #expect(presentation.speedLevels == [.two, .five])
         #expect(presentation.opacities == [initialOpacity, DanmakuOpacity(0.4)])
+        #expect(presentation.displayAreas == [.half, .full, .half])
+        #expect(presentation.densities == [.overlapping, .increased])
         #expect(savedSpeedLevels == [.five])
         #expect(savedOpacities == [DanmakuOpacity(0.4)])
+        #expect(savedDisplayAreas == [.full, .half])
+        #expect(savedDensities == [.increased])
         #expect(
             presentation.modeValues == [
                 ModeValues(scrolling: false, top: true, bottom: true),
@@ -55,6 +70,9 @@ struct DanmakuControlsViewModelTests {
         #expect(!model.showsBottom)
         #expect(model.speedLevel == .five)
         #expect(model.opacity == DanmakuOpacity(0.4))
+        #expect(model.displayArea == .half)
+        #expect(model.density == .increased)
+        #expect(!model.canAdjustDensity)
         #expect(model.authenticationRevalidationGeneration == 1)
     }
 }
@@ -74,6 +92,8 @@ private final class RecordingDanmakuPresentation:
     private(set) var modeValues: [ModeValues] = []
     private(set) var speedLevels: [DanmakuSpeedLevel] = []
     private(set) var opacities: [DanmakuOpacity] = []
+    private(set) var displayAreas: [DanmakuDisplayArea] = []
+    private(set) var densities: [DanmakuDensity] = []
     private(set) var stopCount = 0
     private var authenticationInvalidationHandler: (@MainActor () -> Void)?
 
@@ -101,6 +121,14 @@ private final class RecordingDanmakuPresentation:
 
     func setOpacity(_ opacity: DanmakuOpacity) {
         opacities.append(opacity)
+    }
+
+    func setDisplayArea(_ displayArea: DanmakuDisplayArea) {
+        displayAreas.append(displayArea)
+    }
+
+    func setDensity(_ density: DanmakuDensity) {
+        densities.append(density)
     }
 
     func setModeVisibility(

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuLaneAllocatorTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuLaneAllocatorTests.swift
@@ -1,3 +1,4 @@
+import BiliApplication
 import BiliDanmaku
 import BiliModels
 import Foundation
@@ -47,6 +48,121 @@ struct DanmakuLaneAllocatorTests {
         )
         #expect(admission.admitted.map(\.originY) == [0, 0, 0])
         #expect(admission.dropCounts.noLane == 2)
+    }
+
+    @Test
+    func scrollingReusesFirstSafeLaneBeforeOpeningAnotherVerticalLane() {
+        var allocator = DanmakuLaneAllocator(configuration: configuration())
+        _ = allocator.admit([request(id: "first")], at: 0)
+
+        let second = allocator.admit([request(id: "second")], at: 4)
+        let third = allocator.admit([request(id: "third")], at: 4)
+
+        #expect(second.admitted.map(\.laneIndex) == [0])
+        #expect(third.admitted.map(\.laneIndex) == [1])
+        #expect(second.admitted.map(\.overlapDepth) == [0])
+        #expect(third.admitted.map(\.overlapDepth) == [0])
+    }
+
+    @Test
+    func overlappingScrollingUsesSafeVerticalLaneBeforeAnotherDepth() {
+        var allocator = DanmakuLaneAllocator(
+            configuration: configuration(
+                surfaceHeight: 40,
+                maximumOverlapDepth: 3
+            )
+        )
+        let initial = allocator.admit(
+            [
+                request(id: "lane-0"),
+                request(id: "lane-1"),
+                request(id: "slow-overlap", duration: 20),
+            ],
+            at: 0
+        )
+
+        #expect(initial.admitted.map(\.laneIndex) == [0, 1, 0])
+        #expect(initial.admitted.map(\.overlapDepth) == [0, 0, 1])
+
+        let next = allocator.admit([request(id: "next")], at: 4)
+
+        #expect(next.dropCounts.total == 0)
+        #expect(next.admitted.map(\.laneIndex) == [1])
+        #expect(next.admitted.map(\.overlapDepth) == [0])
+    }
+
+    @Test
+    func reducingOverlapDepthStillChecksEveryActiveScrollingTail() {
+        var allocator = DanmakuLaneAllocator(
+            configuration: configuration(
+                surfaceHeight: 20,
+                maximumOverlapDepth: 3
+            )
+        )
+        let overlapping = allocator.admit(
+            [
+                request(id: "fast", duration: 8),
+                request(id: "slow", duration: 20),
+            ],
+            at: 0
+        )
+
+        #expect(overlapping.admitted.map(\.overlapDepth) == [0, 1])
+
+        allocator.updateConfiguration(
+            configuration(surfaceHeight: 20, maximumOverlapDepth: 1)
+        )
+        let blockedByOldDepth = allocator.admit(
+            [request(id: "blocked", duration: 8)],
+            at: 4
+        )
+
+        #expect(blockedByOldDepth.admitted.isEmpty)
+        #expect(blockedByOldDepth.dropCounts.noLane == 1)
+
+        let recovered = allocator.admit(
+            [request(id: "recovered", duration: 8)],
+            at: 20
+        )
+
+        #expect(
+            recovered.expired.map(\.request.event.id).sorted()
+                == ["fast", "slow"]
+        )
+        #expect(recovered.admitted.map(\.request.event.id) == ["recovered"])
+        #expect(recovered.admitted.map(\.overlapDepth) == [0])
+    }
+
+    @Test
+    func overlappingFixedDanmakuFillsEveryLaneBeforeNextDepth() {
+        var allocator = DanmakuLaneAllocator(
+            configuration: configuration(maximumOverlapDepth: 3)
+        )
+        let admission = allocator.admit(
+            (0..<7).map {
+                request(id: "top-\($0)", mode: .top)
+            },
+            at: 0
+        )
+
+        #expect(admission.dropCounts.total == 0)
+        #expect(admission.admitted.map(\.laneIndex) == [0, 1, 2, 0, 1, 2, 0])
+        #expect(admission.admitted.map(\.overlapDepth) == [0, 0, 0, 1, 1, 1, 2])
+    }
+
+    @Test
+    func nonOverlappingDensityRejectsAfterAllFixedLanesAreOccupied() {
+        var allocator = DanmakuLaneAllocator(configuration: configuration())
+        let admission = allocator.admit(
+            (0..<4).map {
+                request(id: "top-\($0)", mode: .top)
+            },
+            at: 0
+        )
+
+        #expect(admission.admitted.map(\.laneIndex) == [0, 1, 2])
+        #expect(admission.admitted.map(\.overlapDepth) == [0, 0, 0])
+        #expect(admission.dropCounts.noLane == 1)
     }
 
     @Test
@@ -366,11 +482,33 @@ struct DanmakuLaneAllocatorTests {
         }
     }
 
+    @Test
+    func fiveDisplayAreaLevelsLimitAvailableLaneCount() {
+        for area in DanmakuDisplayArea.allCases {
+            var allocator = DanmakuLaneAllocator(
+                configuration: configuration(
+                    surfaceHeight: 400,
+                    displayAreaFraction: area.fraction
+                )
+            )
+            let admission = allocator.admit(
+                (0..<20).map {
+                    request(id: "\(area.rawValue)-\($0)", mode: .top)
+                },
+                at: 0
+            )
+
+            #expect(admission.admitted.count == area.rawValue / 5)
+            #expect(admission.dropCounts.noLane == 20 - area.rawValue / 5)
+        }
+    }
+
     private func configuration(
         surfaceWidth: Double = 1_000,
         surfaceHeight: Double = 60,
         maximumActiveCount: Int = 640,
-        displayAreaFraction: Double = 1
+        displayAreaFraction: Double = 1,
+        maximumOverlapDepth: Int = 1
     ) -> DanmakuLaneConfiguration {
         DanmakuLaneConfiguration(
             surfaceWidth: surfaceWidth,
@@ -378,7 +516,8 @@ struct DanmakuLaneAllocatorTests {
             laneHeight: 20,
             minimumHorizontalGap: 20,
             maximumActiveCount: maximumActiveCount,
-            displayAreaFraction: displayAreaFraction
+            displayAreaFraction: displayAreaFraction,
+            maximumOverlapDepth: maximumOverlapDepth
         )
     }
 

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
@@ -11,6 +11,167 @@ import Testing
 @Suite
 struct DanmakuPresentationControllerTests {
     @Test
+    func densityPoliciesMatchProductionSpacingAndOverlapDepths() {
+        let policies = DanmakuDensity.allCases.map(
+            DanmakuDensityAdmissionPolicy.init
+        )
+
+        #expect(policies.map(\.minimumHorizontalGap) == [24, 12, 0])
+        #expect(policies.map(\.maximumOverlapDepth) == [1, 1, 3])
+    }
+
+    @Test
+    func displayAreaAndDensityChangesPreserveActiveAndAffectNewAdmissions() {
+        let backend = RecordingRenderingBackend()
+        let controller = DanmakuPresentationController(
+            backend: backend,
+            configuration: configuration(maximumActiveCount: 20)
+        )
+        let identity = PlaybackItemIdentity(bvid: "BV1DensityFixture", cid: 1)
+
+        controller.setDensity(.overlapping)
+        controller.setDisplayArea(.half)
+        controller.apply(
+            update(
+                identity: identity,
+                position: 1,
+                generation: 1,
+                events: (0..<11).map {
+                    event(id: "half-\($0)", mode: .top)
+                }
+            )
+        )
+
+        #expect(controller.statistics.active == 5)
+        #expect(controller.statistics.droppedNoLane == 6)
+        #expect(backend.renderedPlacements.map(\.overlapDepth) == [0, 0, 0, 0, 0])
+
+        let clearCount = backend.clearCount
+        controller.setDisplayArea(.full)
+        #expect(backend.clearCount == clearCount)
+        #expect(controller.statistics.active == 5)
+        controller.apply(
+            update(
+                identity: identity,
+                position: 2,
+                generation: 1,
+                events: (0..<6).map {
+                    event(id: "full-\($0)", mode: .top)
+                }
+            )
+        )
+
+        #expect(controller.statistics.active == 11)
+        #expect(Array(backend.renderedPlacements.suffix(6)).map(\.laneIndex) == [5, 6, 7, 8, 9, 0])
+        #expect(
+            Array(backend.renderedPlacements.suffix(6)).map(\.overlapDepth)
+                == [0, 0, 0, 0, 0, 1]
+        )
+    }
+
+    @Test
+    func disablingOverlapWaitsForEveryOldScrollingDepthToBecomeSafe() {
+        let backend = RecordingRenderingBackend()
+        let controller = DanmakuPresentationController(
+            backend: backend,
+            configuration: configuration(
+                maximumActiveCount: 20,
+                surfaceHeight: 30
+            )
+        )
+        let identity = PlaybackItemIdentity(bvid: "BV1DensityTransition", cid: 1)
+
+        controller.setDensity(.overlapping)
+        controller.setSpeedLevel(.five)
+        controller.apply(
+            update(
+                identity: identity,
+                position: 1,
+                generation: 1,
+                events: [event(id: "fast", mode: .scrolling)]
+            )
+        )
+        controller.setSpeedLevel(.one)
+        controller.apply(
+            update(
+                identity: identity,
+                position: 1,
+                generation: 1,
+                events: [event(id: "slow-overlap", mode: .scrolling)]
+            )
+        )
+
+        #expect(backend.renderedPlacements.map(\.overlapDepth) == [0, 1])
+
+        controller.setSpeedLevel(.five)
+        controller.setDensity(.normal)
+        controller.apply(
+            update(
+                identity: identity,
+                position: 3,
+                generation: 1,
+                events: [event(id: "blocked", mode: .scrolling)]
+            )
+        )
+
+        #expect(backend.renderedEventIDs == ["fast", "slow-overlap"])
+        #expect(controller.statistics.droppedNoLane == 1)
+    }
+
+    @Test
+    func reducingDisplayAreaChecksOldScrollingOverlapDepths() {
+        let backend = RecordingRenderingBackend()
+        let controller = DanmakuPresentationController(
+            backend: backend,
+            configuration: configuration(
+                maximumActiveCount: 20,
+                surfaceHeight: 60
+            )
+        )
+        let identity = PlaybackItemIdentity(bvid: "BV1AreaTransition", cid: 1)
+
+        controller.setDensity(.overlapping)
+        controller.setSpeedLevel(.five)
+        controller.apply(
+            update(
+                identity: identity,
+                position: 1,
+                generation: 1,
+                events: [
+                    event(id: "fast-0", mode: .scrolling),
+                    event(id: "fast-1", mode: .scrolling),
+                ]
+            )
+        )
+        controller.setSpeedLevel(.one)
+        controller.apply(
+            update(
+                identity: identity,
+                position: 1,
+                generation: 1,
+                events: [event(id: "slow-overlap", mode: .scrolling)]
+            )
+        )
+
+        #expect(backend.renderedPlacements.map(\.laneIndex) == [0, 1, 0])
+        #expect(backend.renderedPlacements.map(\.overlapDepth) == [0, 0, 1])
+
+        controller.setSpeedLevel(.five)
+        controller.setDisplayArea(.half)
+        controller.apply(
+            update(
+                identity: identity,
+                position: 3,
+                generation: 1,
+                events: [event(id: "blocked", mode: .scrolling)]
+            )
+        )
+
+        #expect(backend.renderedEventIDs == ["fast-0", "fast-1", "slow-overlap"])
+        #expect(controller.statistics.droppedNoLane == 1)
+    }
+
+    @Test
     func lengthWeightedMotionMatchesFivePointSpeedsAcrossRealViewports() {
         let policy = DanmakuMotionPolicy()
         let levelPointSpeeds = zip(
@@ -119,7 +280,10 @@ struct DanmakuPresentationControllerTests {
         let backend = RecordingRenderingBackend()
         let controller = DanmakuPresentationController(
             backend: backend,
-            configuration: configuration(maximumActiveCount: 4)
+            configuration: configuration(
+                maximumActiveCount: 4,
+                surfaceHeight: 30
+            )
         )
         let identity = PlaybackItemIdentity(bvid: "BV1SpeedFixture", cid: 1)
 
@@ -367,13 +531,15 @@ struct DanmakuPresentationControllerTests {
 
         #expect(
             !controller.updateSurface(
-                zeroConfiguration(),
+                width: 0,
+                height: 0,
                 ownerID: replacementOwner
             )
         )
         #expect(
             controller.updateSurface(
-                zeroConfiguration(),
+                width: 0,
+                height: 0,
                 ownerID: firstOwner
             )
         )
@@ -385,7 +551,8 @@ struct DanmakuPresentationControllerTests {
         #expect(controller.statistics.active == 1)
         #expect(
             controller.updateSurface(
-                configuration(maximumActiveCount: 1),
+                width: 800,
+                height: 300,
                 ownerID: firstOwner
             )
         )
@@ -879,25 +1046,15 @@ struct DanmakuPresentationControllerTests {
     }
 
     private func configuration(
-        maximumActiveCount: Int
+        maximumActiveCount: Int,
+        surfaceHeight: Double = 300
     ) -> DanmakuLaneConfiguration {
         DanmakuLaneConfiguration(
             surfaceWidth: 800,
-            surfaceHeight: 300,
+            surfaceHeight: surfaceHeight,
             laneHeight: 30,
             minimumHorizontalGap: 12,
             maximumActiveCount: maximumActiveCount,
-            displayAreaFraction: 1
-        )
-    }
-
-    private func zeroConfiguration() -> DanmakuLaneConfiguration {
-        DanmakuLaneConfiguration(
-            surfaceWidth: 0,
-            surfaceHeight: 0,
-            laneHeight: 36,
-            minimumHorizontalGap: 12,
-            maximumActiveCount: 1,
             displayAreaFraction: 1
         )
     }

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSessionTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSessionTests.swift
@@ -137,6 +137,12 @@ struct DanmakuSessionTests {
         #expect(sink.opacities == [opacity])
         #expect(sink.clearCount == 2)
 
+        session.setDisplayArea(.quarter)
+        session.setDensity(.overlapping)
+        #expect(sink.displayAreas == [.quarter])
+        #expect(sink.densities == [.overlapping])
+        #expect(sink.clearCount == 2)
+
         session.stop()
         #expect(sink.stopCount == 1)
     }
@@ -313,6 +319,8 @@ private final class SessionPresentationSink: DanmakuPresentationSink {
     private(set) var updates: [DanmakuPresentationUpdate] = []
     private(set) var speedLevels: [DanmakuSpeedLevel] = []
     private(set) var opacities: [DanmakuOpacity] = []
+    private(set) var displayAreas: [DanmakuDisplayArea] = []
+    private(set) var densities: [DanmakuDensity] = []
     private(set) var clearCount = 0
     private(set) var stopCount = 0
     private var updateWaiters:
@@ -338,6 +346,14 @@ private final class SessionPresentationSink: DanmakuPresentationSink {
 
     func setOpacity(_ opacity: DanmakuOpacity) {
         opacities.append(opacity)
+    }
+
+    func setDisplayArea(_ displayArea: DanmakuDisplayArea) {
+        displayAreas.append(displayArea)
+    }
+
+    func setDensity(_ density: DanmakuDensity) {
+        densities.append(density)
     }
 
     func clearPresentation() {


### PR DESCRIPTION
## 依赖关系

本 PR 叠加在 #48（WBI 弹幕接口）之上。请先审查并合并 #48；之后本 PR 应重新以 `main` 为 base。

## 变化

- 增加 10%、25%、50%、75%、100% 五档弹幕显示区域并持久化。
- 在 100% 显示区域下提供“正常、较多、重叠”三档密度；较小显示区域自动采用非重叠准入。
- 正常与较多保持无碰撞语义，只调整横向发射间隔；不改变纵向轨道定义。
- 重叠策略优先遍历尚安全的轨道，全部不安全后才使用额外 overlap depth。
- 滚动弹幕依据追尾安全而非“必须已被左侧裁切”准入；降低 overlap depth 后仍检查全部在途旧 tail。
- 顶部和底部固定弹幕分别从上向下、从下向上使用完整允许区域，并同样优先寻找空闲轨道。
- 补齐 ViewModel、偏好、allocator、controller、session 与 resize/策略切换测试。

## 原因

原有固定 50% 区域和单一准入策略无法表达官方用户熟悉的显示区域/密度选择；在高弹幕量视频中还会出现新开稀疏轨道、未先填满安全轨道便开始重叠的问题。

## 用户影响

用户可以控制弹幕覆盖高度；100% 区域配合“重叠”会优先填满可用轨道，再在必要时重叠。普通模式继续避免碰撞，不会因为选择“较多”直接纵向叠字。

## 验证

- 最终树与重排前已审核的 combined tree `07b2913` 字节级一致。
- Xcode 26.6 / macOS，fresh 隔离缓存。
- combined tree Swift Package：369 tests / 45 suites 通过。
- App build-for-testing 通过。
- App 全并发单测中仅 `VideoDetailLifecycleTests.replacementKeepsPlayerSurfaceUntilReset` 在 1 秒等待边界失败；全新 DerivedData 单独重跑通过。
- 用户已在真实 App 中确认：100% + 重叠能够占满屏幕，并完成窗口尺寸变化观察。
- 三路 agent 审查后修复 overlap → normal 仍需检查旧 depth tail 的问题；复审无剩余 P0–P3。

## 未覆盖边界

- 本 PR 不改变 WBI 请求、认证或弹幕候选池获取；这些由 #48 单独负责。
- UI 实测为当前 macOS/Xcode/账户与公开视频环境，不代表所有视频在任意时间点都有足量可显示弹幕。