### PR TITLE
build(gates): 治理构建缓存与最终门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,4 @@ jobs:
           echo "Selected quality gate: ${mode}"
 
       - name: Run selected quality gate (includes strict Swift format lint)
-        env:
-          BILIKIT_GATE_FRESH: 1
-        run: sh Scripts/run-quality-gates.sh "${{ steps.quality-gate.outputs.mode }}"
+        run: sh Scripts/run-quality-gates.sh "${{ steps.quality-gate.outputs.mode }}" closure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,5 +74,9 @@ sh Scripts/run-quality-gates.sh package  # Package 代码；包含 static
 sh Scripts/run-quality-gates.sh app      # App/Xcode/composition；包含 package
 ```
 
+production PR 的最终自动验收在最高适用 mode 后使用 `closure`（例如
+`sh Scripts/run-quality-gates.sh app closure`），由 Gate 在任务局部完整 Xcode 与全新隔离
+环境中运行；不得修改全局 `xcode-select`，也不得以 iteration 结果冒充 closure。
+
 涉及签名、Keychain、真实 UI、播放或性能时，再运行能够观察该行为的真实检查；build、mock、
 截图和一次 trace 不能互相替代。只有实际证据支持时才更新路线图完成状态。

--- a/Scripts/check-project-contract.sh
+++ b/Scripts/check-project-contract.sh
@@ -24,6 +24,7 @@ package_file="Packages/BiliKitCore/Package.swift"
 package_resolution_file="Packages/BiliKitCore/Package.resolved"
 xcode_resolution_file="BiliKitMac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
 quality_gate_file="Scripts/run-quality-gates.sh"
+quality_gate_artifact_test="Scripts/test-quality-gate-artifacts.sh"
 swift_format_config=".swift-format"
 swift_format_check="Scripts/check-swift-format.sh"
 ci_file=".github/workflows/ci.yml"
@@ -39,9 +40,9 @@ assert_occurrences 1 \
     "$ci_file" \
     "CI 必须明确通过统一 Gate 执行 strict Swift 格式检查"
 assert_occurrences 1 \
-    'run: sh Scripts/run-quality-gates.sh "${{ steps.quality-gate.outputs.mode }}"' \
+    'run: sh Scripts/run-quality-gates.sh "${{ steps.quality-gate.outputs.mode }}" closure' \
     "$ci_file" \
-    "CI 必须运行所选择的统一 Gate"
+    "CI 必须以 closure policy 运行所选择的统一 Gate"
 assert_occurrences 1 \
     'sh Scripts/select-quality-gate.sh)' \
     "$ci_file" \
@@ -61,9 +62,22 @@ assert_occurrences 1 \
     "$quality_gate_file" \
     "统一质量 Gate 必须向 GitHub Actions 输出阶段摘要"
 assert_occurrences 1 \
-    'BILIKIT_GATE_FRESH: 1' \
-    "$ci_file" \
-    "CI 必须使用可确定清理的 fresh Gate"
+    'cache_schema="bilikit-quality-gates-v2"' \
+    "$quality_gate_file" \
+    "质量 Gate 必须显式版本化缓存 identity"
+assert_occurrences 1 \
+    'developer_dir_input="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}"' \
+    "$quality_gate_file" \
+    "质量 Gate 必须默认使用任务局部完整 Xcode"
+assert_occurrences 1 \
+    'iteration|fresh|closure' \
+    "$quality_gate_file" \
+    "质量 Gate 必须区分 iteration、fresh 与 closure"
+[ -f "$quality_gate_artifact_test" ] || fail "缺少质量 Gate 产物行为契约测试"
+sh -n "$quality_gate_file" || fail "质量 Gate 脚本语法无效"
+sh -n "$quality_gate_artifact_test" || fail "质量 Gate 产物契约测试脚本语法无效"
+sh "$quality_gate_artifact_test" \
+    || fail "质量 Gate 产物、清理与故障分类行为契约失败"
 assert_occurrences 1 \
     'export SWIFTPM_MODULECACHE_OVERRIDE="$swift_module_cache_path"' \
     "$quality_gate_file" \

--- a/Scripts/run-quality-gates.sh
+++ b/Scripts/run-quality-gates.sh
@@ -4,90 +4,260 @@ set -eu
 
 umask 077
 
-fail() {
-    echo "质量 Gate 失败：$1" >&2
+cache_schema="bilikit-quality-gates-v2"
+
+fail_classification() {
+    classification="$1"
+    shift
+    echo "[Gate] classification=$classification" >&2
+    echo "质量 Gate 失败：$*" >&2
     exit 1
 }
 
-mode="${1:-package}"
-case "$mode" in
-    static|package|app) ;;
-    *) fail "模式必须是 static、package 或 app" ;;
-esac
-
-fresh_artifacts="${BILIKIT_GATE_FRESH:-0}"
-retain_artifacts="${BILIKIT_GATE_RETAIN_ARTIFACTS:-0}"
-print_paths_only="${BILIKIT_GATE_PRINT_PATHS_ONLY:-0}"
-case "$fresh_artifacts" in
-    0|1) ;;
-    *) fail "BILIKIT_GATE_FRESH 必须是 0 或 1" ;;
-esac
-case "$retain_artifacts" in
-    0|1) ;;
-    *) fail "BILIKIT_GATE_RETAIN_ARTIFACTS 必须是 0 或 1" ;;
-esac
-case "$print_paths_only" in
-    0|1) ;;
-    *) fail "BILIKIT_GATE_PRINT_PATHS_ONLY 必须是 0 或 1" ;;
-esac
-[ "$retain_artifacts" = "0" ] || [ "$fresh_artifacts" = "1" ] \
-    || fail "BILIKIT_GATE_RETAIN_ARTIFACTS=1 只能与 BILIKIT_GATE_FRESH=1 一起使用"
+marker_has_line() {
+    marker_file="$1"
+    expected_line="$2"
+    grep -F -x "$expected_line" "$marker_file" >/dev/null 2>&1
+}
 
 script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 repository_root=$(CDPATH= cd -- "$script_dir/.." && pwd -P)
 checkout_key=$(printf '%s' "$repository_root" | shasum -a 256 | awk '{ print substr($1, 1, 16) }')
-[ -n "$checkout_key" ] || fail "无法从 canonical worktree path 计算缓存 key"
+[ -n "$checkout_key" ] || fail_classification configuration "无法从 canonical worktree path 计算缓存 key"
 cd "$repository_root"
 
-fresh_root=""
-gate_log_dir=""
-cleanup_status=0
+temporary_base=$(CDPATH= cd -- "${TMPDIR:-/tmp}" && pwd -P) \
+    || fail_classification sandbox "无法解析任务临时目录"
+gate_checkout_root="$repository_root/.build/bilikit-quality-gates/$checkout_key"
+
+validate_iteration_root() {
+    candidate="$1"
+    [ -d "$candidate" ] || return 1
+    [ ! -L "$candidate" ] || return 1
+    canonical_candidate=$(CDPATH= cd -- "$candidate" && pwd -P) || return 1
+    [ "$canonical_candidate" = "$gate_checkout_root" ] || return 1
+    marker="$candidate/.bilikit-quality-gate-iteration-root"
+    [ -f "$marker" ] || return 1
+    marker_has_line "$marker" "schema=$cache_schema" || return 1
+    marker_has_line "$marker" "repository_root=$repository_root" || return 1
+    marker_has_line "$marker" "checkout_key=$checkout_key" || return 1
+}
+
+validate_fresh_root() {
+    candidate="$1"
+    expected_run_identity="${2:-}"
+    [ -n "$candidate" ] || return 1
+    case "$candidate" in
+        /|"${HOME:-/nonexistent}"|"$repository_root") return 1 ;;
+        "$temporary_base"/BiliKit-quality-gate.*) ;;
+        *) return 1 ;;
+    esac
+    [ -d "$candidate" ] || return 1
+    [ ! -L "$candidate" ] || return 1
+    canonical_candidate=$(CDPATH= cd -- "$candidate" && pwd -P) || return 1
+    [ "$canonical_candidate" = "${candidate%/}" ] || return 1
+    [ "$(/usr/bin/stat -f '%u' "$candidate" 2>/dev/null)" = "$(id -u)" ] || return 1
+    [ "$(/usr/bin/stat -f '%Lp' "$candidate" 2>/dev/null)" = "700" ] || return 1
+    marker="$candidate/.bilikit-quality-gate-fresh-root"
+    [ -f "$marker" ] || return 1
+    marker_has_line "$marker" "schema=$cache_schema" || return 1
+    marker_has_line "$marker" "repository_root=$repository_root" || return 1
+    marker_has_line "$marker" "checkout_key=$checkout_key" || return 1
+    grep -E -x 'artifact_policy=(fresh|closure)' "$marker" >/dev/null 2>&1 || return 1
+    grep -E -x 'run_identity=[^[:space:]]+' "$marker" >/dev/null 2>&1 || return 1
+    if [ -n "$expected_run_identity" ]; then
+        marker_has_line "$marker" "run_identity=$expected_run_identity" || return 1
+    fi
+}
+
+safe_remove_iteration_root() {
+    [ -e "$gate_checkout_root" ] || {
+        echo "[Gate] 当前 checkout 没有 iteration 产物"
+        return 0
+    }
+    case "$gate_checkout_root" in
+        "$repository_root"/.build/bilikit-quality-gates/"$checkout_key") ;;
+        *) return 1 ;;
+    esac
+    validate_iteration_root "$gate_checkout_root" || return 1
+    rm -rf -- "$gate_checkout_root"
+    [ ! -e "$gate_checkout_root" ]
+}
 
 safe_remove_fresh_root() {
-    [ -n "$fresh_root" ] || return 0
-    case "$fresh_root" in
-        "$temporary_base"/BiliKit-quality-gate.*) ;;
-        *)
-            echo "[Gate] 拒绝清理未验证的 fresh 路径：$fresh_root" >&2
-            return 1
-            ;;
+    candidate="$1"
+    expected_run_identity="${2:-}"
+    validate_fresh_root "$candidate" "$expected_run_identity" || return 1
+    rm -rf -- "$candidate"
+    [ ! -e "$candidate" ]
+}
+
+command_name="${1:-package}"
+case "$command_name" in
+    cleanup-iteration)
+        [ "$#" -eq 1 ] || fail_classification configuration "cleanup-iteration 不接受路径参数"
+        safe_remove_iteration_root \
+            || fail_classification configuration "拒绝清理未通过 marker 与 checkout identity 验证的 iteration 路径"
+        echo "[Gate] iteration 产物已清理：$gate_checkout_root"
+        exit 0
+        ;;
+    cleanup-retained)
+        [ "$#" -eq 2 ] || fail_classification configuration "cleanup-retained 需要一个脚本打印的精确路径"
+        retained_root="$2"
+        safe_remove_fresh_root "$retained_root" "" \
+            || fail_classification configuration "拒绝清理未通过 owner、mode、marker 与 checkout identity 验证的 retained 路径"
+        echo "[Gate] retained fresh 产物已清理：$retained_root"
+        exit 0
+        ;;
+esac
+
+mode="$command_name"
+case "$mode" in
+    static|package|app) ;;
+    *) fail_classification configuration "模式必须是 static、package、app、cleanup-iteration 或 cleanup-retained" ;;
+esac
+[ "$#" -le 2 ] || fail_classification configuration "质量 Gate 最多接受 mode 与 artifact policy 两个参数"
+
+fresh_compat="${BILIKIT_GATE_FRESH:-0}"
+retain_artifacts="${BILIKIT_GATE_RETAIN_ARTIFACTS:-0}"
+print_paths_only="${BILIKIT_GATE_PRINT_PATHS_ONLY:-0}"
+term_is_timeout="${BILIKIT_GATE_TERM_IS_TIMEOUT:-0}"
+case "$fresh_compat" in 0|1) ;; *) fail_classification configuration "BILIKIT_GATE_FRESH 必须是 0 或 1" ;; esac
+case "$retain_artifacts" in 0|1) ;; *) fail_classification configuration "BILIKIT_GATE_RETAIN_ARTIFACTS 必须是 0 或 1" ;; esac
+case "$print_paths_only" in 0|1) ;; *) fail_classification configuration "BILIKIT_GATE_PRINT_PATHS_ONLY 必须是 0 或 1" ;; esac
+case "$term_is_timeout" in 0|1) ;; *) fail_classification configuration "BILIKIT_GATE_TERM_IS_TIMEOUT 必须是 0 或 1" ;; esac
+
+if [ "$#" -eq 2 ]; then
+    artifact_policy="$2"
+    if [ "$fresh_compat" = "1" ] && [ "$artifact_policy" = "iteration" ]; then
+        fail_classification configuration "显式 iteration 与 BILIKIT_GATE_FRESH=1 冲突"
+    fi
+else
+    if [ "$fresh_compat" = "1" ]; then
+        artifact_policy="fresh"
+    else
+        artifact_policy="iteration"
+    fi
+fi
+case "$artifact_policy" in
+    iteration|fresh|closure) ;;
+    *) fail_classification configuration "artifact policy 必须是 iteration、fresh 或 closure" ;;
+esac
+if [ "$retain_artifacts" = "1" ] && [ "$artifact_policy" = "iteration" ]; then
+    fail_classification configuration "BILIKIT_GATE_RETAIN_ARTIFACTS=1 只能用于 fresh 或 closure"
+fi
+case "$artifact_policy" in fresh|closure) fresh_artifacts=1 ;; iteration) fresh_artifacts=0 ;; esac
+
+developer_dir_input="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}"
+[ -d "$developer_dir_input" ] \
+    || fail_classification toolchain "完整 Xcode Developer 目录不存在：$developer_dir_input"
+developer_dir=$(CDPATH= cd -- "$developer_dir_input" && pwd -P) \
+    || fail_classification toolchain "无法解析完整 Xcode Developer 目录"
+export DEVELOPER_DIR="$developer_dir"
+
+if ! xcode_version=$(xcodebuild -version 2>&1); then
+    fail_classification toolchain "DEVELOPER_DIR 没有提供可用的完整 Xcode"
+fi
+if ! swift_version=$(xcrun swift --version 2>&1); then
+    fail_classification toolchain "所选 Xcode 没有提供可用的 Swift 工具链"
+fi
+
+identity_files="
+Packages/BiliKitCore/Package.swift
+Packages/BiliKitCore/Package.resolved
+BiliKitMac.xcodeproj/project.pbxproj
+BiliKitMac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+"
+for identity_file in $identity_files; do
+    [ -f "$identity_file" ] || fail_classification configuration "缺少构建身份输入：$identity_file"
+done
+
+generation_key=$(
+    {
+        printf 'schema=%s\n' "$cache_schema"
+        printf 'repository_root=%s\n' "$repository_root"
+        printf 'developer_dir=%s\n' "$developer_dir"
+        printf 'architecture=%s\n' "$(uname -m)"
+        printf '%s\n' "$xcode_version"
+        printf '%s\n' "$swift_version"
+        for identity_file in $identity_files; do
+            shasum -a 256 "$identity_file"
+        done
+        find BiliKitMac.xcodeproj -type f \
+            \( -name '*.xcscheme' -o -name '*.xcconfig' -o -name '*.xctestplan' \) \
+            -print | LC_ALL=C sort | while IFS= read -r identity_file; do
+                shasum -a 256 "$identity_file"
+            done
+    } | shasum -a 256 | awk '{ print substr($1, 1, 16) }'
+)
+[ -n "$generation_key" ] || fail_classification configuration "无法计算 iteration generation"
+
+fresh_root=""
+fresh_run_identity=""
+gate_log_dir=""
+artifact_root=""
+cleanup_status=0
+force_cleanup_fresh=0
+
+report_artifact_capacity() {
+    [ -n "$artifact_root" ] || return 0
+    [ -d "$artifact_root" ] || return 0
+    total_kib=$(/usr/bin/du -sk "$artifact_root" 2>/dev/null | awk '{ print $1 }') || total_kib="unknown"
+    echo "[Gate] repository-artifacts total-kib=$total_kib policy=$artifact_policy generation=$generation_key"
+    accounted_kib=0
+    capacity_known=1
+    for component in swiftpm-scratch swiftpm-cache swiftpm-config swiftpm-security swiftpm-home xcode-derived xcode-packages xcode-package-cache xcode-user-home module-cache; do
+        if [ -e "$artifact_root/$component" ]; then
+            component_kib=$(/usr/bin/du -sk "$artifact_root/$component" 2>/dev/null | awk '{ print $1 }') || component_kib="unknown"
+            echo "[Gate] repository-artifacts component=$component kib=$component_kib"
+            case "$component_kib" in
+                *[!0-9]*|"") capacity_known=0 ;;
+                *) accounted_kib=$((accounted_kib + component_kib)) ;;
+            esac
+        fi
+    done
+    logs_kib=$(find "$artifact_root" -mindepth 1 -maxdepth 1 -type d -name 'logs.*' -exec /usr/bin/du -sk {} + 2>/dev/null | awk '{ total += $1 } END { print total + 0 }') \
+        || logs_kib="unknown"
+    echo "[Gate] repository-artifacts component=logs kib=$logs_kib"
+    case "$logs_kib" in
+        *[!0-9]*|"") capacity_known=0 ;;
+        *) accounted_kib=$((accounted_kib + logs_kib)) ;;
     esac
-    [ -f "$fresh_root/.bilikit-quality-gate-fresh-root" ] \
-        || {
-            echo "[Gate] 拒绝清理缺少 marker 的 fresh 路径：$fresh_root" >&2
-            return 1
-        }
-    [ "$(cat "$fresh_root/.bilikit-quality-gate-fresh-root")" = "$repository_root" ] \
-        || {
-            echo "[Gate] 拒绝清理 checkout marker 不匹配的 fresh 路径：$fresh_root" >&2
-            return 1
-        }
-    rm -rf -- "$fresh_root"
-    [ ! -e "$fresh_root" ] || return 1
+    case "$total_kib" in *[!0-9]*|"") capacity_known=0 ;; esac
+    if [ "$capacity_known" -eq 1 ] && [ "$total_kib" -ge "$accounted_kib" ]; then
+        other_kib=$((total_kib - accounted_kib))
+    else
+        other_kib="unknown"
+    fi
+    echo "[Gate] repository-artifacts component=other kib=$other_kib"
+    if [ "$artifact_policy" = "iteration" ]; then
+        generation_count=$(find "$gate_checkout_root/generations" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | awk 'END { print NR + 0 }')
+        echo "[Gate] repository-artifacts generation-count=$generation_count"
+        if [ "$generation_count" -gt 1 ]; then
+            echo "[Gate] 存在旧 generation；确认无并行 Gate 后可运行：sh Scripts/run-quality-gates.sh cleanup-iteration"
+        fi
+    fi
 }
 
 safe_remove_gate_logs() {
     [ -n "$gate_log_dir" ] || return 0
     [ "$fresh_artifacts" = "0" ] || return 0
-    case "$gate_log_dir" in
-        "$artifact_root"/logs.*) ;;
-        *)
-            echo "[Gate] 拒绝清理未验证的日志路径：$gate_log_dir" >&2
-            return 1
-            ;;
-    esac
-    [ -f "$gate_log_dir/.bilikit-quality-gate-log-root" ] \
-        || {
-            echo "[Gate] 拒绝清理缺少 marker 的日志路径：$gate_log_dir" >&2
-            return 1
-        }
+    case "$gate_log_dir" in "$artifact_root"/logs.*) ;; *) return 1 ;; esac
+    marker="$gate_log_dir/.bilikit-quality-gate-log-root"
+    [ -f "$marker" ] || return 1
+    marker_has_line "$marker" "schema=$cache_schema" || return 1
+    marker_has_line "$marker" "repository_root=$repository_root" || return 1
+    marker_has_line "$marker" "checkout_key=$checkout_key" || return 1
+    marker_has_line "$marker" "generation_key=$generation_key" || return 1
     rm -rf -- "$gate_log_dir"
-    [ ! -e "$gate_log_dir" ] || return 1
+    [ ! -e "$gate_log_dir" ]
 }
 
 finalize_artifacts() {
     status=$?
-    trap - EXIT HUP INT TERM
+    trap - EXIT
+    trap '' HUP INT TERM
+    report_artifact_capacity || true
 
     if ! safe_remove_gate_logs; then
         echo "[Gate] 临时日志清理失败" >&2
@@ -95,15 +265,17 @@ finalize_artifacts() {
     fi
 
     if [ "$fresh_artifacts" = "1" ] && [ -n "$fresh_root" ]; then
-        if [ "$retain_artifacts" = "1" ]; then
+        if [ "$retain_artifacts" = "1" ] && [ "$force_cleanup_fresh" = "0" ]; then
             echo "[Gate] fresh 诊断产物已保留：$fresh_root"
-        elif safe_remove_fresh_root; then
+            echo "[Gate] 安全清理命令：sh Scripts/run-quality-gates.sh cleanup-retained '$fresh_root'"
+        elif safe_remove_fresh_root "$fresh_root" "$fresh_run_identity"; then
             echo "[Gate] fresh 产物已清理：$fresh_root"
         else
             echo "[Gate] fresh 产物清理失败：$fresh_root" >&2
             cleanup_status=1
         fi
     fi
+    trap - HUP INT TERM
 
     if [ "$status" -eq 0 ] && [ "$cleanup_status" -ne 0 ]; then
         status=$cleanup_status
@@ -111,38 +283,163 @@ finalize_artifacts() {
     exit "$status"
 }
 
+handle_signal() {
+    signal_name="$1"
+    signal_status="$2"
+    if [ "$signal_name" = "TERM" ] && [ "$term_is_timeout" = "1" ]; then
+        echo "[Gate] classification=timeout.inconclusive signal=TERM" >&2
+    else
+        echo "[Gate] classification=unknown signal=$signal_name" >&2
+    fi
+    exit "$signal_status"
+}
+
 trap finalize_artifacts EXIT
-trap 'exit 129' HUP
-trap 'exit 130' INT
-trap 'exit 143' TERM
+trap 'handle_signal HUP 129' HUP
+trap 'handle_signal INT 130' INT
+trap 'handle_signal TERM 143' TERM
 
 if [ "$fresh_artifacts" = "1" ]; then
     [ -z "${BILIKIT_DERIVED_DATA_PATH:-}" ] \
-        || fail "fresh 模式不接受 BILIKIT_DERIVED_DATA_PATH；所有产物必须位于唯一临时根"
-    temporary_base=$(CDPATH= cd -- "${TMPDIR:-/tmp}" && pwd -P)
-    fresh_root=$(mktemp -d "$temporary_base/BiliKit-quality-gate.XXXXXX")
-    chmod 700 "$fresh_root"
-    printf '%s\n' "$repository_root" >"$fresh_root/.bilikit-quality-gate-fresh-root"
-    artifact_root=$fresh_root
-    artifact_mode="fresh"
+        || fail_classification configuration "fresh/closure 不接受 BILIKIT_DERIVED_DATA_PATH"
+    fresh_root=$(mktemp -d "$temporary_base/BiliKit-quality-gate.XXXXXX") \
+        || fail_classification sandbox "无法创建 fresh 私有根"
+    chmod 700 "$fresh_root" || fail_classification sandbox "无法设置 fresh 私有根权限"
+    fresh_run_identity="$(basename "$fresh_root").$$"
+    {
+        printf 'schema=%s\n' "$cache_schema"
+        printf 'repository_root=%s\n' "$repository_root"
+        printf 'checkout_key=%s\n' "$checkout_key"
+        printf 'artifact_policy=%s\n' "$artifact_policy"
+        printf 'run_identity=%s\n' "$fresh_run_identity"
+    } >"$fresh_root/.bilikit-quality-gate-fresh-root"
+    artifact_root="$fresh_root"
 else
-    artifact_root="$repository_root/.build/bilikit-quality-gates/$checkout_key"
-    mkdir -p "$artifact_root"
-    artifact_root=$(CDPATH= cd -- "$artifact_root" && pwd -P)
-    artifact_mode="iteration"
+    build_root="$repository_root/.build"
+    if [ -e "$build_root" ]; then
+        [ -d "$build_root" ] && [ ! -L "$build_root" ] \
+            || fail_classification configuration "checkout-local .build 不是普通目录"
+    else
+        mkdir "$build_root" || fail_classification sandbox "无法创建 checkout-local .build"
+    fi
+    canonical_build_root=$(CDPATH= cd -- "$build_root" && pwd -P) \
+        || fail_classification sandbox "无法解析 checkout-local .build"
+    [ "$canonical_build_root" = "$build_root" ] \
+        || fail_classification configuration "checkout-local .build 不能通过 symlink 逃逸仓库"
+    gate_base="$build_root/bilikit-quality-gates"
+    if [ -e "$gate_base" ]; then
+        [ -d "$gate_base" ] && [ ! -L "$gate_base" ] \
+            || fail_classification configuration "checkout-local Gate 容器不是普通目录"
+    else
+        mkdir "$gate_base" || fail_classification sandbox "无法创建 checkout-local Gate 根"
+    fi
+    canonical_gate_base=$(CDPATH= cd -- "$gate_base" && pwd -P) \
+        || fail_classification sandbox "无法解析 checkout-local Gate 根"
+    [ "$canonical_gate_base" = "$gate_base" ] \
+        || fail_classification configuration "checkout-local Gate 根不能通过 symlink 逃逸仓库"
+    if [ -e "$gate_checkout_root" ]; then
+        validate_iteration_root "$gate_checkout_root" \
+            || fail_classification configuration "iteration 根缺少有效 marker 或 checkout identity 不匹配"
+    else
+        mkdir "$gate_checkout_root" || fail_classification sandbox "无法创建 iteration 根"
+        {
+            printf 'schema=%s\n' "$cache_schema"
+            printf 'repository_root=%s\n' "$repository_root"
+            printf 'checkout_key=%s\n' "$checkout_key"
+        } >"$gate_checkout_root/.bilikit-quality-gate-iteration-root"
+    fi
+    generation_parent="$gate_checkout_root/generations"
+    if [ -e "$generation_parent" ]; then
+        [ -d "$generation_parent" ] && [ ! -L "$generation_parent" ] \
+            || fail_classification configuration "generation 容器不是受控目录"
+    else
+        mkdir "$generation_parent" || fail_classification sandbox "无法创建 generation 容器"
+    fi
+    canonical_generation_parent=$(CDPATH= cd -- "$generation_parent" && pwd -P) \
+        || fail_classification sandbox "无法解析 generation 容器"
+    [ "$canonical_generation_parent" = "$generation_parent" ] \
+        || fail_classification configuration "generation 容器不能通过 symlink 逃逸 iteration 根"
+    artifact_root="$generation_parent/$generation_key"
+    generation_marker="$artifact_root/.bilikit-quality-gate-generation-root"
+    if [ -e "$artifact_root" ]; then
+        [ -d "$artifact_root" ] && [ ! -L "$artifact_root" ] \
+            || fail_classification configuration "generation 路径不是受控目录"
+        [ -f "$generation_marker" ] \
+            || fail_classification configuration "generation 根缺少 marker"
+        marker_has_line "$generation_marker" "schema=$cache_schema" \
+            && marker_has_line "$generation_marker" "repository_root=$repository_root" \
+            && marker_has_line "$generation_marker" "checkout_key=$checkout_key" \
+            && marker_has_line "$generation_marker" "generation_key=$generation_key" \
+            || fail_classification configuration "generation marker identity 不匹配"
+    else
+        mkdir "$artifact_root" || fail_classification sandbox "无法创建 generation 根"
+        {
+            printf 'schema=%s\n' "$cache_schema"
+            printf 'repository_root=%s\n' "$repository_root"
+            printf 'checkout_key=%s\n' "$checkout_key"
+            printf 'generation_key=%s\n' "$generation_key"
+        } >"$generation_marker"
+    fi
 fi
+
+canonical_artifact_root=$(CDPATH= cd -- "$artifact_root" && pwd -P) \
+    || fail_classification sandbox "无法解析 Gate 产物根"
+[ "$canonical_artifact_root" = "$artifact_root" ] \
+    || fail_classification configuration "Gate 产物根不能通过 symlink 逃逸受控路径"
+
+ensure_artifact_directory() {
+    candidate="$1"
+    case "$candidate" in
+        "$artifact_root"/*) ;;
+        *) fail_classification configuration "受控缓存路径必须位于当前 Gate 产物根内" ;;
+    esac
+    parent=${candidate%/*}
+    [ -d "$parent" ] && [ ! -L "$parent" ] \
+        || fail_classification configuration "受控缓存父目录缺失或为 symlink"
+    canonical_parent=$(CDPATH= cd -- "$parent" && pwd -P) \
+        || fail_classification sandbox "无法解析受控缓存父目录"
+    case "$canonical_parent" in
+        "$artifact_root"|"$artifact_root"/*) ;;
+        *) fail_classification configuration "受控缓存父目录通过 symlink 逃逸 Gate 产物根" ;;
+    esac
+    if [ -e "$candidate" ]; then
+        [ -d "$candidate" ] && [ ! -L "$candidate" ] \
+            || fail_classification configuration "受控缓存路径不是普通目录"
+    else
+        mkdir "$candidate" || fail_classification sandbox "无法创建受控缓存路径"
+    fi
+    canonical_candidate=$(CDPATH= cd -- "$candidate" && pwd -P) \
+        || fail_classification sandbox "无法解析受控缓存路径"
+    case "$canonical_candidate" in
+        "$artifact_root"/*) ;;
+        *) fail_classification configuration "受控缓存路径通过 symlink 逃逸 Gate 产物根" ;;
+    esac
+}
 
 swiftpm_scratch_path="$artifact_root/swiftpm-scratch"
 swiftpm_cache_path="$artifact_root/swiftpm-cache"
 swiftpm_config_path="$artifact_root/swiftpm-config"
 swiftpm_security_path="$artifact_root/swiftpm-security"
+swiftpm_home_path="$artifact_root/swiftpm-home"
 xcode_package_path="$artifact_root/xcode-packages"
 xcode_package_cache_path="$artifact_root/xcode-package-cache"
+xcode_user_home_path="$artifact_root/xcode-user-home"
 clang_module_cache_path="$artifact_root/module-cache/clang"
 swift_module_cache_path="$artifact_root/module-cache/swift"
 
 if [ -n "${BILIKIT_DERIVED_DATA_PATH:-}" ]; then
-    derived_data_path=$BILIKIT_DERIVED_DATA_PATH
+    [ "$artifact_policy" = "iteration" ] \
+        || fail_classification configuration "只有 iteration 可使用受控 DerivedData 覆盖"
+    derived_data_path="$BILIKIT_DERIVED_DATA_PATH"
+    case "$derived_data_path" in
+        "$artifact_root"/*)
+            derived_data_leaf=${derived_data_path#"$artifact_root"/}
+            case "$derived_data_leaf" in
+                ""|.|..|*/*) fail_classification configuration "BILIKIT_DERIVED_DATA_PATH 只能是当前 generation 的直接子目录" ;;
+            esac
+            ;;
+        *) fail_classification configuration "BILIKIT_DERIVED_DATA_PATH 必须位于当前受控 generation 根内" ;;
+    esac
 else
     derived_data_path="$artifact_root/xcode-derived"
 fi
@@ -152,27 +449,31 @@ for path in \
     "$swiftpm_cache_path" \
     "$swiftpm_config_path" \
     "$swiftpm_security_path" \
+    "$swiftpm_home_path" \
     "$xcode_package_path" \
     "$xcode_package_cache_path" \
-    "$clang_module_cache_path" \
-    "$swift_module_cache_path" \
+    "$xcode_user_home_path" \
+    "$artifact_root/module-cache" \
     "$derived_data_path"
 do
-    mkdir -p "$path"
+    ensure_artifact_directory "$path"
 done
-derived_data_path=$(CDPATH= cd -- "$derived_data_path" && pwd -P)
-
-case "$derived_data_path" in
-    /|"${HOME:-/nonexistent}"|"$repository_root")
-        fail "BILIKIT_DERIVED_DATA_PATH 不能解析为根目录、HOME 或仓库根目录"
-        ;;
-esac
+for path in \
+    "$swiftpm_home_path/.cache" \
+    "$xcode_user_home_path/.cache" \
+    "$clang_module_cache_path" \
+    "$swift_module_cache_path"
+do
+    ensure_artifact_directory "$path"
+done
 
 export CLANG_MODULE_CACHE_PATH="$clang_module_cache_path"
 export SWIFT_MODULE_CACHE_PATH="$swift_module_cache_path"
 export SWIFTPM_MODULECACHE_OVERRIDE="$swift_module_cache_path"
 
-echo "[Gate] 产物模式：${artifact_mode}（checkout key: ${checkout_key}）"
+echo "[Gate] artifact-policy=$artifact_policy mode=$mode"
+echo "[Gate] checkout-key=$checkout_key generation=$generation_key"
+echo "[Gate] DEVELOPER_DIR=$developer_dir"
 echo "[Gate] SwiftPM scratch：$swiftpm_scratch_path"
 echo "[Gate] Xcode DerivedData：$derived_data_path"
 echo "[Gate] Clang module cache：$clang_module_cache_path"
@@ -183,19 +484,76 @@ if [ "$print_paths_only" = "1" ]; then
     exit 0
 fi
 
-compact_logs="${BILIKIT_COMPACT_LOGS:-0}"
-case "$compact_logs" in
-    0|1) ;;
-    *) fail "BILIKIT_COMPACT_LOGS 必须是 0 或 1" ;;
-esac
+compact_logs="${BILIKIT_COMPACT_LOGS:-1}"
+case "$compact_logs" in 0|1) ;; *) fail_classification configuration "BILIKIT_COMPACT_LOGS 必须是 0 或 1" ;; esac
 
+sanitize_gate_log_file() {
+    source_log="$1"
+    sanitized_log="$source_log.sanitized"
+    awk \
+        -v repository="$repository_root" \
+        -v artifact="$artifact_root" \
+        -v user_home="${HOME:-}" '
+        function replace_literal(text, old, replacement, position) {
+            if (old == "") return text
+            while ((position = index(text, old)) > 0) {
+                text = substr(text, 1, position - 1) replacement substr(text, position + length(old))
+            }
+            return text
+        }
+        function redact_credential_fields(text, lower, rest, consumed, quote_end, key_start, key_length) {
+            lower = tolower(text)
+            while (match(lower, /"?(token|refresh_token|qrcode_key)"?[[:space:]]*[=:][[:space:]]*/)) {
+                key_start = RSTART
+                key_length = RLENGTH
+                rest = substr(text, key_start + key_length)
+                if (substr(rest, 1, 1) == "\"") {
+                    quote_end = index(substr(rest, 2), "\"")
+                    consumed = quote_end > 0 ? quote_end + 1 : length(rest)
+                } else if (match(rest, /[[:space:],}]/)) {
+                    consumed = RSTART - 1
+                } else {
+                    consumed = length(rest)
+                }
+                text = substr(text, 1, key_start - 1) "credential=<redacted>" substr(rest, consumed + 1)
+                lower = tolower(text)
+            }
+            return text
+        }
+        {
+            line = replace_literal($0, artifact, "<gate-artifact-root>")
+            line = replace_literal(line, repository, "<checkout-root>")
+            line = replace_literal(line, user_home, "<user-home>")
+            gsub(/\/(private\/)?var\/folders\/[^[:space:]]*\/BiliKit-quality-gate\.[^\/[:space:]]+/, "<gate-artifact-root>", line)
+            gsub(/on '\''[^'\'']*'\''/, "on '\''<redacted-test-destination>'\''", line)
+            gsub(/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/, "<redacted-identifier>", line)
+            gsub(/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}/, "<redacted-identifier>", line)
+            gsub(/https?:\/\/[^[:space:]"'\''<>]+/, "<redacted-url>", line)
+            lower = tolower(line)
+            if (match(lower, /(cookie|authorization)[[:space:]]*[=:]/)) {
+                line = substr(line, 1, RSTART - 1) "credential-header=<redacted>"
+            }
+            line = redact_credential_fields(line)
+            print line
+        }
+    ' "$source_log" >"$sanitized_log" || return 1
+    mv "$sanitized_log" "$source_log"
+}
+
+gate_log_dir=$(mktemp -d "$artifact_root/logs.XXXXXX") \
+    || fail_classification sandbox "无法创建 Gate 日志根"
+{
+    printf 'schema=%s\n' "$cache_schema"
+    printf 'repository_root=%s\n' "$repository_root"
+    printf 'checkout_key=%s\n' "$checkout_key"
+    printf 'generation_key=%s\n' "$generation_key"
+} >"$gate_log_dir/.bilikit-quality-gate-log-root"
+echo "[Gate] 日志捕获与脱敏已启用；普通日志在退出时清理"
 if [ "$compact_logs" = "1" ]; then
-    gate_log_dir=$(mktemp -d "$artifact_root/logs.XXXXXX")
-    printf '%s\n' "$repository_root" >"$gate_log_dir/.bilikit-quality-gate-log-root"
-    echo "[Gate] 精简日志已启用；日志在退出时清理"
-    if [ "$fresh_artifacts" = "1" ] && [ "$retain_artifacts" = "1" ]; then
-        echo "[Gate] fresh retain 已启用；完整日志将随诊断产物保留：$gate_log_dir"
-    fi
+    echo "[Gate] compact 输出已启用；成功阶段不回显完整日志"
+fi
+if [ "$fresh_artifacts" = "1" ] && [ "$retain_artifacts" = "1" ]; then
+    echo "[Gate] fresh retain 已启用；只有脱敏成功的完整日志才会保留"
 fi
 
 github_actions="${GITHUB_ACTIONS:-false}"
@@ -203,6 +561,9 @@ github_summary="${GITHUB_STEP_SUMMARY:-}"
 if [ "$github_actions" = "true" ] && [ -n "$github_summary" ]; then
     {
         echo "### BiliKit quality gate"
+        echo
+        echo "- Artifact policy: \`$artifact_policy\`"
+        echo "- Generation: \`$generation_key\`"
         echo
         echo "| Stage | Result |"
         echo "| --- | --- |"
@@ -217,46 +578,89 @@ record_stage_result() {
     fi
 }
 
+classify_stage_failure() {
+    stage="$1"
+    log_path="${2:-}"
+    stage_status="${3:-1}"
+    if [ "$stage_status" -eq 143 ] && [ "$term_is_timeout" = "1" ]; then
+        echo timeout.inconclusive
+        return
+    fi
+    if [ -n "$log_path" ] && grep -E \
+        'Executed [0-9]+ tests?, with [1-9][0-9]* failures?|Test run with [1-9][0-9]* failures?|Failing tests:|Test case .* failed|✘ Test' \
+        "$log_path" >/dev/null 2>&1; then
+        echo test.assertion
+        return
+    fi
+    if [ -n "$log_path" ] && grep -E -i \
+        'sandbox-exec:.*(Operation not permitted|Permission denied)|sandbox_apply:.*Operation not permitted|(<gate-artifact-root>|DerivedData|ModuleCache|SourcePackages|swiftpm|\.build/).*(Operation not permitted|Permission denied|Read-only file system)|(Operation not permitted|Permission denied|Read-only file system).*(<gate-artifact-root>|DerivedData|ModuleCache|SourcePackages|swiftpm|\.build/)' \
+        "$log_path" >/dev/null 2>&1; then
+        echo sandbox
+        return
+    fi
+    if [ -n "$log_path" ] && grep -E -i \
+        "no such module ['\"]Testing|xcrun: error|requires.*Xcode|SDK.*(not found|unavailable)" \
+        "$log_path" >/dev/null 2>&1; then
+        echo toolchain
+        return
+    fi
+    if [ -n "$log_path" ] && grep -E -i \
+        'CodeSign|provisioning profile|signing certificate|Developer Mode' \
+        "$log_path" >/dev/null 2>&1; then
+        echo signing
+        return
+    fi
+    if [ -n "$log_path" ] && grep -E -i \
+        'Failed to launch.*test|test runner.*failed|test session.*failed|lost connection.*test' \
+        "$log_path" >/dev/null 2>&1; then
+        echo test.infrastructure
+        return
+    fi
+    if [ "$stage" = "app-build-for-testing" ]; then
+        echo build
+    elif [ "$stage" = "static-contracts" ]; then
+        echo configuration
+    elif [ -n "$log_path" ] && grep -E -i \
+        'emit-module command failed|compile command failed|linker command failed|SwiftCompile.*failed' \
+        "$log_path" >/dev/null 2>&1; then
+        echo build
+    else
+        echo unknown
+    fi
+}
+
 run_with_optional_compact_log() {
     stage="$1"
     shift
+    if [ "$github_actions" = "true" ]; then echo "::group::$stage"; fi
 
-    if [ "$github_actions" = "true" ]; then
-        echo "::group::$stage"
+    log_path="$gate_log_dir/$stage.log"
+    if "$@" >"$log_path" 2>&1; then status=0; else status=$?; fi
+    if ! sanitize_gate_log_file "$log_path"; then
+        rm -f -- "$log_path" "$log_path.sanitized" 2>/dev/null || true
+        force_cleanup_fresh=1
+        fail_classification unknown "无法脱敏 Gate 日志；已禁止 retain 并安排精确清理"
     fi
-
     if [ "$compact_logs" = "0" ]; then
-        if "$@"; then
-            status=0
-        else
-            status=$?
-        fi
+        echo "[Gate] $stage 脱敏完整日志如下"
+        LC_ALL=C cut -c 1-360 "$log_path"
+    elif [ "$status" -eq 0 ]; then
+        echo "[Gate] $stage 通过"
     else
-        log_path="$gate_log_dir/$stage.log"
-        if "$@" >"$log_path" 2>&1; then
-            echo "[Gate] $stage 通过"
-            if [ "$fresh_artifacts" = "1" ] && [ "$retain_artifacts" = "1" ]; then
-                echo "[Gate] $stage 完整日志：$log_path"
-            fi
-            status=0
-        else
-            status=$?
-            echo "[Gate] $stage 失败；临时日志末尾如下" >&2
-            tail -n 40 "$log_path" | LC_ALL=C cut -c 1-360 >&2
-            if [ "$fresh_artifacts" = "1" ] && [ "$retain_artifacts" = "1" ]; then
-                echo "[Gate] $stage 完整日志：$log_path" >&2
-            fi
-        fi
+        echo "[Gate] $stage 失败；脱敏日志末尾如下" >&2
+        tail -n 40 "$log_path" | LC_ALL=C cut -c 1-360 >&2
+    fi
+    if [ "$fresh_artifacts" = "1" ] && [ "$retain_artifacts" = "1" ]; then
+        echo "[Gate] $stage 脱敏完整日志：$log_path"
     fi
 
-    if [ "$github_actions" = "true" ]; then
-        echo "::endgroup::"
-    fi
-
+    if [ "$github_actions" = "true" ]; then echo "::endgroup::"; fi
     if [ "$status" -eq 0 ]; then
-        record_stage_result "$stage" "passed"
+        record_stage_result "$stage" passed
     else
-        record_stage_result "$stage" "failed"
+        classification=$(classify_stage_failure "$stage" "$log_path" "$status")
+        echo "[Gate] classification=$classification stage=$stage exit=$status" >&2
+        record_stage_result "$stage" "failed ($classification)"
     fi
     return "$status"
 }
@@ -274,13 +678,17 @@ echo "[Gate] 静态契约"
 run_with_optional_compact_log static-contracts run_static_contracts
 
 if [ "$mode" = "static" ]; then
-    echo "[Gate] static 通过"
+    echo "[Gate] static 通过（artifact-policy=${artifact_policy}）"
     exit 0
 fi
 
 echo "[Gate] Swift Package"
 run_with_optional_compact_log \
     swift-package \
+    env \
+    HOME="$swiftpm_home_path" \
+    CFFIXED_USER_HOME="$swiftpm_home_path" \
+    XDG_CACHE_HOME="$swiftpm_home_path/.cache" \
     xcrun swift test \
     --package-path Packages/BiliKitCore \
     --scratch-path "$swiftpm_scratch_path" \
@@ -290,16 +698,17 @@ run_with_optional_compact_log \
     --manifest-cache local
 
 if [ "$mode" = "package" ]; then
-    echo "[Gate] package 通过"
+    echo "[Gate] package 通过（artifact-policy=${artifact_policy}）"
     exit 0
 fi
-
-xcodebuild -version >/dev/null 2>&1 \
-    || fail "app 模式需要完整 Xcode；请先切换 xcode-select 或显式设置 DEVELOPER_DIR"
 
 echo "[Gate] App build-for-testing"
 run_with_optional_compact_log \
     app-build-for-testing \
+    env \
+    HOME="$xcode_user_home_path" \
+    CFFIXED_USER_HOME="$xcode_user_home_path" \
+    XDG_CACHE_HOME="$xcode_user_home_path/.cache" \
     xcodebuild \
     -project BiliKitMac.xcodeproj \
     -scheme BiliKitMac \
@@ -316,6 +725,10 @@ run_with_optional_compact_log \
 echo "[Gate] App unit tests"
 run_with_optional_compact_log \
     app-unit-tests \
+    env \
+    HOME="$xcode_user_home_path" \
+    CFFIXED_USER_HOME="$xcode_user_home_path" \
+    XDG_CACHE_HOME="$xcode_user_home_path/.cache" \
     xcodebuild \
     -project BiliKitMac.xcodeproj \
     -scheme BiliKitMac \
@@ -330,4 +743,4 @@ run_with_optional_compact_log \
     test-without-building \
     -only-testing:BiliKitMacTests
 
-echo "[Gate] app 通过"
+echo "[Gate] app 通过（artifact-policy=${artifact_policy}）"

--- a/Scripts/test-quality-gate-artifacts.sh
+++ b/Scripts/test-quality-gate-artifacts.sh
@@ -1,0 +1,644 @@
+#!/bin/sh
+
+set -eu
+
+fail() {
+    echo "质量 Gate 产物契约测试失败：$1" >&2
+    exit 1
+}
+
+assert_contains() {
+    haystack="$1"
+    needle="$2"
+    description="$3"
+    printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null \
+        || fail "$description"
+}
+
+assert_not_contains() {
+    haystack="$1"
+    needle="$2"
+    description="$3"
+    if printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
+        fail "$description"
+    fi
+}
+
+expect_failure() {
+    description="$1"
+    shift
+    set +e
+    last_output=$(run_gate "$@" 2>&1)
+    last_status=$?
+    set -e
+    [ "$last_status" -ne 0 ] || fail "$description"
+}
+
+generation_from_output() {
+    printf '%s\n' "$1" |
+        sed -n 's/^\[Gate\] checkout-key=[^ ]* generation=\([0-9a-f]*\)$/\1/p' |
+        head -n 1
+}
+
+artifact_root_from_output() {
+    printf '%s\n' "$1" |
+        sed -n 's/^\[Gate\] SwiftPM scratch：\(.*\)\/swiftpm-scratch$/\1/p' |
+        head -n 1
+}
+
+retained_root_from_output() {
+    printf '%s\n' "$1" |
+        sed -n 's/^\[Gate\] fresh 诊断产物已保留：\(.*\)$/\1/p' |
+        head -n 1
+}
+
+test_base=$(mktemp -d "${TMPDIR:-/tmp}/BiliKit gate contract.XXXXXX")
+trap 'rm -rf -- "$test_base"' EXIT HUP INT TERM
+test_base=$(CDPATH= cd -- "$test_base" && pwd -P)
+
+fixture_root="$test_base/repository with spaces"
+fixture_home="$test_base/user home"
+fixture_tmp="$test_base/private tmp"
+fixture_bin="$test_base/fake bin"
+fixture_developer="$test_base/Xcode Contract.app/Contents/Developer"
+mkdir -p \
+    "$fixture_root/Scripts" \
+    "$fixture_root/Packages/BiliKitCore/Sources/Contract" \
+    "$fixture_root/BiliKitMac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm" \
+    "$fixture_root/BiliKitMac.xcodeproj/xcshareddata/xcschemes" \
+    "$fixture_home/.cache/clang" \
+    "$fixture_tmp" \
+    "$fixture_bin" \
+    "$fixture_developer"
+
+cp Scripts/run-quality-gates.sh "$fixture_root/Scripts/run-quality-gates.sh"
+cp Packages/BiliKitCore/Package.swift "$fixture_root/Packages/BiliKitCore/Package.swift"
+cp Packages/BiliKitCore/Package.resolved "$fixture_root/Packages/BiliKitCore/Package.resolved"
+cp BiliKitMac.xcodeproj/project.pbxproj "$fixture_root/BiliKitMac.xcodeproj/project.pbxproj"
+cp \
+    BiliKitMac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved \
+    "$fixture_root/BiliKitMac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+cp \
+    BiliKitMac.xcodeproj/xcshareddata/xcschemes/BiliKitMac.xcscheme \
+    "$fixture_root/BiliKitMac.xcodeproj/xcshareddata/xcschemes/BiliKitMac.xcscheme"
+
+printf 'user-cache-sentinel\n' >"$fixture_home/.cache/clang/sentinel"
+
+for contract_script in check-secrets.sh check-project-contract.sh check-swift-format.sh; do
+    printf '%s\n' '#!/bin/sh' 'exit 0' >"$fixture_root/Scripts/$contract_script"
+done
+
+cat >"$fixture_root/Scripts/check-architecture.sh" <<'EOF'
+#!/bin/sh
+if [ "${FAKE_BLOCK_STAGE:-0}" = "1" ]; then
+    printf '%s\n' "$$" >"$FAKE_READY_FILE"
+    while kill -0 "$PPID" 2>/dev/null; do
+        sleep 0.01
+    done
+    exit 0
+fi
+if [ -n "${FAKE_SIGNAL:-}" ]; then
+    kill -s "$FAKE_SIGNAL" "$PPID"
+    exit 0
+fi
+if [ "${FAKE_STATIC_FAILURE:-0}" = "1" ]; then
+    printf '%s\n' "${FAKE_STATIC_TEXT:-static contract failed}" >&2
+    exit "${FAKE_STATIC_STATUS:-1}"
+fi
+exit 0
+EOF
+
+cat >"$fixture_bin/git" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+
+cat >"$fixture_bin/xcodebuild" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = "-version" ]; then
+    printf '%s\n' "${FAKE_XCODE_VERSION:-Xcode Contract 1.0}" 'Build version CONTRACT1'
+    exit 0
+fi
+case "${DEVELOPER_DIR:-}" in */Xcode\ Contract.app/Contents/Developer) ;; *) exit 91 ;; esac
+case "${HOME:-}" in */xcode-user-home) artifact_root=${HOME%/xcode-user-home} ;; *) exit 92 ;; esac
+[ "${CFFIXED_USER_HOME:-}" = "$HOME" ] || exit 93
+[ "${XDG_CACHE_HOME:-}" = "$HOME/.cache" ] || exit 94
+[ "${CLANG_MODULE_CACHE_PATH:-}" = "$artifact_root/module-cache/clang" ] || exit 95
+[ "${SWIFT_MODULE_CACHE_PATH:-}" = "$artifact_root/module-cache/swift" ] || exit 96
+argument_value() {
+    expected_name="$1"
+    shift
+    while [ "$#" -gt 1 ]; do
+        if [ "$1" = "$expected_name" ]; then
+            printf '%s\n' "$2"
+            return 0
+        fi
+        shift
+    done
+    return 1
+}
+derived_data=$(argument_value -derivedDataPath "$@") || exit 97
+package_path=$(argument_value -clonedSourcePackagesDirPath "$@") || exit 98
+package_cache=$(argument_value -packageCachePath "$@") || exit 99
+[ "$derived_data" = "$artifact_root/xcode-derived" ] || exit 100
+[ "$package_path" = "$artifact_root/xcode-packages" ] || exit 101
+[ "$package_cache" = "$artifact_root/xcode-package-cache" ] || exit 102
+case " $* " in
+    *' build-for-testing '*)
+        [ "${FAKE_APP_BUILD_STATUS:-0}" -eq 0 ] || {
+            printf '%s\n' "${FAKE_APP_BUILD_TEXT:-compile command failed}" >&2
+            exit "$FAKE_APP_BUILD_STATUS"
+        }
+        ;;
+    *' test-without-building '*)
+        [ "${FAKE_APP_TEST_STATUS:-0}" -eq 0 ] || {
+            printf '%s\n' "${FAKE_APP_TEST_TEXT:-test runner failed}" >&2
+            exit "$FAKE_APP_TEST_STATUS"
+        }
+        ;;
+esac
+exit 0
+EOF
+
+cat >"$fixture_bin/xcrun" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = "swift" ] && [ "${2:-}" = "--version" ]; then
+    printf '%s\n' "${FAKE_SWIFT_VERSION:-Apple Swift Contract 1.0}"
+    exit 0
+fi
+if [ "${1:-}" = "swift" ] && [ "${2:-}" = "test" ]; then
+    case "${DEVELOPER_DIR:-}" in */Xcode\ Contract.app/Contents/Developer) ;; *) exit 91 ;; esac
+    case "${HOME:-}" in */swiftpm-home) artifact_root=${HOME%/swiftpm-home} ;; *) exit 92 ;; esac
+    [ "${CFFIXED_USER_HOME:-}" = "$HOME" ] || exit 93
+    [ "${XDG_CACHE_HOME:-}" = "$HOME/.cache" ] || exit 94
+    [ "${CLANG_MODULE_CACHE_PATH:-}" = "$artifact_root/module-cache/clang" ] || exit 95
+    [ "${SWIFT_MODULE_CACHE_PATH:-}" = "$artifact_root/module-cache/swift" ] || exit 96
+    [ "${SWIFTPM_MODULECACHE_OVERRIDE:-}" = "$artifact_root/module-cache/swift" ] || exit 97
+    argument_value() {
+        expected_name="$1"
+        shift
+        while [ "$#" -gt 1 ]; do
+            if [ "$1" = "$expected_name" ]; then
+                printf '%s\n' "$2"
+                return 0
+            fi
+            shift
+        done
+        return 1
+    }
+    scratch_path=$(argument_value --scratch-path "$@") || exit 98
+    cache_path=$(argument_value --cache-path "$@") || exit 99
+    config_path=$(argument_value --config-path "$@") || exit 100
+    security_path=$(argument_value --security-path "$@") || exit 101
+    [ "$scratch_path" = "$artifact_root/swiftpm-scratch" ] || exit 102
+    [ "$cache_path" = "$artifact_root/swiftpm-cache" ] || exit 103
+    [ "$config_path" = "$artifact_root/swiftpm-config" ] || exit 104
+    [ "$security_path" = "$artifact_root/swiftpm-security" ] || exit 105
+    if [ "${FAKE_SANITIZER_FAILURE:-0}" = "1" ]; then
+        for log_dir in "$artifact_root"/logs.*; do
+            [ -d "$log_dir" ] || continue
+            mkdir "$log_dir/swift-package.log.sanitized"
+        done
+    fi
+    [ "${FAKE_PACKAGE_STATUS:-0}" -eq 0 ] || {
+        printf '%s\n' "${FAKE_PACKAGE_TEXT:-package command failed}" >&2
+        exit "$FAKE_PACKAGE_STATUS"
+    }
+    exit 0
+fi
+exit 0
+EOF
+
+cat >"$fixture_bin/xcode-select" <<'EOF'
+#!/bin/sh
+printf 'called\n' >"$FAKE_XCODE_SELECT_SENTINEL"
+exit 99
+EOF
+
+chmod +x \
+    "$fixture_root"/Scripts/*.sh \
+    "$fixture_bin/xcodebuild" \
+    "$fixture_bin/xcrun" \
+    "$fixture_bin/git" \
+    "$fixture_bin/xcode-select"
+
+run_gate() {
+    (
+        cd "$fixture_root"
+        env \
+            PATH="$fixture_bin:$PATH" \
+            HOME="$fixture_home" \
+            TMPDIR="$fixture_tmp" \
+            DEVELOPER_DIR="$fixture_developer" \
+            FAKE_XCODE_SELECT_SENTINEL="$test_base/xcode-select-called" \
+            FAKE_XCODE_VERSION="${FAKE_XCODE_VERSION:-Xcode Contract 1.0}" \
+            FAKE_SWIFT_VERSION="${FAKE_SWIFT_VERSION:-Apple Swift Contract 1.0}" \
+            FAKE_STATIC_FAILURE="${FAKE_STATIC_FAILURE:-0}" \
+            FAKE_STATIC_TEXT="${FAKE_STATIC_TEXT:-}" \
+            FAKE_STATIC_STATUS="${FAKE_STATIC_STATUS:-1}" \
+            FAKE_SIGNAL="${FAKE_SIGNAL:-}" \
+            FAKE_BLOCK_STAGE=0 \
+            FAKE_READY_FILE="$test_base/unused-ready" \
+            FAKE_PACKAGE_STATUS="${FAKE_PACKAGE_STATUS:-0}" \
+            FAKE_PACKAGE_TEXT="${FAKE_PACKAGE_TEXT:-}" \
+            FAKE_SANITIZER_FAILURE="${FAKE_SANITIZER_FAILURE:-0}" \
+            FAKE_APP_BUILD_STATUS="${FAKE_APP_BUILD_STATUS:-0}" \
+            FAKE_APP_BUILD_TEXT="${FAKE_APP_BUILD_TEXT:-}" \
+            FAKE_APP_TEST_STATUS="${FAKE_APP_TEST_STATUS:-0}" \
+            FAKE_APP_TEST_TEXT="${FAKE_APP_TEST_TEXT:-}" \
+            BILIKIT_GATE_PRINT_PATHS_ONLY="${BILIKIT_GATE_PRINT_PATHS_ONLY:-0}" \
+            BILIKIT_GATE_RETAIN_ARTIFACTS="${BILIKIT_GATE_RETAIN_ARTIFACTS:-0}" \
+            BILIKIT_GATE_TERM_IS_TIMEOUT="${BILIKIT_GATE_TERM_IS_TIMEOUT:-0}" \
+            BILIKIT_COMPACT_LOGS="${BILIKIT_COMPACT_LOGS:-1}" \
+            BILIKIT_DERIVED_DATA_PATH="${BILIKIT_DERIVED_DATA_PATH:-}" \
+            sh Scripts/run-quality-gates.sh "$@"
+    )
+}
+
+run_gate_process() {
+    cd "$fixture_root"
+    exec env \
+        PATH="$fixture_bin:$PATH" \
+        HOME="$fixture_home" \
+        TMPDIR="$fixture_tmp" \
+        DEVELOPER_DIR="$fixture_developer" \
+        FAKE_XCODE_SELECT_SENTINEL="$test_base/xcode-select-called" \
+        FAKE_XCODE_VERSION='Xcode Contract 1.0' \
+        FAKE_SWIFT_VERSION='Apple Swift Contract 1.0' \
+        FAKE_STATIC_FAILURE=0 \
+        FAKE_STATIC_TEXT= \
+        FAKE_STATIC_STATUS=1 \
+        FAKE_SIGNAL= \
+        FAKE_BLOCK_STAGE=1 \
+        FAKE_READY_FILE="$test_base/signal-ready" \
+        FAKE_PACKAGE_STATUS=0 \
+        FAKE_PACKAGE_TEXT= \
+        FAKE_SANITIZER_FAILURE=0 \
+        FAKE_APP_BUILD_STATUS=0 \
+        FAKE_APP_BUILD_TEXT= \
+        FAKE_APP_TEST_STATUS=0 \
+        FAKE_APP_TEST_TEXT= \
+        BILIKIT_GATE_PRINT_PATHS_ONLY=0 \
+        BILIKIT_GATE_RETAIN_ARTIFACTS=0 \
+        BILIKIT_GATE_TERM_IS_TIMEOUT="${BILIKIT_GATE_TERM_IS_TIMEOUT:-0}" \
+        BILIKIT_COMPACT_LOGS=1 \
+        BILIKIT_DERIVED_DATA_PATH= \
+        sh Scripts/run-quality-gates.sh "$@"
+}
+
+run_signal_case() {
+    signal_name="$1"
+    timeout_flag="$2"
+    signal_output_file="$test_base/signal-$signal_name-$timeout_flag.log"
+    rm -f "$test_base/signal-ready"
+    BILIKIT_GATE_TERM_IS_TIMEOUT="$timeout_flag" \
+        run_gate_process static closure >"$signal_output_file" 2>&1 &
+    gate_pid=$!
+    observed_setup=0
+    poll_count=0
+    while [ "$poll_count" -lt 500 ]; do
+        if [ -f "$test_base/signal-ready" ]; then
+            observed_setup=1
+            break
+        fi
+        kill -0 "$gate_pid" 2>/dev/null || break
+        poll_count=$((poll_count + 1))
+        sleep 0.01
+    done
+    [ "$observed_setup" -eq 1 ] || fail "$signal_name 测试没有观察到 Gate setup 事件"
+    stage_pid=$(cat "$test_base/signal-ready")
+    kill -s "$signal_name" "$gate_pid"
+    kill -s "$signal_name" "$stage_pid" 2>/dev/null || true
+    set +e
+    wait "$gate_pid"
+    signal_status=$?
+    set -e
+    signal_output=$(cat "$signal_output_file")
+    [ "$signal_status" -ne 0 ] || fail "$signal_name 没有中断 Gate"
+}
+
+# Stable generation identity and paths containing spaces.
+baseline_output=$(BILIKIT_GATE_PRINT_PATHS_ONLY=1 run_gate static iteration)
+baseline_generation=$(generation_from_output "$baseline_output")
+[ -n "$baseline_generation" ] || fail "没有输出 baseline generation"
+assert_contains "$baseline_output" "$fixture_root/.build/" "路径含空格时没有使用 checkout-local 根"
+
+reuse_output=$(BILIKIT_GATE_PRINT_PATHS_ONLY=1 run_gate static iteration)
+[ "$(generation_from_output "$reuse_output")" = "$baseline_generation" ] \
+    || fail "相同输入没有复用 iteration generation"
+
+static_success_output=$(run_gate static iteration)
+assert_contains "$static_success_output" 'static 通过（artifact-policy=iteration）' "完整 static 成功路径没有正确结束"
+
+printf 'let sourceOnlyChange = true\n' >"$fixture_root/Packages/BiliKitCore/Sources/Contract/Source.swift"
+source_output=$(BILIKIT_GATE_PRINT_PATHS_ONLY=1 run_gate static iteration)
+[ "$(generation_from_output "$source_output")" = "$baseline_generation" ] \
+    || fail "普通源码变化不应切换 generation"
+
+printf '\n// package identity change\n' >>"$fixture_root/Packages/BiliKitCore/Package.swift"
+package_output=$(BILIKIT_GATE_PRINT_PATHS_ONLY=1 run_gate static iteration)
+package_generation=$(generation_from_output "$package_output")
+[ "$package_generation" != "$baseline_generation" ] || fail "Package.swift 变化没有切换 generation"
+
+toolchain_output=$(
+    FAKE_XCODE_VERSION='Xcode Contract 2.0' \
+    BILIKIT_GATE_PRINT_PATHS_ONLY=1 \
+    run_gate static iteration
+)
+toolchain_generation=$(generation_from_output "$toolchain_output")
+[ "$toolchain_generation" != "$package_generation" ] || fail "Xcode 变化没有切换 generation"
+
+printf '\n// project identity change\n' >>"$fixture_root/BiliKitMac.xcodeproj/project.pbxproj"
+project_output=$(
+    FAKE_XCODE_VERSION='Xcode Contract 2.0' \
+    BILIKIT_GATE_PRINT_PATHS_ONLY=1 \
+    run_gate static iteration
+)
+[ "$(generation_from_output "$project_output")" != "$toolchain_generation" ] \
+    || fail "Xcode 工程变化没有切换 generation"
+
+# Arbitrary DerivedData and global toolchain changes are rejected or untouched.
+external_derived="$test_base/external-derived"
+set +e
+last_output=$(
+    BILIKIT_DERIVED_DATA_PATH="$external_derived" \
+    BILIKIT_GATE_PRINT_PATHS_ONLY=1 \
+    run_gate static iteration 2>&1
+)
+last_status=$?
+set -e
+[ "$last_status" -ne 0 ] || fail "外部 DerivedData 被接受"
+assert_contains "$last_output" 'classification=configuration' "外部 DerivedData 没有归类 configuration"
+[ ! -e "$external_derived" ] || fail "拒绝外部 DerivedData 前已经创建了该路径"
+[ ! -e "$test_base/xcode-select-called" ] || fail "Gate 调用了全局 xcode-select"
+
+# Fresh uniqueness, mode, retain, success cleanup and exact retained cleanup.
+fresh_one_output=$(
+    BILIKIT_GATE_PRINT_PATHS_ONLY=1 \
+    BILIKIT_GATE_RETAIN_ARTIFACTS=1 \
+    run_gate static closure
+)
+fresh_one=$(retained_root_from_output "$fresh_one_output")
+[ -d "$fresh_one" ] || fail "closure retain 没有保留 fresh root"
+[ "$(/usr/bin/stat -f '%Lp' "$fresh_one")" = "700" ] || fail "fresh root 不是 mode 0700"
+assert_contains "$fresh_one_output" 'artifact-policy=closure' "closure 输出没有独立 policy"
+
+fresh_two_output=$(
+    BILIKIT_GATE_PRINT_PATHS_ONLY=1 \
+    BILIKIT_GATE_RETAIN_ARTIFACTS=1 \
+    run_gate static closure
+)
+fresh_two=$(retained_root_from_output "$fresh_two_output")
+[ "$fresh_one" != "$fresh_two" ] || fail "两次 fresh root 不唯一"
+
+run_gate cleanup-retained "$fresh_one" >/dev/null
+[ ! -e "$fresh_one" ] || fail "cleanup-retained 没有删除精确 fresh root"
+run_gate cleanup-retained "$fresh_two" >/dev/null
+[ ! -e "$fresh_two" ] || fail "cleanup-retained 没有删除第二个 fresh root"
+
+fresh_success_output=$(BILIKIT_GATE_PRINT_PATHS_ONLY=1 run_gate static closure)
+fresh_success_root=$(artifact_root_from_output "$fresh_success_output")
+[ -n "$fresh_success_root" ] || fail "无法取得成功 closure root"
+[ ! -e "$fresh_success_root" ] || fail "成功 closure 后没有清理 fresh root"
+
+# Failure, INT, TERM and timeout-attributed TERM all clean their exact fresh root.
+set +e
+fresh_failure_output=$(FAKE_STATIC_FAILURE=1 run_gate static fresh 2>&1)
+fresh_failure_status=$?
+set -e
+[ "$fresh_failure_status" -ne 0 ] || fail "注入的 fresh failure 没有失败"
+fresh_failure_root=$(artifact_root_from_output "$fresh_failure_output")
+[ ! -e "$fresh_failure_root" ] || fail "失败后没有清理 fresh root"
+assert_contains "$fresh_failure_output" 'classification=configuration' "静态失败没有归类 configuration"
+
+set +e
+int_output=$(FAKE_SIGNAL=INT run_gate static closure 2>&1)
+int_status=$?
+set -e
+[ "$int_status" -ne 0 ] || fail "INT 没有中断 Gate"
+int_root=$(artifact_root_from_output "$int_output")
+[ ! -e "$int_root" ] || fail "INT 后没有清理 fresh root"
+
+run_signal_case TERM 0
+term_output="$signal_output"
+term_root=$(artifact_root_from_output "$term_output")
+[ ! -e "$term_root" ] || fail "TERM 后没有清理 fresh root"
+
+set +e
+timeout_output=$(
+    FAKE_STATIC_FAILURE=1 \
+    FAKE_STATIC_STATUS=143 \
+    BILIKIT_GATE_TERM_IS_TIMEOUT=1 \
+    run_gate static closure 2>&1
+)
+timeout_status=$?
+set -e
+[ "$timeout_status" -ne 0 ] || fail "timeout fixture 没有失败"
+timeout_root=$(artifact_root_from_output "$timeout_output")
+[ ! -e "$timeout_root" ] || fail "timeout TERM 后没有清理 fresh root"
+assert_contains "$timeout_output" 'classification=timeout.inconclusive' "timeout 分类不透明"
+
+# Evidence-based stage classification.
+set +e
+sandbox_output=$(
+    FAKE_STATIC_FAILURE=1 \
+    FAKE_STATIC_TEXT='sandbox-exec: Operation not permitted' \
+    run_gate static fresh 2>&1
+)
+sandbox_status=$?
+set -e
+[ "$sandbox_status" -ne 0 ] || fail "sandbox fixture 没有失败"
+assert_contains "$sandbox_output" 'classification=sandbox' "sandbox 证据没有正确分类"
+
+set +e
+toolchain_failure_output=$(
+    FAKE_STATIC_FAILURE=1 \
+    FAKE_STATIC_TEXT="no such module 'Testing'" \
+    run_gate static fresh 2>&1
+)
+toolchain_failure_status=$?
+set -e
+[ "$toolchain_failure_status" -ne 0 ] || fail "toolchain fixture 没有失败"
+assert_contains "$toolchain_failure_output" 'classification=toolchain' "Testing 缺失没有正确分类"
+
+set +e
+assertion_output=$(
+    FAKE_PACKAGE_STATUS=1 \
+    FAKE_PACKAGE_TEXT="Failing tests: Test case 'ContractTests/example()' failed" \
+    run_gate package fresh 2>&1
+)
+assertion_status=$?
+set -e
+[ "$assertion_status" -ne 0 ] || fail "assertion fixture 没有失败"
+assert_contains "$assertion_output" 'classification=test.assertion' "实际 assertion 没有正确分类"
+
+set +e
+assertion_permission_output=$(
+    FAKE_PACKAGE_STATUS=1 \
+    FAKE_PACKAGE_TEXT="Failing tests: Test case 'ContractTests/permissionText()' failed: Operation not permitted" \
+    run_gate package fresh 2>&1
+)
+assertion_permission_status=$?
+set -e
+[ "$assertion_permission_status" -ne 0 ] || fail "含权限文本的 assertion fixture 没有失败"
+assert_contains "$assertion_permission_output" 'classification=test.assertion' "断言被宽泛权限文本误归类为 sandbox"
+
+set +e
+build_output=$(
+    FAKE_APP_BUILD_STATUS=1 \
+    FAKE_APP_BUILD_TEXT='compile command failed' \
+    run_gate app fresh 2>&1
+)
+build_status=$?
+set -e
+[ "$build_status" -ne 0 ] || fail "build fixture 没有失败"
+assert_contains "$build_output" 'classification=build' "build failure 没有正确分类"
+
+set +e
+infrastructure_output=$(
+    FAKE_APP_TEST_STATUS=1 \
+    FAKE_APP_TEST_TEXT='Failed to launch test runner' \
+    run_gate app fresh 2>&1
+)
+infrastructure_status=$?
+set -e
+[ "$infrastructure_status" -ne 0 ] || fail "test infrastructure fixture 没有失败"
+assert_contains "$infrastructure_output" 'classification=test.infrastructure' "测试基础设施没有正确分类"
+
+set +e
+signing_output=$(
+    FAKE_APP_BUILD_STATUS=1 \
+    FAKE_APP_BUILD_TEXT='CodeSign failed: signing certificate unavailable' \
+    run_gate app fresh 2>&1
+)
+signing_status=$?
+set -e
+[ "$signing_status" -ne 0 ] || fail "signing fixture 没有失败"
+assert_contains "$signing_output" 'classification=signing' "签名证据没有正确分类"
+
+set +e
+unknown_output=$(
+    FAKE_PACKAGE_STATUS=1 \
+    FAKE_PACKAGE_TEXT='unclassified package failure' \
+    run_gate package fresh 2>&1
+)
+unknown_status=$?
+set -e
+[ "$unknown_status" -ne 0 ] || fail "unknown fixture 没有失败"
+assert_contains "$unknown_output" 'classification=unknown' "证据不足时没有保持 unknown"
+
+# Retained compact logs are sanitized before they are exposed.
+secret_text="$fixture_root $fixture_home https://example.invalid/private?token=abc token=secret-value
+Authorization: Bearer header-secret
+Cookie: session=cookie-secret; token=cookie-token
+AUTHORIZATION: Bearer uppercase-auth-secret
+COOKIE: session=uppercase-cookie-secret
+{"token":"json-token-secret","refresh_token":"json-refresh-secret","qrcode_key":"json-qr-secret"}
+Test case 'ContractTests/example()' passed on 'My Mac - BiliKit (123)'
+/var/folders/example/T/BiliKit-quality-gate.ABC123/xcode-derived"
+set +e
+redacted_output=$(
+    FAKE_STATIC_FAILURE=1 \
+    FAKE_STATIC_TEXT="$secret_text" \
+    BILIKIT_GATE_RETAIN_ARTIFACTS=1 \
+    run_gate static fresh 2>&1
+)
+redacted_status=$?
+set -e
+[ "$redacted_status" -ne 0 ] || fail "脱敏 fixture 没有失败"
+redacted_root=$(retained_root_from_output "$redacted_output")
+[ -d "$redacted_root" ] || fail "失败 retain 没有保留诊断根"
+redacted_log=$(find "$redacted_root" -path '*/logs.*/static-contracts.log' -type f -print | head -n 1)
+[ -f "$redacted_log" ] || fail "没有找到 retained 脱敏日志"
+redacted_contents=$(cat "$redacted_log")
+assert_not_contains "$redacted_contents" "$fixture_root" "日志泄露 checkout 路径"
+assert_not_contains "$redacted_contents" "$fixture_home" "日志泄露 HOME 路径"
+assert_not_contains "$redacted_contents" 'https://example.invalid' "日志泄露完整 URL"
+assert_not_contains "$redacted_contents" 'secret-value' "日志泄露 token"
+assert_not_contains "$redacted_contents" 'header-secret' "日志泄露 Authorization header"
+assert_not_contains "$redacted_contents" 'cookie-secret' "日志泄露 Cookie header"
+assert_not_contains "$redacted_contents" 'uppercase-auth-secret' "日志泄露全大写 Authorization header"
+assert_not_contains "$redacted_contents" 'uppercase-cookie-secret' "日志泄露全大写 Cookie header"
+assert_not_contains "$redacted_contents" 'json-token-secret' "日志泄露 JSON token"
+assert_not_contains "$redacted_contents" 'json-refresh-secret' "日志泄露 JSON refresh_token"
+assert_not_contains "$redacted_contents" 'json-qr-secret' "日志泄露 JSON qrcode_key"
+assert_not_contains "$redacted_contents" 'My Mac' "日志泄露测试 destination"
+assert_not_contains "$redacted_contents" '/var/folders/example' "日志泄露 fresh root 路径别名"
+assert_contains "$redacted_contents" '<redacted-url>' "日志没有留下可解释的 URL 脱敏标记"
+run_gate cleanup-retained "$redacted_root" >/dev/null
+
+# Disabling compact output still captures, sanitizes and classifies from the log.
+set +e
+noncompact_output=$(
+    FAKE_PACKAGE_STATUS=1 \
+    FAKE_PACKAGE_TEXT="$secret_text
+Failing tests: Test case 'ContractTests/noncompact()' failed" \
+    BILIKIT_COMPACT_LOGS=0 \
+    run_gate package fresh 2>&1
+)
+noncompact_status=$?
+set -e
+[ "$noncompact_status" -ne 0 ] || fail "noncompact 脱敏 fixture 没有失败"
+assert_contains "$noncompact_output" 'classification=test.assertion' "noncompact 输出没有保留日志分类"
+assert_not_contains "$noncompact_output" "$fixture_root" "noncompact 输出泄露 checkout 路径"
+assert_not_contains "$noncompact_output" "$fixture_home" "noncompact 输出泄露 HOME 路径"
+assert_not_contains "$noncompact_output" 'secret-value' "noncompact 输出泄露 token"
+assert_not_contains "$noncompact_output" 'header-secret' "noncompact 输出泄露 Authorization header"
+assert_not_contains "$noncompact_output" 'cookie-secret' "noncompact 输出泄露 Cookie header"
+assert_not_contains "$noncompact_output" 'uppercase-auth-secret' "noncompact 输出泄露全大写 Authorization header"
+assert_not_contains "$noncompact_output" 'uppercase-cookie-secret' "noncompact 输出泄露全大写 Cookie header"
+assert_not_contains "$noncompact_output" 'json-token-secret' "noncompact 输出泄露 JSON token"
+
+# Sanitizer failure overrides retain and removes the exact fresh root.
+set +e
+sanitizer_failure_output=$(
+    FAKE_SANITIZER_FAILURE=1 \
+    BILIKIT_GATE_RETAIN_ARTIFACTS=1 \
+    run_gate package fresh 2>&1
+)
+sanitizer_failure_status=$?
+set -e
+[ "$sanitizer_failure_status" -ne 0 ] || fail "注入的 sanitizer failure 没有失败"
+sanitizer_failure_root=$(artifact_root_from_output "$sanitizer_failure_output")
+[ -n "$sanitizer_failure_root" ] || fail "无法取得 sanitizer failure 的 fresh root"
+[ ! -e "$sanitizer_failure_root" ] || fail "sanitizer failure 后仍保留 fresh root"
+assert_not_contains "$sanitizer_failure_output" 'fresh 诊断产物已保留' "sanitizer failure 没有覆盖 retain"
+
+# Cleanup never accepts broad paths and never touches the user cache sentinel.
+expect_failure "cleanup-retained 接受了 HOME" cleanup-retained "$fixture_home"
+assert_contains "$last_output" 'classification=configuration' "拒绝 HOME cleanup 没有归类 configuration"
+[ "$(cat "$fixture_home/.cache/clang/sentinel")" = 'user-cache-sentinel' ] \
+    || fail "Gate 触碰了用户级 module cache"
+
+# Existing marker tampering and component symlink escape are rejected before writes.
+tamper_baseline_output=$(BILIKIT_GATE_PRINT_PATHS_ONLY=1 run_gate static iteration)
+current_artifact_root=$(artifact_root_from_output "$tamper_baseline_output")
+generation_marker="$current_artifact_root/.bilikit-quality-gate-generation-root"
+cp "$generation_marker" "$generation_marker.backup"
+printf 'schema=tampered\n' >"$generation_marker"
+expect_failure "generation marker 篡改被接受" static iteration
+assert_contains "$last_output" 'classification=configuration' "generation marker 篡改没有归类 configuration"
+mv "$generation_marker.backup" "$generation_marker"
+
+external_cache="$test_base/external-component-cache"
+mkdir "$external_cache"
+rm -rf "$current_artifact_root/swiftpm-cache"
+ln -s "$external_cache" "$current_artifact_root/swiftpm-cache"
+expect_failure "组件 symlink 逃逸被接受" static iteration
+assert_contains "$last_output" 'classification=configuration' "组件 symlink 逃逸没有归类 configuration"
+[ -z "$(find "$external_cache" -mindepth 1 -print -quit)" ] || fail "Gate 通过 symlink 写入外部目录"
+
+iteration_root=$(artifact_root_from_output "$baseline_output" | sed 's:/generations/[^/]*$::')
+[ -d "$iteration_root" ] || fail "iteration root 不存在"
+run_gate cleanup-iteration >/dev/null
+[ ! -e "$iteration_root" ] || fail "cleanup-iteration 没有删除当前 checkout 精确根"
+
+external_build_root="$test_base/external-build-root"
+mkdir "$external_build_root"
+rmdir "$fixture_root/.build/bilikit-quality-gates" "$fixture_root/.build"
+ln -s "$external_build_root" "$fixture_root/.build"
+expect_failure "checkout-local .build symlink 被接受" static iteration
+assert_contains "$last_output" 'classification=configuration' ".build symlink 没有归类 configuration"
+[ -z "$(find "$external_build_root" -mindepth 1 -print -quit)" ] || fail "拒绝 .build symlink 前已写入外部目录"
+
+echo "质量 Gate 产物契约测试通过"

--- a/docs/development/QUALITY-GATES.md
+++ b/docs/development/QUALITY-GATES.md
@@ -20,36 +20,85 @@ sh Scripts/run-quality-gates.sh app
 
 ## 构建产物生命周期
 
-Gate 默认使用适合日常迭代的稳定缓存。缓存位于当前 checkout 的
-`.build/bilikit-quality-gates/<checkout-key>/`；`checkout-key` 来自 canonical checkout
-路径。同一 checkout 会复用 SwiftPM scratch、Xcode DerivedData、Xcode package checkout
-以及 Clang／Swift module cache，不同 worktree 不共享这些可变状态。删除 checkout 时，这些
-默认产物也随之进入同一清理边界。
-
-验收或排查缓存污染时使用 fresh 模式：
+Gate 把检查范围与产物策略分开。默认策略是适合日常开发的 `iteration`：
 
 ```sh
-BILIKIT_GATE_FRESH=1 sh Scripts/run-quality-gates.sh app
+sh Scripts/run-quality-gates.sh app iteration
 ```
 
-fresh 模式把 SwiftPM、Xcode、module cache 和精简日志都放入一次唯一、权限为 `0700` 的
-临时根。脚本在成功、失败、`HUP`、`INT` 和 `TERM` 退出路径上验证 marker 与精确路径后清理
-该根。需要保留失败现场时，唯一保留开关为：
+省略第二个参数仍表示 `iteration`。缓存位于当前 checkout 的
+`.build/bilikit-quality-gates/<checkout-key>/generations/<generation-key>/`；`checkout-key`
+来自 canonical checkout 路径。`generation-key` 包含缓存 schema、完整 Xcode Developer
+目录、Xcode／Swift 版本、architecture、`Package.swift`、两份 `Package.resolved`、
+`project.pbxproj`、shared scheme、`.xcconfig` 和 `.xctestplan`。这些输入变化会建立新
+generation；普通 Swift 源码、测试、资源和文档变化继续复用当前 generation，由 SwiftPM／
+Xcode 自己做增量失效，不会因每次编辑变成 cold build。
+
+日常定向测试必须同样使用当前 generation 的 SwiftPM scratch/cache/config/security 或
+Xcode DerivedData/package/module 路径，且只能作为定向证据。日常 `iteration` Gate 证明当前
+增量环境；production PR 最终自动验收必须在最高适用 mode 后使用独立的 `closure`。例如
+代码、App 或 Composition 改动使用：
 
 ```sh
-BILIKIT_GATE_FRESH=1 \
+sh Scripts/run-quality-gates.sh app closure
+```
+
+`closure` 强制使用 fresh 私有根，并在输出与 GitHub Summary 中留下独立 artifact policy，
+因此不能用普通 `app` 成功冒充最终 closure。仅为排查缓存污染可使用 diagnostic `fresh`；
+`BILIKIT_GATE_FRESH=1` 作为旧调用方兼容入口等价于它：
+
+```sh
+sh Scripts/run-quality-gates.sh app fresh
+```
+
+`fresh` 与 `closure` 都把 SwiftPM scratch/cache/config/security/private home、Xcode
+DerivedData/package checkout/package cache/private home、Clang／Swift／manifest ModuleCache
+和精简日志放入一次唯一、权限为 `0700` 的临时根。xcodebuild 的 `HOME`、
+`CFFIXED_USER_HOME` 与 `XDG_CACHE_HOME` 只对该子进程定向到 private home，避免内部 SwiftPM
+manifest 与 Xcode log store 回落到用户目录。脚本在成功、失败、`HUP`、`INT` 和 `TERM` 等可捕获退出路径上验证
+canonical prefix、owner、mode、schema marker、checkout identity 与 run identity 后，只清理
+该精确根。finalizer 开始后会忽略二次可捕获信号，直到容量统计与精确清理完成。外部 bounded
+runner 应终止 Gate 的整个进程组，避免只结束父 shell 而留下正在运行的编译子进程；以 `TERM`
+实现 timeout 时应设置
+`BILIKIT_GATE_TERM_IS_TIMEOUT=1`；最终 `timeout.inconclusive` 归因仍由实际发出 timeout 的
+调用方确认。`SIGKILL`、断电或 marker 写入前的强制终止无法安全捕获，宁可遗留也不扩大删除
+范围。
+
+需要保留脱敏后的诊断产物时，唯一保留开关为：
+
+```sh
 BILIKIT_GATE_RETAIN_ARTIFACTS=1 \
-BILIKIT_COMPACT_LOGS=1 \
-sh Scripts/run-quality-gates.sh app
+sh Scripts/run-quality-gates.sh app fresh
 ```
 
-脚本会明确打印保留位置。保留目录包含构建产物和完整 gate 日志，需要由调用者在诊断后清理。
-普通 compact 日志随 gate 退出清理；失败摘要仍打印最后 40 行。
+脚本会打印保留位置及 `cleanup-retained` 精确命令。后续清理仍验证 owner、0700、marker、
+checkout identity 和临时根 prefix；`/`、`HOME`、仓库根、外部目录、symlink 逃逸或缺失 marker
+都会被拒绝。所有阶段无论 compact 开关如何都先捕获并脱敏 checkout/HOME/artifact path、完整
+URL 和常见凭据字段；`BILIKIT_COMPACT_LOGS=0` 只表示向控制台回显脱敏后的完整日志。若脱敏或
+原子替换失败，Gate 会覆盖 retain 并清理精确 fresh root，绝不保留或打印原始日志。普通日志
+随 Gate 退出清理，compact 失败摘要只打印最后 40 行。
 
-`BILIKIT_DERIVED_DATA_PATH` 继续作为日常模式的调用方管理兼容入口；fresh 模式拒绝该覆盖，
-以保证所有产物都位于唯一临时根。路径诊断可设置 `BILIKIT_GATE_PRINT_PATHS_ONLY=1`，它只输出
-解析后的缓存路径，不运行 gate。所有模式都显式设置 SwiftPM scratch/package cache、Xcode
-DerivedData/package cache 和 Clang／Swift module cache，避免回退到用户级 module cache。
+`BILIKIT_DERIVED_DATA_PATH` 只保留为 `iteration` 的受控兼容入口，并且只能解析为当前
+generation 的直接子目录；fresh/closure 或任意外部路径都会失败关闭。路径诊断可设置
+`BILIKIT_GATE_PRINT_PATHS_ONLY=1`，它只输出解析后的缓存路径，不运行检查。所有模式默认局部
+使用 `/Applications/Xcode.app/Contents/Developer`，也允许调用方显式传入另一套完整
+`DEVELOPER_DIR`；Gate 从不执行 `xcode-select --switch`。
+
+每次退出会分别报告 `repository-artifacts` 的 total、SwiftPM scratch/cache/config/security、
+private home、DerivedData、package、ModuleCache、logs 与无法归类的 other 大小，以及 iteration
+generation 数。它只描述仓库产物，不等于 apple-dev-loop 的 session quota，也不等于磁盘真正
+不足。出现旧 generation 或明确缓存污染证据时，确认没有同 checkout
+并行 Gate 后运行：
+
+```sh
+sh Scripts/run-quality-gates.sh cleanup-iteration
+```
+
+该命令不接受路径参数，只能删除当前 checkout 下 marker 与 identity 验证通过的精确根；它不
+扫描其他 worktree，也不触碰用户级 SwiftPM、DerivedData 或 ModuleCache。Gate 不会在任意编译
+错误后自动重跑 fresh；失败会按明确证据区分 `configuration`、`toolchain`、`sandbox`、
+`build`、`test.assertion`、`test.infrastructure`、`signing`、`timeout.inconclusive` 与
+`unknown`。断言没有实际执行时，不能称为代码或测试 assertion 失败。
 
 异步测试必须用可观察事件、状态、continuation 或显式闸门判断工作开始和完成；固定时长
 只能作为超时，不能用来推断状态已经稳定。


### PR DESCRIPTION
## 变化

- 为 checkout-local iteration 缓存增加基于工具链、SwiftPM 与 Xcode 工程输入的 generation identity
- 将 production PR 最终门禁固定为独立的 `closure` fresh 环境
- 隔离 SwiftPM scratch/cache/config/security、Xcode DerivedData/package/private home 与 Clang/Swift ModuleCache
- 增加 marker、owner、mode、canonical path 和 symlink 边界验证，以及精确 cleanup/retain 入口
- 补齐日志捕获与脱敏、故障分类、容量分项和信号清理
- 扩展既有 shell/static contract tests，并让 CI 使用所选最高 mode 的 closure policy

## 原因

日常 iteration 缓存需要保持增量性能，但较大依赖或工具链变化可能留下旧接口、模块或残缺 package checkout。最终验收不能依赖可能污染的日常缓存，也不能通过清理用户全局缓存解决。

## 影响

日常开发仍复用当前 checkout 与 generation 的缓存；影响缓存兼容性的输入变化会自然切换 generation。CI 最终验收使用唯一、0700、完成后精确清理的 fresh root。脚本不会修改全局 `xcode-select`，也不会写入用户级 SwiftPM 或 ModuleCache。

## 验证

- `sh Scripts/test-quality-gate-artifacts.sh`
- `sh Scripts/check-project-contract.sh`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer sh Scripts/run-quality-gates.sh static iteration`
- managed sandbox 的 app closure 在 SwiftPM manifest 阶段得到明确 `sandbox` 归因，未误报为代码失败，fresh root 已清理
- 获准等价环境执行 `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer sh Scripts/run-quality-gates.sh app closure`：static、Swift Package、App build-for-testing、App unit tests 全部通过，fresh root 已清理
- 独立 reviewer 最终复核无 actionable finding

## 未覆盖边界

本 PR 不修改生产 Swift/SwiftUI、播放、认证、API 或产品测试；unsigned build 和单元测试不证明签名、Keychain、真实 UI、真实播放或网络行为。