### PR TITLE
feat(danmaku): 按收到字号渲染弹幕

### DIFF
--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/DanmakuPayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/DanmakuPayloads.swift
@@ -78,7 +78,12 @@ enum DanmakuPayloadDecoder {
     }
 
     private static func normalizedFontSize(_ value: Int32) -> Double {
-        Double(min(max(value, 12), 64))
+        switch value {
+        case 18, 25, 36:
+            Double(value)
+        default:
+            25
+        }
     }
 }
 

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuRenderer.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuRenderer.swift
@@ -17,6 +17,7 @@ public final class CoreAnimationDanmakuRenderer:
     private static let maximumTextWidthPixels: CGFloat = 8_192
     private static let maximumTextHeightPixels: CGFloat = 512
     private static let maximumTextUTF16Length = 512
+    private static let supportedFontSizes: Set<Double> = [18, 25, 36]
     private static let lightInkRelativeLuminanceThreshold = 0.179
 
     private struct Entry {
@@ -33,7 +34,6 @@ public final class CoreAnimationDanmakuRenderer:
     public var activeLayerCount: Int { entries.count }
 
     private let contentsScale: CGFloat
-    private let font = NSFont.systemFont(ofSize: 24, weight: .semibold)
     private let darkInkShadow: NSShadow = {
         let shadow = NSShadow()
         shadow.shadowColor = NSColor.black
@@ -66,7 +66,9 @@ public final class CoreAnimationDanmakuRenderer:
         else {
             return DanmakuTextMetrics(width: 0, height: 0)
         }
-        let attributed = attributedString(for: event)
+        guard let attributed = attributedString(for: event) else {
+            return DanmakuTextMetrics(width: 0, height: 0)
+        }
         let framesetter = CTFramesetterCreateWithAttributedString(attributed)
         let measured = CTFramesetterSuggestFrameSizeWithConstraints(
             framesetter,
@@ -108,7 +110,9 @@ public final class CoreAnimationDanmakuRenderer:
 
         nextObjectIdentity &+= 1
         let objectIdentity = nextObjectIdentity
-        let textLayer = makeTextLayer(for: placement)
+        guard let textLayer = makeTextLayer(for: placement) else {
+            return
+        }
         let relay = AnimationCompletionRelay(
             renderer: self,
             eventID: event.id,
@@ -217,7 +221,8 @@ public final class CoreAnimationDanmakuRenderer:
 
     private func attributedString(
         for event: DanmakuEvent
-    ) -> NSAttributedString {
+    ) -> NSAttributedString? {
+        guard let font = font(for: event) else { return nil }
         let components = rgbComponents(for: event.colorRGB)
         var attributes: [NSAttributedString.Key: Any] = [
             .font: font,
@@ -234,6 +239,19 @@ public final class CoreAnimationDanmakuRenderer:
         return NSAttributedString(
             string: event.text,
             attributes: attributes
+        )
+    }
+
+    private func font(for event: DanmakuEvent) -> NSFont? {
+        guard event.fontSize.isFinite else {
+            return nil
+        }
+        let normalizedFontSize =
+            Self.supportedFontSizes.contains(event.fontSize)
+            ? event.fontSize : 25
+        return NSFont.systemFont(
+            ofSize: CGFloat(normalizedFontSize),
+            weight: .semibold
         )
     }
 
@@ -273,9 +291,16 @@ public final class CoreAnimationDanmakuRenderer:
 
     private func makeTextLayer(
         for placement: DanmakuLanePlacement
-    ) -> CATextLayer {
+    ) -> CATextLayer? {
         let layer = CATextLayer()
-        layer.string = attributedString(for: placement.request.event)
+        guard
+            let attributed = attributedString(
+                for: placement.request.event
+            )
+        else {
+            return nil
+        }
+        layer.string = attributed
         layer.alignmentMode = .left
         layer.isWrapped = false
         layer.contentsScale = contentsScale

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneAllocator.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneAllocator.swift
@@ -3,10 +3,14 @@ import Foundation
 
 /// 在固定 surface 与活动数量上限内分配弹幕轨道，并阻止滚动弹幕追尾。
 ///
+/// 高于一个 lane 基元的文本会占用连续 lane，避免大字号重叠；小字号仍只占一个基元。
+///
 /// allocator 只使用媒体时间计算占用/过期；renderer completion 通过 `remove` 回收相同事件。
 public struct DanmakuLaneAllocator: Sendable {
     private struct ActivePlacement: Sendable {
         let placement: DanmakuLanePlacement
+        let laneKeys: [LaneKey]
+        let slotKeys: [LaneSlotKey]
     }
 
     private struct LaneKey: Hashable, Sendable {
@@ -56,31 +60,31 @@ public struct DanmakuLaneAllocator: Sendable {
             return nil
         }
         let placement = removed.placement
-        let laneKey = LaneKey(
-            mode: placement.request.event.mode,
-            index: placement.laneIndex
-        )
-        let slotKey = LaneSlotKey(
-            lane: laneKey,
-            overlapDepth: placement.overlapDepth
-        )
+        let laneKeys = removed.laneKeys
+        let slotKeys = removed.slotKeys
         switch placement.request.event.mode {
         case .scrolling:
-            if scrollingLaneTails[slotKey]?
-                .placement.request.event.id == eventID
+            for slotKey in slotKeys
+            where scrollingLaneTails[slotKey]?.placement.request.event.id
+                == eventID
             {
                 scrollingLaneTails[slotKey] = nil
             }
         case .top, .bottom:
-            if fixedLaneOccupants[slotKey]?.placement.request.event.id == eventID {
+            for slotKey in slotKeys
+            where fixedLaneOccupants[slotKey]?.placement.request.event.id
+                == eventID
+            {
                 fixedLaneOccupants[slotKey] = nil
             }
         }
-        let remainingCount = (activeLaneCounts[laneKey] ?? 1) - 1
-        if remainingCount > 0 {
-            activeLaneCounts[laneKey] = remainingCount
-        } else {
-            activeLaneCounts[laneKey] = nil
+        for laneKey in laneKeys {
+            let remainingCount = (activeLaneCounts[laneKey] ?? 1) - 1
+            if remainingCount > 0 {
+                activeLaneCounts[laneKey] = remainingCount
+            } else {
+                activeLaneCounts[laneKey] = nil
+            }
         }
         return placement
     }
@@ -125,7 +129,6 @@ public struct DanmakuLaneAllocator: Sendable {
     ) -> Result<DanmakuLanePlacement, DanmakuLaneDropReason> {
         guard configuration.isValid,
             request.isValid,
-            request.height <= configuration.laneHeight,
             active[request.event.id] == nil
         else {
             return .failure(.invalidRequest)
@@ -144,12 +147,26 @@ public struct DanmakuLaneAllocator: Sendable {
                 Double(DanmakuLaneConfiguration.hardMaximumActiveCount)
             )
         )
-        guard laneCount > 0 else {
+        guard laneCount > 0,
+            request.height <= displayHeight
+        else {
             return .failure(.noLane)
         }
-        if let safeLane = (0..<laneCount).first(where: {
+        let uncappedLaneSpan = ceil(
+            request.height / configuration.laneHeight
+        )
+        guard uncappedLaneSpan.isFinite,
+            uncappedLaneSpan > 0,
+            uncappedLaneSpan <= Double(laneCount)
+        else {
+            return .failure(.noLane)
+        }
+        let laneSpan = Int(uncappedLaneSpan)
+        let candidateLanes = 0...(laneCount - laneSpan)
+        if let safeLane = candidateLanes.first(where: {
             laneIsSafeWithoutOverlap(
                 $0,
+                laneSpan: laneSpan,
                 for: request,
                 at: playbackTime
             )
@@ -158,6 +175,7 @@ public struct DanmakuLaneAllocator: Sendable {
                 place(
                     request,
                     laneIndex: safeLane,
+                    laneSpan: laneSpan,
                     overlapDepth: 0,
                     at: playbackTime
                 )
@@ -167,9 +185,10 @@ public struct DanmakuLaneAllocator: Sendable {
             return .failure(.noLane)
         }
         for overlapDepth in 0..<configuration.maximumOverlapDepth {
-            if let availableLane = (0..<laneCount).first(where: {
+            if let availableLane = candidateLanes.first(where: {
                 laneIsAvailable(
                     $0,
+                    laneSpan: laneSpan,
                     overlapDepth: overlapDepth,
                     for: request,
                     at: playbackTime
@@ -179,6 +198,7 @@ public struct DanmakuLaneAllocator: Sendable {
                     place(
                         request,
                         laneIndex: availableLane,
+                        laneSpan: laneSpan,
                         overlapDepth: overlapDepth,
                         at: playbackTime
                     )
@@ -191,6 +211,7 @@ public struct DanmakuLaneAllocator: Sendable {
     private mutating func place(
         _ request: DanmakuLaneRequest,
         laneIndex: Int,
+        laneSpan: Int,
         overlapDepth: Int,
         at playbackTime: Double
     ) -> DanmakuLanePlacement {
@@ -199,26 +220,38 @@ public struct DanmakuLaneAllocator: Sendable {
             laneIndex: laneIndex,
             originY: originY(
                 for: request.event.mode,
-                laneIndex: laneIndex
+                laneIndex: laneIndex,
+                requestHeight: request.height
             ),
             surfaceWidthAtAdmission: configuration.surfaceWidth,
             admittedAtSeconds: playbackTime,
             expiresAtSeconds: playbackTime + request.durationSeconds,
             overlapDepth: overlapDepth
         )
-        let activePlacement = ActivePlacement(placement: placement)
-        let laneKey = LaneKey(mode: request.event.mode, index: laneIndex)
-        let slotKey = LaneSlotKey(
-            lane: laneKey,
-            overlapDepth: overlapDepth
+        let laneKeys = (laneIndex..<(laneIndex + laneSpan)).map {
+            LaneKey(mode: request.event.mode, index: $0)
+        }
+        let slotKeys = laneKeys.map {
+            LaneSlotKey(lane: $0, overlapDepth: overlapDepth)
+        }
+        let activePlacement = ActivePlacement(
+            placement: placement,
+            laneKeys: laneKeys,
+            slotKeys: slotKeys
         )
         active[request.event.id] = activePlacement
-        activeLaneCounts[laneKey, default: 0] += 1
+        for laneKey in laneKeys {
+            activeLaneCounts[laneKey, default: 0] += 1
+        }
         switch request.event.mode {
         case .scrolling:
-            scrollingLaneTails[slotKey] = activePlacement
+            for slotKey in slotKeys {
+                scrollingLaneTails[slotKey] = activePlacement
+            }
         case .top, .bottom:
-            fixedLaneOccupants[slotKey] = activePlacement
+            for slotKey in slotKeys {
+                fixedLaneOccupants[slotKey] = activePlacement
+            }
         }
         peakActiveCount = max(peakActiveCount, active.count)
         return placement
@@ -226,57 +259,66 @@ public struct DanmakuLaneAllocator: Sendable {
 
     private func originY(
         for mode: DanmakuPresentationMode,
-        laneIndex: Int
+        laneIndex: Int,
+        requestHeight: Double
     ) -> Double {
         switch mode {
         case .scrolling, .top:
             Double(laneIndex) * configuration.laneHeight
         case .bottom:
             configuration.surfaceHeight
-                - Double(laneIndex + 1) * configuration.laneHeight
+                - Double(laneIndex) * configuration.laneHeight
+                - requestHeight
         }
     }
 
     private func laneIsAvailable(
         _ laneIndex: Int,
+        laneSpan: Int,
         overlapDepth: Int,
         for request: DanmakuLaneRequest,
         at playbackTime: Double
     ) -> Bool {
-        let slotKey = LaneSlotKey(
-            lane: LaneKey(mode: request.event.mode, index: laneIndex),
-            overlapDepth: overlapDepth
-        )
+        let slotKeys = (laneIndex..<(laneIndex + laneSpan)).map {
+            LaneSlotKey(
+                lane: LaneKey(mode: request.event.mode, index: $0),
+                overlapDepth: overlapDepth
+            )
+        }
         switch request.event.mode {
         case .top, .bottom:
-            return fixedLaneOccupants[slotKey] == nil
+            return slotKeys.allSatisfy { fixedLaneOccupants[$0] == nil }
         case .scrolling:
-            guard let previous = scrollingLaneTails[slotKey] else {
-                return true
+            return slotKeys.allSatisfy { slotKey in
+                guard let previous = scrollingLaneTails[slotKey] else {
+                    return true
+                }
+                return scrollingRequest(
+                    request,
+                    canFollow: previous.placement,
+                    at: playbackTime
+                )
             }
-            return scrollingRequest(
-                request,
-                canFollow: previous.placement,
-                at: playbackTime
-            )
         }
     }
 
     private func laneIsSafeWithoutOverlap(
         _ laneIndex: Int,
+        laneSpan: Int,
         for request: DanmakuLaneRequest,
         at playbackTime: Double
     ) -> Bool {
-        let laneKey = LaneKey(
-            mode: request.event.mode,
-            index: laneIndex
+        let laneKeys = Set(
+            (laneIndex..<(laneIndex + laneSpan)).map {
+                LaneKey(mode: request.event.mode, index: $0)
+            }
         )
         switch request.event.mode {
         case .top, .bottom:
-            return activeLaneCounts[laneKey] == nil
+            return laneKeys.allSatisfy { activeLaneCounts[$0] == nil }
         case .scrolling:
             return scrollingLaneTails.allSatisfy { slotKey, previous in
-                guard slotKey.lane == laneKey else { return true }
+                guard laneKeys.contains(slotKey.lane) else { return true }
                 return scrollingRequest(
                     request,
                     canFollow: previous.placement,

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliDanmakuRepositoryTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliDanmakuRepositoryTests.swift
@@ -429,6 +429,28 @@ struct BiliDanmakuRepositoryTests {
     }
 
     @Test
+    func decoderUsesOnlySupportedReceivedFontSizes() throws {
+        let sizes: [Int32] = [0, 12, 18, 25, 36, 45, 64]
+        var payload = Bilikit_Danmaku_SegmentReply()
+        payload.elements = sizes.enumerated().map { index, fontSize in
+            var element = Bilikit_Danmaku_Element()
+            element.id = Int64(index + 1)
+            element.progressMilliseconds = 1_000
+            element.mode = 1
+            element.fontSize = fontSize
+            element.colorRgb = 0xFF_FF_FF
+            element.content = "font size fixture"
+            return element
+        }
+
+        let events = try DanmakuPayloadDecoder.events(
+            from: payload.serializedData()
+        )
+
+        #expect(events.map(\.fontSize) == [25, 25, 18, 25, 36, 25, 25])
+    }
+
+    @Test
     func cancellationIsNotCollapsedIntoTransportFailure() async {
         let client = BiliAPIClient(transport: DanmakuCancellationTransport())
         let repository = BiliDanmakuRepository(client: client)

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuLaneAllocatorTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuLaneAllocatorTests.swift
@@ -326,14 +326,36 @@ struct DanmakuLaneAllocatorTests {
     }
 
     @Test
+    func extremeFiniteRequestHeightDoesNotOverflowLaneSpanConversion() {
+        var allocator = DanmakuLaneAllocator(
+            configuration: DanmakuLaneConfiguration(
+                surfaceWidth: 1_000,
+                surfaceHeight: .greatestFiniteMagnitude,
+                laneHeight: .leastNonzeroMagnitude,
+                minimumHorizontalGap: 12,
+                maximumActiveCount: 1,
+                displayAreaFraction: 1
+            )
+        )
+
+        let admission = allocator.admit(
+            [request(id: "extreme-span", height: .greatestFiniteMagnitude)],
+            at: 0
+        )
+
+        #expect(admission.admitted.isEmpty)
+        #expect(admission.dropCounts.noLane == 1)
+    }
+
+    @Test
     func invalidGeometryHardLimitAndResizeStayBounded() {
         var allocator = DanmakuLaneAllocator(configuration: configuration())
         _ = allocator.admit([request(id: "active")], at: 0)
         let tooTall = allocator.admit(
-            [request(id: "tall", height: 21)],
+            [request(id: "tall", height: 61)],
             at: 0
         )
-        #expect(tooTall.dropCounts.invalidRequest == 1)
+        #expect(tooTall.dropCounts.noLane == 1)
 
         allocator.updateConfiguration(
             configuration(surfaceWidth: 0)
@@ -376,6 +398,98 @@ struct DanmakuLaneAllocatorTests {
         )
         #expect(recovered.expired.map(\.request.event.id) == ["active"])
         #expect(recovered.admitted.map(\.request.event.id) == ["recovered"])
+    }
+
+    @Test
+    func tallRequestsOccupyAdjacentLanesWithoutReducingSmallTextDensity() {
+        var allocator = DanmakuLaneAllocator(configuration: configuration())
+        let admission = allocator.admit(
+            [
+                request(id: "large", mode: .top, height: 39),
+                request(id: "small", mode: .top, height: 18),
+                request(id: "blocked", mode: .top, height: 18),
+            ],
+            at: 0
+        )
+
+        #expect(admission.admitted.map(\.request.event.id) == ["large", "small"])
+        #expect(admission.admitted.map(\.laneIndex) == [0, 2])
+        #expect(admission.admitted.map(\.originY) == [0, 40])
+        #expect(admission.dropCounts.noLane == 1)
+    }
+
+    @Test
+    func tallScrollingRequestChecksEveryAdjacentLaneForCollision() {
+        var allocator = DanmakuLaneAllocator(configuration: configuration())
+        let admission = allocator.admit(
+            [
+                request(id: "large", height: 39),
+                request(id: "small", height: 18),
+                request(id: "blocked-large", height: 39),
+            ],
+            at: 0
+        )
+
+        #expect(admission.admitted.map(\.request.event.id) == ["large", "small"])
+        #expect(admission.admitted.map(\.laneIndex) == [0, 2])
+        #expect(admission.dropCounts.noLane == 1)
+    }
+
+    @Test
+    func removingTallFixedRequestReleasesEveryOccupiedLane() {
+        var allocator = DanmakuLaneAllocator(configuration: configuration())
+        _ = allocator.admit(
+            [
+                request(id: "large", mode: .top, height: 39),
+                request(id: "small", mode: .top, height: 18),
+            ],
+            at: 0
+        )
+
+        #expect(allocator.remove(eventID: "large") != nil)
+        let reused = allocator.admit(
+            [request(id: "large-next", mode: .top, height: 39)],
+            at: 0.1
+        )
+
+        #expect(reused.admitted.map(\.request.event.id) == ["large-next"])
+        #expect(reused.admitted.first?.laneIndex == 0)
+        #expect(reused.dropCounts.total == 0)
+    }
+
+    @Test
+    func expiringTallScrollingRequestReleasesEveryOccupiedLane() {
+        var allocator = DanmakuLaneAllocator(configuration: configuration())
+        _ = allocator.admit(
+            [
+                request(id: "large", height: 39, duration: 1),
+                request(id: "small", height: 18, duration: 10),
+            ],
+            at: 0
+        )
+        let reused = allocator.admit(
+            [request(id: "large-next", height: 39)],
+            at: 1
+        )
+
+        #expect(reused.expired.map(\.request.event.id) == ["large"])
+        #expect(reused.admitted.map(\.request.event.id) == ["large-next"])
+        #expect(reused.admitted.first?.laneIndex == 0)
+        #expect(reused.dropCounts.total == 0)
+    }
+
+    @Test
+    func tallBottomRequestUsesItsMeasuredHeightFromSurfaceEdge() throws {
+        var allocator = DanmakuLaneAllocator(configuration: configuration())
+        let admission = allocator.admit(
+            [request(id: "large-bottom", mode: .bottom, height: 39)],
+            at: 0
+        )
+
+        let placement = try #require(admission.admitted.first)
+        #expect(placement.laneIndex == 0)
+        #expect(placement.originY == 21)
+        #expect(placement.originY + placement.request.height == 60)
     }
 
     @Test

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
@@ -655,6 +655,33 @@ struct DanmakuPresentationControllerTests {
     }
 
     @Test
+    func receivedLegacyLargeBottomStaysAnchoredAcrossResize() throws {
+        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
+        renderer.updateSurfaceSize(width: 800, height: 300)
+        let fixture = event(
+            id: "large-bottom-resize",
+            mode: .bottom,
+            fontSize: 36
+        )
+        let metrics = renderer.measure(fixture)
+        renderer.render(
+            placement(
+                event: fixture,
+                metrics: metrics,
+                originY: 300 - metrics.height
+            )
+        )
+        let layer = try #require(
+            renderer.textLayer(forEventID: fixture.id)
+        )
+
+        #expect(layer.frame.maxY == 300)
+        renderer.updateSurfaceSize(width: 1_200, height: 500)
+        #expect(layer.frame.maxY == 500)
+        #expect(layer.position.x == 600)
+    }
+
+    @Test
     func coreAnimationStyleUsesHeavyInkWithoutCompositorShadow() throws {
         let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
         renderer.updateSurfaceSize(width: 800, height: 200)
@@ -682,6 +709,169 @@ struct DanmakuPresentationControllerTests {
         #expect(shadow.shadowBlurRadius == 1.5)
         #expect(shadow.shadowOffset == .zero)
         #expect(renderer.activeLayerCount == 1)
+    }
+
+    @Test
+    func coreAnimationUsesReceivedFontSizeForMeasurementAndLayer() throws {
+        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
+        renderer.updateSurfaceSize(width: 800, height: 240)
+        let fixtures = [18.0, 25.0, 36.0].map { fontSize in
+            DanmakuEvent(
+                id: "font-\(fontSize)",
+                timeSeconds: 1,
+                mode: .top,
+                text: "同一条字号测试弹幕",
+                fontSize: fontSize,
+                colorRGB: 0xFFFFFF,
+                weight: 1
+            )
+        }
+        let metrics = fixtures.map(renderer.measure)
+
+        #expect(metrics[0].width < metrics[1].width)
+        #expect(metrics[1].width < metrics[2].width)
+        #expect(metrics[0].height < metrics[1].height)
+        #expect(metrics[1].height < metrics[2].height)
+
+        for (index, fixture) in fixtures.enumerated() {
+            renderer.render(
+                placement(
+                    event: fixture,
+                    metrics: metrics[index],
+                    originY: Double(index) * 64
+                )
+            )
+            let layer = try #require(
+                renderer.textLayer(forEventID: fixture.id)
+            )
+            let attributed = try #require(
+                layer.string as? NSAttributedString
+            )
+            let font = try #require(
+                attributed.attribute(.font, at: 0, effectiveRange: nil)
+                    as? NSFont
+            )
+            #expect(Double(font.pointSize) == fixture.fontSize)
+            #expect(Double(layer.bounds.width) == metrics[index].width)
+            #expect(Double(layer.bounds.height) == metrics[index].height)
+        }
+    }
+
+    @Test
+    func presentationControllerAdmitsReceivedSizesWithoutVerticalOverlap()
+        throws
+    {
+        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
+        let controller = DanmakuPresentationController(
+            backend: renderer,
+            configuration: DanmakuLaneConfiguration(
+                surfaceWidth: 800,
+                surfaceHeight: 240,
+                laneHeight: 36,
+                minimumHorizontalGap: 12,
+                maximumActiveCount: 20,
+                displayAreaFraction: 1
+            )
+        )
+        let identity = PlaybackItemIdentity(
+            bvid: "BV1FontSizeFixture",
+            cid: 1
+        )
+
+        controller.apply(
+            update(
+                identity: identity,
+                position: 1,
+                generation: 1,
+                events: [
+                    ("controller-font-18.0", 18.0),
+                    ("controller-font-25.0", 25.0),
+                    ("controller-font-36.0", 36.0),
+                    ("controller-after-large", 18.0),
+                ].map { id, fontSize in
+                    event(
+                        id: id,
+                        mode: .top,
+                        fontSize: fontSize
+                    )
+                }
+            )
+        )
+
+        #expect(controller.statistics.admitted == 4)
+        #expect(controller.statistics.active == 4)
+        #expect(controller.statistics.droppedNoLane == 0)
+        #expect(renderer.activeLayerCount == 4)
+
+        let smallLayer = try #require(
+            renderer.textLayer(forEventID: "controller-font-18.0")
+        )
+        let standardLayer = try #require(
+            renderer.textLayer(forEventID: "controller-font-25.0")
+        )
+        let legacyLargeLayer = try #require(
+            renderer.textLayer(forEventID: "controller-font-36.0")
+        )
+        let afterLargeLayer = try #require(
+            renderer.textLayer(forEventID: "controller-after-large")
+        )
+        #expect(legacyLargeLayer.bounds.height > 36)
+        #expect(smallLayer.frame.maxY <= standardLayer.frame.minY)
+        #expect(standardLayer.frame.maxY <= legacyLargeLayer.frame.minY)
+        #expect(legacyLargeLayer.frame.maxY <= afterLargeLayer.frame.minY)
+    }
+
+    @Test(arguments: [Double.nan, .infinity, -.infinity])
+    func nonfiniteReceivedFontSizeFailsClosed(fontSize: Double) {
+        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
+        renderer.updateSurfaceSize(width: 800, height: 200)
+        let fixture = DanmakuEvent(
+            id: "invalid-font-size",
+            timeSeconds: 1,
+            mode: .scrolling,
+            text: "不会进入图层的测试弹幕",
+            fontSize: fontSize,
+            colorRGB: 0xFFFFFF,
+            weight: 1
+        )
+        let metrics = renderer.measure(fixture)
+
+        #expect(metrics == DanmakuTextMetrics(width: 0, height: 0))
+        renderer.render(
+            placement(event: fixture, metrics: metrics, originY: 0)
+        )
+        #expect(renderer.activeLayerCount == 0)
+    }
+
+    @Test(arguments: [12.0, 24.0, 45.0, 64.0])
+    func unknownFiniteFontSizeFallsBackToStandard(
+        fontSize: Double
+    )
+        throws
+    {
+        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
+        renderer.updateSurfaceSize(width: 800, height: 200)
+        let fixture = event(
+            id: "font-fallback-\(fontSize)",
+            mode: .top,
+            fontSize: fontSize
+        )
+        let metrics = renderer.measure(fixture)
+
+        #expect(metrics.width > 0)
+        #expect(metrics.height > 0)
+        renderer.render(
+            placement(event: fixture, metrics: metrics, originY: 0)
+        )
+        let layer = try #require(
+            renderer.textLayer(forEventID: fixture.id)
+        )
+        let attributed = try #require(layer.string as? NSAttributedString)
+        let font = try #require(
+            attributed.attribute(.font, at: 0, effectiveRange: nil)
+                as? NSFont
+        )
+        #expect(Double(font.pointSize) == 25)
     }
 
     @Test
@@ -1090,14 +1280,15 @@ struct DanmakuPresentationControllerTests {
     private func event(
         id: String,
         mode: DanmakuPresentationMode,
-        colorRGB: UInt32 = 0xFFFFFF
+        colorRGB: UInt32 = 0xFFFFFF,
+        fontSize: Double = 24
     ) -> DanmakuEvent {
         DanmakuEvent(
             id: id,
             timeSeconds: 1,
             mode: mode,
             text: "中文 日本語 한국어 Latin 😀 #",
-            fontSize: 24,
+            fontSize: fontSize,
             colorRGB: colorRGB,
             weight: 1
         )

--- a/docs/development/danmaku-small-font-support-research-2026-08-10.md
+++ b/docs/development/danmaku-small-font-support-research-2026-08-10.md
@@ -1,14 +1,15 @@
 # 弹幕小字号支持调研（2026-08-10）
 
-> 范围：只读代码与公开 Web 资源调研；没有登录、读取凭据、发送弹幕或保存远端响应。
+> 范围：只读代码与公开 Web 资源调研，以及后续收到字号的本地呈现切片；没有登录、读取
+> 凭据、发送弹幕或保存远端响应。
 > 本文不是实现授权，不更新 `ROADMAP.md` 完成状态。
 
 ## 结论
 
 “小字号”必须拆成两个能力：
 
-1. **按收到的字号渲染**：当前数据链路已经保留字号，但生产 renderer 没有使用它。这个能力
-   可以在不增加写操作的独立显示正确性切片中安全支持。
+1. **按收到的字号渲染**：数据链路保留的合法字号现在同时用于 CoreText 测量与生产
+   `CATextLayer`。较高文本占用连续 lane，避免大字号与相邻弹幕重叠；这仍是纯只读能力。
 2. **选择小字号并发送**：当前仓库没有弹幕草稿、发送 Use Case、写 Repository、POST
    endpoint 或发送 UI；现行路线图也没有授权该写操作。现在不应实现，应延期到独立写操作
    milestone，先完成产品范围、协议、认证和风控 Gate。
@@ -22,19 +23,20 @@
 ### 接收与模型
 
 - clean-room `danmaku.proto` 将 element field 4 定义为 `int32 font_size`。
-- `DanmakuPayloadDecoder` 把值限制到 `12...64` 后写入
-  `DanmakuEvent.fontSize: Double`；当前 fixture 固定并断言标准值 25。
+- `DanmakuPayloadDecoder` 只把收到的 18、25、36 写入
+  `DanmakuEvent.fontSize: Double`；缺省 0 和其他整数安全回退到标准值 25。
 - decoder 只接受滚动、顶部和底部基础类型；高级、互动、代码和反向类型在 adapter 边界
   丢弃。字号本身不是 mode。
 
 ### 渲染
 
-- `CoreAnimationDanmakuRenderer` 测量和生成 attributed string 时都使用固定
-  `NSFont.systemFont(ofSize: 24, weight: .semibold)`。
-- 因此 `DanmakuEvent.fontSize` 当前是“已解码但未呈现”的字段：收到 18、25 或 36 都按
-  24pt 渲染。BiliKitMac **尚不能诚实声称会显示收到的小字弹幕**。
-- lane allocator 使用 renderer 的测量结果；未来使用事件字号时，必须让测量、lane 高度、
-  碰撞判断和最终 `CATextLayer` 共用同一个规范化字体，不能只缩放最终 layer。
+- `CoreAnimationDanmakuRenderer` 的 CoreText 测量和 attributed string 现在使用同一个事件
+  字号；API 将缺省 0 和未知整数映射为标准 25，保留 18／25／36。绕过 API 构造出的未知
+  有限值也回退到 25，NaN／无穷值失败关闭。
+- lane allocator 使用 renderer 的实测高度。高于一个 lane 基元的 36pt 文本会占用
+  多个连续 lane；没有通过全局放大 lane 间距来降低小字号密度。
+- 自动测试固定 18 < 25 < 36 的宽高顺序、最终 attributed font、controller 实际准入、
+  未知整数回退、非有限值拒绝，以及高文本 top／bottom 连续 lane 几何。
 
 ### UI 与写操作
 
@@ -89,17 +91,35 @@
 站内文章是用户内容，不是官方 API 文档，只用于解释官方压缩脚本中缺失的语义标签。发送
 实现前仍必须重新观察当前官方客户端的实际请求，并用全假值 contract 固定允许集合。
 
+### OSS 交叉观察
+
+只读检查公开 OSS 的当前或固定快照得到更窄的接收策略证据：
+
+- [PiliPlus 发送 UI](https://github.com/bggRGjQaUbCoE/PiliPlus/blob/36dec609315cd34f8895cf15607f1cc582a66f01/lib/pages/video/send_danmaku/view.dart#L185-L198)
+  只提供 `18`“小”和 `25`“标准”；其本地全局显示字号是另一套用户偏好，不应混入事件字号。
+- [wiliwili 模型](https://github.com/xfangfang/wiliwili/blob/88e5876bea9502d06f46a8656e3530684d3aaf7d/wiliwili/include/view/danmaku_core.hpp#L97-L103)
+  和[解析](https://github.com/xfangfang/wiliwili/blob/88e5876bea9502d06f46a8656e3530684d3aaf7d/wiliwili/source/view/danmaku_core.cpp#L79-L85)
+  仍将收到的 `18/25/36` 解释为相对标准 25 的事件比例，支持把 36 作为只读历史兼容值。
+- [DanmakuFlameMaster 示例解析](https://github.com/bilibili/DanmakuFlameMaster/blob/e2846461a09e33720a049f628f09c653f55531f0/Sample/src/main/java/com/sample/BiliDanmukuParser.java#L119-L133)
+  与[全局缩放](https://github.com/bilibili/DanmakuFlameMaster/blob/e2846461a09e33720a049f628f09c653f55531f0/DanmakuFlameMaster/src/main/java/master/flame/danmaku/danmaku/model/android/AndroidDisplayer.java#L151-L166)
+  也把事件字号和观看者全局缩放分层。
+
+这些实现不能证明 B 站当前服务端的正式枚举，但足以否定“`12...64` 内任意整数都是当前产品
+字号”的假设。故接收端采用离散兼容集合 18／25／36；当前证据不足以把 12、16、45、64
+等其他数值纳入受支持集合，它们按未知值处理。36 只作为内部接收兼容，不进入未来普通发送
+UI。
+
 ## 可安全实施的拆分
 
 ### A. 只呈现收到的小字号
 
-建议作为独立只读切片，且在当前唯一产品阶段完成或重新裁决后再排期：
+已按独立只读切片实现：
 
-1. 在 `BiliModels` 将任意 `Double` 收敛成有界的 presentation size，或在 `BiliAPI`
-   映射为明确的受支持字号值；不要让 renderer 再做一套不一致的 clamp。
+1. `BiliAPI` 保留离散接收值 18／25／36，缺省 0 和其他整数回退到标准 25；renderer 在模型
+   绕过 API 时执行同一有限值回退，非有限值失败关闭。
 2. `CoreAnimationDanmakuRenderer` 的 CoreText 测量和 attributed string 使用同一事件字号。
-3. 重新验证 lane 高度、滚动碰撞、顶部/底部锚定、显示区域、resize、对象上限与长文本上限。
-4. 远端异常字号继续失败关闭或按已批准规则规范化；不能让超大字号绕过 512px 高度、
+3. lane allocator 以实测高度占用连续 lane，保持滚动碰撞及顶部／底部锚定。
+4. 超大字号不能绕过 512px 高度、
    8192px 宽度和 active layer 上限。
 
 这不需要新增账号权限、endpoint 或 Cookie，但会改变真实视觉密度，不能只用 build 证明。
@@ -126,7 +146,7 @@
 
 ### 只读呈现
 
-- decoder：18/25/36、边界 12/64、越界、缺省 0、超大文本组合；明确 clamp 或拒绝策略。
+- decoder：保留 18／25／36；缺省 0 及 12／16／45／64 等未知整数回退 25。
 - renderer：同一 event 的测量字体等于渲染字体；18 小于 25、36 大于 25；三种 mode 的 lane
   和锚点不重叠越界；resize/seek/替换/stop 后无残留 layer。
 - UI/性能：合成 fixture 对比 18/25/36 的可见大小；高密度 30 分钟对象与 layer 上限；大
@@ -144,8 +164,8 @@
 
 ## 建议
 
-- **现在不做发送。** 它是新的认证写操作和产品范围，不是“小字号 UI”附带的一行参数。
-- **拆分两个 milestone。** 先把收到的字号正确呈现，作为只读播放正确性；发送能力只有在
+- **现在仍不做发送。** 它是新的认证写操作和产品范围，不是“小字号 UI”附带的一行参数。
+- **继续拆分发送 milestone。** 收到字号的只读呈现已经独立落地；发送能力只有在
   被选为唯一下一阶段、更新产品愿景/路线图并建立写操作威胁模型后再实施。
 - 若只想让用户整体缩放所有弹幕，那是本地显示偏好，与“按发送者选择的小字号呈现”及
   “发送小字号”是第三个不同需求，应单独命名，避免复用 `fontSize` 造成语义混淆。

--- a/docs/development/danmaku-small-font-support-research-2026-08-10.md
+++ b/docs/development/danmaku-small-font-support-research-2026-08-10.md
@@ -1,0 +1,151 @@
+# 弹幕小字号支持调研（2026-08-10）
+
+> 范围：只读代码与公开 Web 资源调研；没有登录、读取凭据、发送弹幕或保存远端响应。
+> 本文不是实现授权，不更新 `ROADMAP.md` 完成状态。
+
+## 结论
+
+“小字号”必须拆成两个能力：
+
+1. **按收到的字号渲染**：当前数据链路已经保留字号，但生产 renderer 没有使用它。这个能力
+   可以在不增加写操作的独立显示正确性切片中安全支持。
+2. **选择小字号并发送**：当前仓库没有弹幕草稿、发送 Use Case、写 Repository、POST
+   endpoint 或发送 UI；现行路线图也没有授权该写操作。现在不应实现，应延期到独立写操作
+   milestone，先完成产品范围、协议、认证和风控 Gate。
+
+公开证据支持 `fontsize` 是发送字段、接收 protobuf field 4 是 `font_size`，小字号长期对应
+数值 18、标准字号对应 25；36 常见于大字号。但本次没有真实发送，不能把 18/25/36 的
+当前服务端接受范围、账号等级权限或失败码宣称为已验证契约。
+
+## 当前 BiliKitMac 能力
+
+### 接收与模型
+
+- clean-room `danmaku.proto` 将 element field 4 定义为 `int32 font_size`。
+- `DanmakuPayloadDecoder` 把值限制到 `12...64` 后写入
+  `DanmakuEvent.fontSize: Double`；当前 fixture 固定并断言标准值 25。
+- decoder 只接受滚动、顶部和底部基础类型；高级、互动、代码和反向类型在 adapter 边界
+  丢弃。字号本身不是 mode。
+
+### 渲染
+
+- `CoreAnimationDanmakuRenderer` 测量和生成 attributed string 时都使用固定
+  `NSFont.systemFont(ofSize: 24, weight: .semibold)`。
+- 因此 `DanmakuEvent.fontSize` 当前是“已解码但未呈现”的字段：收到 18、25 或 36 都按
+  24pt 渲染。BiliKitMac **尚不能诚实声称会显示收到的小字弹幕**。
+- lane allocator 使用 renderer 的测量结果；未来使用事件字号时，必须让测量、lane 高度、
+  碰撞判断和最终 `CATextLayer` 共用同一个规范化字体，不能只缩放最终 layer。
+
+### UI 与写操作
+
+- 当前 `DanmakuControlsView` 只有开关、显示类型、显示区域、密度、滚动速度和透明度；没有
+  字号选择，也没有输入框或发送按钮。
+- `DanmakuSegmentRepository` 只有只读 `segment(index:for:)`；`BiliAPIClient` 只有弹幕
+  分段 GET。仓库中没有 `/x/v2/dm/post`、发送 DTO、CSRF 写授权器或发送失败状态。
+- 现有认证边界只允许凭据进入精确批准的读取请求。Feature 不接触 Cookie/token；游客、
+  图片、媒体和 loopback 也不能继承认证。
+
+## 2026-08-10 公开 Web 观察
+
+### 官方可观察资源
+
+匿名获取一个公开 B 站视频页时，页面声明当前播放器资源为：
+
+- `https://s1.hdslb.com/bfs/static/player/main/core.238e0712.js`
+
+只读检查该 B 站托管脚本可确认：
+
+- 普通弹幕发送 endpoint 为 `POST https://api.bilibili.com/x/v2/dm/post`；请求设置
+  `withCredentials: true`。
+- 发送状态默认 `fontsize: 25`。
+- 脚本维护 7 个字号权限槽位。普通注册/普通用户只开放相邻的第 3、4 个槽位；VIP、UP 主/
+  管理角色和高级权限开放集合不同。因此“大字号是否可选”至少受身份/权限影响，不能只靠
+  客户端枚举决定。
+- 通用 POST 中间件会从 `bili_jct` 注入 `csrf`；该 endpoint 同时进入播放器的请求治理
+  列表。脚本还包含 ticket、指纹和风控相关中间件，说明“有 Cookie + CSRF”不等于请求就
+  可以稳定成功。
+
+这份压缩脚本没有给 7 个权限槽位保留可读的语义标签，因此仅凭官方脚本不能严格证明每个
+索引对应哪个像素值。B 站站内长期公开资料与当前仓库接收协议一致地把 18/25/36 描述为
+小/标准/大；较新的站内界面观察只明确提到“小/正常”两个普通选项。故本调研采用以下
+证据分级：
+
+| 判断 | 可信度 | 边界 |
+| --- | --- | --- |
+| 收发协议存在独立字号字段 | 高 | 官方脚本 + 当前生产 protobuf 解码 |
+| 25 是 Web 默认/标准字号 | 高 | 官方脚本默认值 + 当前 fixture |
+| 18 是小字号，36 是大字号 | 中高 | B 站站内长期资料交叉一致；本次未发送验证 |
+| 普通账号当前可发送大字号 | 未确认 | 官方权限数组显示身份差异，但语义索引已压缩 |
+| POST 当前需要 WBI `w_rid/wts` | 未确认 | 当前脚本可见请求治理，但本次未观察实际网络请求 |
+| 当前频率限制、审核与风控失败码 | 未确认 | 未登录、未发送，不能复用旧经验冒充当前契约 |
+
+公开参考：
+
+- [B 站公开视频页](https://www.bilibili.com/video/BV1xx411c7mD/)
+- [该页面声明的 B 站播放器脚本](https://s1.hdslb.com/bfs/static/player/main/core.238e0712.js)
+- [B 站站内 2020 年发送字段观察](https://www.bilibili.com/opus/387946262497681345)
+- [B 站站内 2023 年弹幕字号结构说明](https://www.bilibili.com/opus/772763602867191830)
+
+站内文章是用户内容，不是官方 API 文档，只用于解释官方压缩脚本中缺失的语义标签。发送
+实现前仍必须重新观察当前官方客户端的实际请求，并用全假值 contract 固定允许集合。
+
+## 可安全实施的拆分
+
+### A. 只呈现收到的小字号
+
+建议作为独立只读切片，且在当前唯一产品阶段完成或重新裁决后再排期：
+
+1. 在 `BiliModels` 将任意 `Double` 收敛成有界的 presentation size，或在 `BiliAPI`
+   映射为明确的受支持字号值；不要让 renderer 再做一套不一致的 clamp。
+2. `CoreAnimationDanmakuRenderer` 的 CoreText 测量和 attributed string 使用同一事件字号。
+3. 重新验证 lane 高度、滚动碰撞、顶部/底部锚定、显示区域、resize、对象上限与长文本上限。
+4. 远端异常字号继续失败关闭或按已批准规则规范化；不能让超大字号绕过 512px 高度、
+   8192px 宽度和 active layer 上限。
+
+这不需要新增账号权限、endpoint 或 Cookie，但会改变真实视觉密度，不能只用 build 证明。
+
+### B. 用户选择小字号并发送
+
+若未来进入路线图，至少需要：
+
+- **模型/Application**：`DanmakuDraft`、离散字号枚举（不要暴露任意 `Int`）、文本/时间/
+  mode/color/pool 限制、`SendDanmakuUseCase`、可取消且防重复提交的状态机。
+- **API**：用途专属 `POST /x/v2/dm/post` adapter，精确 host/path/method/content-type/字段
+  allowlist，响应大小与 JSON 业务码校验，拒绝重定向；先确认是否需要 WBI/ticket/设备字段，
+  证据不足时失败关闭。
+- **认证**：由 `BiliAuth` 的新写授权器在最后一跳注入最小 Cookie 与 CSRF；Feature、draft、
+  日志和 fixture 不得持有凭据。游客或凭据损坏不能匿名发送，也不能自动扩大 Cookie 集合。
+- **UI**：明确账号/等级能力、字符计数、发送中防连点、成功/审核中/被拒绝/风控/登录失效/
+  网络不确定状态；“超时”不能直接当失败重发，否则可能重复发送。
+- **生命周期**：发送意图绑定 `(bvid, cid)` 与当前 progress generation；切 P、换视频、返回、
+  登出时取消未发请求。服务器已受理但客户端丢失响应时，必须呈现结果未知而不是自动重试。
+- **隐私与治理**：不持久化草稿正文、发送历史、完整 URL 或响应；需要新的写操作威胁模型、
+  审核/频率限制/服务条款评估与显式真实账号验证授权。
+
+## 失败路径与测试建议
+
+### 只读呈现
+
+- decoder：18/25/36、边界 12/64、越界、缺省 0、超大文本组合；明确 clamp 或拒绝策略。
+- renderer：同一 event 的测量字体等于渲染字体；18 小于 25、36 大于 25；三种 mode 的 lane
+  和锚点不重叠越界；resize/seek/替换/stop 后无残留 layer。
+- UI/性能：合成 fixture 对比 18/25/36 的可见大小；高密度 30 分钟对象与 layer 上限；大
+  文字、Reduce Motion、VoiceOver 不因弹幕字号功能退化。
+
+### 发送（未来）
+
+- contract：只允许离散字号，精确字段、POST、来源、CSRF 注入位置；Cookie 不进入 GET
+  游客、媒体、图片或 loopback。
+- 状态：401/登录失效、403/412/业务拒绝、频率限制、审核、超时、取消、响应丢失、重复点击、
+  A→B→A 迟到结果与 logout 清理。
+- fixture：全部使用虚构 identity/text 和 `example.invalid`，不保存真实请求或响应。
+- 真实验证：另行取得用户授权后，使用专用测试账号和一条明确允许测试的内容；记录字段名、
+  状态分类和计数，不记录正文、Cookie/token、完整认证 URL 或完整响应。
+
+## 建议
+
+- **现在不做发送。** 它是新的认证写操作和产品范围，不是“小字号 UI”附带的一行参数。
+- **拆分两个 milestone。** 先把收到的字号正确呈现，作为只读播放正确性；发送能力只有在
+  被选为唯一下一阶段、更新产品愿景/路线图并建立写操作威胁模型后再实施。
+- 若只想让用户整体缩放所有弹幕，那是本地显示偏好，与“按发送者选择的小字号呈现”及
+  “发送小字号”是第三个不同需求，应单独命名，避免复用 `fontSize` 造成语义混淆。


### PR DESCRIPTION
## 变化

- 将收到的弹幕字号收敛为离散兼容集合：18（小）、25（标准）、36（只读历史兼容）。
- 缺省 0、未知整数和绕过 API 的未知有限值回退为 25；非有限值失败关闭。
- CoreText 测量与 CATextLayer 使用同一个规范化字号。
- 36pt 等高于单个 lane 的文本占用连续 lane，并完整覆盖回收、过期、滚动碰撞和 bottom resize 锚定。
- 补充公开 OSS 与官方可观察边界调研文档。

## 原因与用户影响

此前 API 模型已经保留 font size，但生产 renderer 始终使用固定 24pt；收到的小字号无法按发送者选择呈现。直接只缩放最终图层还会使测量和碰撞几何失配，因此本次同时统一测量、渲染和 lane 占用。

用户现在可以在播放中看到收到的小字号；36 仅用于接收兼容。该 PR 不新增弹幕输入、发送 endpoint、认证写授权器、CSRF/WBI 或发送 UI。

## 验证

- Xcode 26.6。
- 最终 PR 分支执行 `sh Scripts/run-quality-gates.sh app closure`：
  - static contracts 通过
  - Swift Package 通过
  - App build-for-testing 通过
  - App unit tests 通过
  - 使用全新隔离 SwiftPM/Xcode 缓存，完成后清理
- 首次 closure 中一个与本 PR 文件无关的 `VideoDetailLifecycleTests.replacementKeepsPlayerSurfaceUntilReset()` 断言失败；第二次全新隔离完整 closure 通过，未修改该测试或相关生产代码。
- 定向测试覆盖：
  - 18 < 25 < 36 的实际测量与最终字体
  - 36pt 后继小字号跳过完整连续 lane
  - tall fixed remove 与 tall scrolling expire 后全部 lane 可复用
  - 36pt bottom resize 保持底边锚定
  - 未知值回退与 NaN/±infinity 失败关闭
- 独立 agent review 的全部 finding 已关闭。
- 人工 Debug App 生产组合路径：游客热门列表、公开视频详情、播放和真实弹幕加载正常；弹幕关闭后清空、重新开启后恢复，目视未见纵向覆盖。

## 未覆盖边界

- 未登录、未发送真实弹幕，也未记录 Cookie、token、完整 URL 或远端响应。
- 远端事件不可控，人工画面不能确认每条弹幕的具体协议字号；离散字号与多 lane 契约由确定性测试证明。
- 未执行签名/Keychain、VoiceOver、长时间性能或不同 macOS/Xcode 矩阵验证。
