### PR TITLE
fix(player): 保证窗口滚轮接管连续性

### DIFF
--- a/BiliKitMac/Platform/PlayerHostView.swift
+++ b/BiliKitMac/Platform/PlayerHostView.swift
@@ -57,10 +57,12 @@ private struct AVPlayerContainerView: NSViewRepresentable {
         view.controlsStyle = .default
         view.showsFullScreenToggleButton = true
         view.allowsPictureInPicturePlayback = true
+        view.installWindowScrollWheelShield()
         return view
     }
 
     func updateNSView(_ view: DanmakuPlayerView, context: Context) {
+        view.installWindowScrollWheelShield()
         view.requestMomentaryPlaybackRate = beginMomentaryPlaybackRate
         view.finishMomentaryPlaybackRate = endMomentaryPlaybackRate
         if view.player !== player {
@@ -174,7 +176,9 @@ private final class PlayerMomentaryRateBadgeHostingView:
 private final class DanmakuPlayerView: AVPlayerView {
     let danmakuOverlay: DanmakuOverlayView
     private let scrollWheelCaptureView = PlayerScrollWheelCaptureView()
+    private let windowScrollWheelShieldView = PlayerScrollWheelShieldView()
     private var installedDanmakuOverlay = false
+    private var installedWindowScrollWheelShield = false
     private var momentaryRateSessionID: UUID?
     private var momentaryRateItemIdentity: ObjectIdentifier?
     private weak var observedPlayer: AVPlayer?
@@ -221,11 +225,60 @@ private final class DanmakuPlayerView: AVPlayerView {
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         installDanmakuOverlayIfNeeded()
+        installWindowScrollWheelShield()
         startObservingFocusLoss()
+    }
+
+    override func layout() {
+        super.layout()
+        installWindowScrollWheelShield()
     }
 
     func cancelMomentaryPlaybackRate() {
         scrollWheelCaptureView.cancelInputSession()
+        if momentaryRateSessionID != nil {
+            endMomentaryPlaybackRate()
+        }
+    }
+
+    func handleWindowSurfaceScrollWheel(_ event: NSEvent) {
+        scrollWheelCaptureView.handleScrollWheel(
+            event,
+            playerFallbackPolicy: .consume
+        )
+    }
+
+    func installWindowScrollWheelShield() {
+        if !installedWindowScrollWheelShield {
+            installedWindowScrollWheelShield = true
+            windowScrollWheelShieldView.frame = bounds
+            windowScrollWheelShieldView.autoresizingMask = [.width, .height]
+            windowScrollWheelShieldView.onScrollWheel = { [weak self] event in
+                self?.handleWindowSurfaceScrollWheel(event)
+            }
+            windowScrollWheelShieldView.onPointerExited = { [weak self] in
+                self?.resetScrollInputSessionForPointerExit()
+            }
+        }
+        if windowScrollWheelShieldView.frame != bounds {
+            windowScrollWheelShieldView.frame = bounds
+        }
+        guard
+            windowScrollWheelShieldView.superview !== self
+                || subviews.last !== windowScrollWheelShieldView
+        else {
+            return
+        }
+        windowScrollWheelShieldView.removeFromSuperview()
+        addSubview(
+            windowScrollWheelShieldView,
+            positioned: .above,
+            relativeTo: nil
+        )
+    }
+
+    private func resetScrollInputSessionForPointerExit() {
+        scrollWheelCaptureView.resetInputSessionForPointerExit()
         if momentaryRateSessionID != nil {
             endMomentaryPlaybackRate()
         }
@@ -409,6 +462,74 @@ private final class DanmakuPlayerView: AVPlayerView {
     }
 }
 
+/// 普通窗口中位于 AVPlayerView 原生子视图上方的 scroll-only direct child。
+///
+/// 该视图没有自己的 router 或播放状态；它只把 precise scroll-wheel 转交给
+/// `contentOverlayView` capture 持有的唯一 surface coordinator。其他输入穿透给 AVKit。
+@MainActor
+final class PlayerScrollWheelShieldView: NSView {
+    var onScrollWheel: (NSEvent) -> Void = { _ in }
+    var onPointerExited: () -> Void = {}
+    private var pointerTrackingArea: NSTrackingArea?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setAccessibilityElement(false)
+    }
+
+    static func capturesEvent(
+        ofType type: NSEvent.EventType?,
+        isPrecise: Bool
+    ) -> Bool {
+        type == .scrollWheel && isPrecise
+    }
+
+    static func capturesEvent(_ event: NSEvent) -> Bool {
+        guard event.type == .scrollWheel else { return false }
+        return event.hasPreciseScrollingDeltas
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard let event = NSApp.currentEvent else { return nil }
+        return Self.capturesEvent(event) ? self : nil
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        onScrollWheel(event)
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let pointerTrackingArea {
+            removeTrackingArea(pointerTrackingArea)
+        }
+        let trackingArea = NSTrackingArea(
+            rect: .zero,
+            options: [
+                .mouseEnteredAndExited,
+                .activeInKeyWindow,
+                .inVisibleRect,
+            ],
+            owner: self
+        )
+        addTrackingArea(trackingArea)
+        pointerTrackingArea = trackingArea
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        handlePointerExit()
+    }
+
+    func handlePointerExit() {
+        onPointerExited()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+}
+
 /// 安装在 AVKit 公开 content overlay 中、位于原生控制条下方的透明滚轮命中层。
 ///
 /// 只对 scroll-wheel 事件参与 hit testing；点击、拖动、magnify、键盘与辅助功能继续穿透。
@@ -453,7 +574,17 @@ final class PlayerScrollWheelCaptureView: NSView {
     }
 
     override func scrollWheel(with event: NSEvent) {
-        surfaceCapture.handleScrollWheel(event)
+        handleScrollWheel(event, playerFallbackPolicy: .dispatchToPlayer)
+    }
+
+    func handleScrollWheel(
+        _ event: NSEvent,
+        playerFallbackPolicy: PlayerScrollWheelPlayerFallbackPolicy
+    ) {
+        surfaceCapture.handleScrollWheel(
+            event,
+            playerFallbackPolicy: playerFallbackPolicy
+        )
     }
 
     override func viewWillMove(toWindow newWindow: NSWindow?) {
@@ -480,6 +611,10 @@ final class PlayerScrollWheelCaptureView: NSView {
 
     func cancelInputSession() {
         surfaceCapture.cancelInputSession()
+    }
+
+    func resetInputSessionForPointerExit() {
+        surfaceCapture.resetInputSessionForPointerExit()
     }
 
     var hasMomentaryRateBadge: Bool {
@@ -532,6 +667,9 @@ final class PlayerScrollWheelSurfaceCapture {
     private var scrollWheelRouter = PlayerScrollWheelRouter()
     private var horizontalRateGesture = PlayerHorizontalRateGestureState()
     private var pendingScrollWheelEvents: [NSEvent] = []
+    private var pendingPlayerFallbackPolicy: PlayerScrollWheelPlayerFallbackPolicy?
+    private var activePlayerFallbackPolicy: PlayerScrollWheelPlayerFallbackPolicy?
+    private var previousEventPhase: NSEvent.Phase = []
     var isMomentaryRateAvailable: () -> Bool = { false }
     var onMomentaryRateBegan: (PlayerMomentaryRate) -> Void = { _ in }
     var onMomentaryRateEnded: () -> Void = {}
@@ -549,35 +687,56 @@ final class PlayerScrollWheelSurfaceCapture {
     }
 
     /// 纵向滚动交给详情页；播放中的精确横向手势用于临时倍速。
-    func handleScrollWheel(_ event: NSEvent) {
+    func handleScrollWheel(
+        _ event: NSEvent,
+        playerFallbackPolicy: PlayerScrollWheelPlayerFallbackPolicy =
+            .dispatchToPlayer
+    ) {
+        defer { previousEventPhase = event.phase }
         cancelAbandonedMomentaryRate(before: event)
         flushAbandonedPendingEvents(before: event)
+        let sequenceFallbackPolicy = fallbackPolicy(
+            for: event,
+            requested: playerFallbackPolicy
+        )
         let route = scrollWheelRouter.route(
             deltaX: event.scrollingDeltaX,
             deltaY: event.scrollingDeltaY,
             phase: event.phase,
             momentumPhase: event.momentumPhase,
             isPrecise: event.hasPreciseScrollingDeltas,
-            allowsMomentaryRate: isMomentaryRateAvailable()
+            allowsMomentaryRate: isMomentaryRateAvailable(),
+            adoptsOrphanedVerticalGesture:
+                sequenceFallbackPolicy == .consume
         )
         if route == .pending {
+            if pendingPlayerFallbackPolicy == nil {
+                pendingPlayerFallbackPolicy = sequenceFallbackPolicy
+            }
             pendingScrollWheelEvents.append(event)
             return
         }
 
         let events = pendingScrollWheelEvents + [event]
         pendingScrollWheelEvents.removeAll(keepingCapacity: true)
+        let resolvedFallbackPolicy =
+            pendingPlayerFallbackPolicy ?? sequenceFallbackPolicy
+        pendingPlayerFallbackPolicy = nil
         switch route {
         case .outerScroll:
             guard let scrollView = detailScrollViewAncestor else {
-                dispatchToAVKit(events)
+                handlePlayerFallback(
+                    events,
+                    policy: resolvedFallbackPolicy
+                )
+                finishFallbackPolicyIfNeeded(after: event)
                 return
             }
             for event in events {
                 scrollView.scrollWheel(with: event)
             }
         case .player:
-            dispatchToAVKit(events)
+            handlePlayerFallback(events, policy: resolvedFallbackPolicy)
         case .momentaryRate:
             for event in events {
                 applyHorizontalRateAction(
@@ -593,16 +752,32 @@ final class PlayerScrollWheelSurfaceCapture {
                 )
             }
         case .discard:
-            return
+            break
         case .pending:
             assertionFailure("Pending scroll events must return before dispatch")
         }
+        finishFallbackPolicyIfNeeded(after: event)
     }
 
     func cancelInputSession() {
+        resetInputSession(quarantinesRemainder: true)
+    }
+
+    func resetInputSessionForPointerExit() {
+        resetInputSession(quarantinesRemainder: false)
+    }
+
+    private func resetInputSession(quarantinesRemainder: Bool) {
         let action = horizontalRateGesture.cancel()
         pendingScrollWheelEvents.removeAll(keepingCapacity: true)
-        scrollWheelRouter.cancelInputSession()
+        pendingPlayerFallbackPolicy = nil
+        activePlayerFallbackPolicy = nil
+        if quarantinesRemainder {
+            scrollWheelRouter.cancelInputSession()
+        } else {
+            scrollWheelRouter.resetPreservingCancellationQuarantine()
+        }
+        previousEventPhase = []
         applyHorizontalRateAction(action)
     }
 
@@ -650,32 +825,78 @@ final class PlayerScrollWheelSurfaceCapture {
         }
     }
 
-    private func flushAbandonedPendingEvents(before event: NSEvent) {
+    private func handlePlayerFallback<Events: Sequence>(
+        _ events: Events,
+        policy: PlayerScrollWheelPlayerFallbackPolicy
+    ) where Events.Element == NSEvent {
+        guard policy == .dispatchToPlayer else { return }
+        dispatchToAVKit(events)
+    }
+
+    private func flushAbandonedPendingEvents(
+        before event: NSEvent
+    ) {
         guard !pendingScrollWheelEvents.isEmpty else { return }
-        let previousPhase = pendingScrollWheelEvents.last?.phase ?? []
-        let startsNewGesture =
-            event.phase.contains(.mayBegin)
-            || (event.phase.contains(.began)
-                && !previousPhase.contains(.mayBegin))
-        let leavesDirectGesture = event.phase.isEmpty
-        guard startsNewGesture || leavesDirectGesture else { return }
-        dispatchToAVKit(pendingScrollWheelEvents)
+        let leavesDirectGesture =
+            event.phase.isEmpty && event.momentumPhase.isEmpty
+        guard startsNewDirectGesture(event) || leavesDirectGesture else {
+            return
+        }
+        handlePlayerFallback(
+            pendingScrollWheelEvents,
+            policy: pendingPlayerFallbackPolicy ?? .dispatchToPlayer
+        )
         pendingScrollWheelEvents.removeAll(keepingCapacity: true)
+        pendingPlayerFallbackPolicy = nil
+        activePlayerFallbackPolicy = nil
         applyHorizontalRateAction(horizontalRateGesture.cancel())
         scrollWheelRouter.reset()
+        previousEventPhase = []
+    }
+
+    private func fallbackPolicy(
+        for event: NSEvent,
+        requested: PlayerScrollWheelPlayerFallbackPolicy
+    ) -> PlayerScrollWheelPlayerFallbackPolicy {
+        let startsUnphasedInput =
+            event.phase.isEmpty && event.momentumPhase.isEmpty
+        if startsNewDirectGesture(event) || startsUnphasedInput {
+            activePlayerFallbackPolicy = requested
+        } else if activePlayerFallbackPolicy == nil {
+            activePlayerFallbackPolicy = requested
+        }
+        return activePlayerFallbackPolicy ?? requested
+    }
+
+    private func finishFallbackPolicyIfNeeded(after event: NSEvent) {
+        if event.phase.contains(.cancelled)
+            || event.momentumPhase.contains(.ended)
+            || event.momentumPhase.contains(.cancelled)
+            || (event.phase.isEmpty && event.momentumPhase.isEmpty)
+        {
+            activePlayerFallbackPolicy = nil
+        }
     }
 
     private func cancelAbandonedMomentaryRate(before event: NSEvent) {
-        let previousPhase = pendingScrollWheelEvents.last?.phase ?? []
-        let startsNewGesture =
-            event.phase.contains(.mayBegin)
-            || (event.phase.contains(.began)
-                && !previousPhase.contains(.mayBegin))
         let startsUnphasedInput =
             event.phase.isEmpty && event.momentumPhase.isEmpty
-        guard startsNewGesture || startsUnphasedInput else { return }
+        guard startsNewDirectGesture(event) || startsUnphasedInput else {
+            return
+        }
         applyHorizontalRateAction(horizontalRateGesture.cancel())
     }
+
+    private func startsNewDirectGesture(_ event: NSEvent) -> Bool {
+        event.phase.contains(.mayBegin)
+            || (event.phase.contains(.began)
+                && !previousEventPhase.contains(.mayBegin))
+    }
+}
+
+enum PlayerScrollWheelPlayerFallbackPolicy: Equatable {
+    case dispatchToPlayer
+    case consume
 }
 
 struct PlayerHorizontalRateGestureState {
@@ -757,7 +978,8 @@ struct PlayerScrollWheelRouter {
         phase: NSEvent.Phase,
         momentumPhase: NSEvent.Phase,
         isPrecise: Bool = true,
-        allowsMomentaryRate: Bool = false
+        allowsMomentaryRate: Bool = false,
+        adoptsOrphanedVerticalGesture: Bool = false
     ) -> Route {
         if discardsCancelledGestureRemainder {
             let startsNewDirectGesture =
@@ -791,7 +1013,16 @@ struct PlayerScrollWheelRouter {
             reset()
             directGestureHasBegun = true
         } else if !directGestureHasBegun {
-            return .player
+            guard adoptsOrphanedVerticalGesture,
+                isPrecise,
+                phase.contains(.changed),
+                isClearlyVertical(deltaX: deltaX, deltaY: deltaY)
+            else {
+                return .player
+            }
+            reset()
+            directGestureHasBegun = true
+            gestureRoute = .outerScroll
         }
 
         if !isPrecise {
@@ -864,6 +1095,14 @@ struct PlayerScrollWheelRouter {
         discardsCancelledGestureRemainder = true
     }
 
+    mutating func resetPreservingCancellationQuarantine() {
+        let preservesCancellationQuarantine =
+            discardsCancelledGestureRemainder
+        reset()
+        discardsCancelledGestureRemainder =
+            preservesCancellationQuarantine
+    }
+
     private func accumulatedRoute(
         allowsMomentaryRate: Bool
     ) -> Route? {
@@ -894,5 +1133,16 @@ struct PlayerScrollWheelRouter {
         let verticalMagnitude = abs(deltaY)
         guard horizontalMagnitude != verticalMagnitude else { return nil }
         return verticalMagnitude > horizontalMagnitude ? .outerScroll : .player
+    }
+
+    private func isClearlyVertical(
+        deltaX: CGFloat,
+        deltaY: CGFloat
+    ) -> Bool {
+        let horizontalMagnitude = abs(deltaX)
+        let verticalMagnitude = abs(deltaY)
+        return verticalMagnitude >= Self.minimumAxisTravel
+            && verticalMagnitude - horizontalMagnitude
+                >= Self.minimumAxisLead
     }
 }

--- a/BiliKitMacTests/PlayerHostViewIdentityTests.swift
+++ b/BiliKitMacTests/PlayerHostViewIdentityTests.swift
@@ -151,6 +151,179 @@ struct PlayerHostViewIdentityTests {
 
         #expect(scrollView.receivedScrollWheelEvents.count == 1)
         #expect(scrollView.receivedScrollWheelEvents.first === event)
+
+        var shieldPlayerEvents: [NSEvent] = []
+        let shieldCapture = PlayerScrollWheelSurfaceCapture(
+            anchorView: NSView(frame: .zero),
+            dispatchToPlayer: { shieldPlayerEvents.append($0) }
+        )
+        let horizontalEvent = try makeScrollWheelEvent(
+            deltaX: -80,
+            deltaY: 0
+        )
+        shieldCapture.handleScrollWheel(
+            horizontalEvent,
+            playerFallbackPolicy: .consume
+        )
+        #expect(shieldPlayerEvents.isEmpty)
+
+        var overlayPlayerEvents: [NSEvent] = []
+        let overlayCapture = PlayerScrollWheelSurfaceCapture(
+            anchorView: NSView(frame: .zero),
+            dispatchToPlayer: { overlayPlayerEvents.append($0) }
+        )
+        overlayCapture.handleScrollWheel(horizontalEvent)
+        #expect(overlayPlayerEvents.count == 1)
+        #expect(overlayPlayerEvents.first === horizontalEvent)
+
+        var alternatingPlayerEvents: [NSEvent] = []
+        let alternatingCapture = PlayerScrollWheelSurfaceCapture(
+            anchorView: NSView(frame: .zero),
+            dispatchToPlayer: { alternatingPlayerEvents.append($0) }
+        )
+        let pendingShieldEvent = try makeScrollWheelEvent(
+            deltaX: 1,
+            deltaY: 1,
+            phase: .began
+        )
+        let resolvingOverlayEvent = try makeScrollWheelEvent(
+            deltaX: -80,
+            deltaY: 0,
+            phase: .changed
+        )
+        alternatingCapture.handleScrollWheel(
+            pendingShieldEvent,
+            playerFallbackPolicy: .consume
+        )
+        alternatingCapture.handleScrollWheel(
+            resolvingOverlayEvent,
+            playerFallbackPolicy: .dispatchToPlayer
+        )
+        #expect(alternatingPlayerEvents.isEmpty)
+
+        var crossingPlayerEvents: [NSEvent] = []
+        let crossingCapture = PlayerScrollWheelSurfaceCapture(
+            anchorView: NSView(frame: .zero),
+            dispatchToPlayer: { crossingPlayerEvents.append($0) }
+        )
+        let mayBeginShieldEvent = try makeScrollWheelEvent(
+            deltaX: -80,
+            deltaY: 0,
+            phase: .mayBegin
+        )
+        let beganOverlayEvent = try makeScrollWheelEvent(
+            deltaX: 1,
+            deltaY: 1,
+            phase: .began
+        )
+        let followingOverlayEvent = try makeScrollWheelEvent(
+            deltaX: -20,
+            deltaY: 0,
+            phase: .changed
+        )
+        crossingCapture.handleScrollWheel(
+            mayBeginShieldEvent,
+            playerFallbackPolicy: .consume
+        )
+        crossingCapture.handleScrollWheel(
+            beganOverlayEvent,
+            playerFallbackPolicy: .dispatchToPlayer
+        )
+        crossingCapture.handleScrollWheel(
+            resolvingOverlayEvent,
+            playerFallbackPolicy: .dispatchToPlayer
+        )
+        crossingCapture.handleScrollWheel(
+            followingOverlayEvent,
+            playerFallbackPolicy: .dispatchToPlayer
+        )
+        #expect(crossingPlayerEvents.isEmpty)
+
+        var reversePlayerEvents: [NSEvent] = []
+        let reverseCapture = PlayerScrollWheelSurfaceCapture(
+            anchorView: NSView(frame: .zero),
+            dispatchToPlayer: { reversePlayerEvents.append($0) }
+        )
+        reverseCapture.handleScrollWheel(
+            pendingShieldEvent,
+            playerFallbackPolicy: .dispatchToPlayer
+        )
+        reverseCapture.handleScrollWheel(
+            resolvingOverlayEvent,
+            playerFallbackPolicy: .consume
+        )
+        #expect(reversePlayerEvents.count == 2)
+        #expect(reversePlayerEvents[0] === pendingShieldEvent)
+        #expect(reversePlayerEvents[1] === resolvingOverlayEvent)
+
+        var momentumPlayerEvents: [NSEvent] = []
+        let momentumCapture = PlayerScrollWheelSurfaceCapture(
+            anchorView: NSView(frame: .zero),
+            dispatchToPlayer: { momentumPlayerEvents.append($0) }
+        )
+        let overlayMomentumEvent = try makeScrollWheelEvent(
+            deltaX: -80,
+            deltaY: 0,
+            momentumPhase: .began
+        )
+        momentumCapture.handleScrollWheel(
+            pendingShieldEvent,
+            playerFallbackPolicy: .consume
+        )
+        momentumCapture.handleScrollWheel(
+            overlayMomentumEvent,
+            playerFallbackPolicy: .dispatchToPlayer
+        )
+        #expect(momentumPlayerEvents.isEmpty)
+
+        let pointerExitCapture = PlayerScrollWheelSurfaceCapture(
+            anchorView: scrollCaptureView
+        )
+        pointerExitCapture.handleScrollWheel(
+            pendingShieldEvent,
+            playerFallbackPolicy: .consume
+        )
+        pointerExitCapture.resetInputSessionForPointerExit()
+        let orphanedVerticalEvent = try makeScrollWheelEvent(
+            deltaX: 1,
+            deltaY: -12,
+            phase: .changed
+        )
+        pointerExitCapture.handleScrollWheel(
+            orphanedVerticalEvent,
+            playerFallbackPolicy: .consume
+        )
+        #expect(scrollView.receivedScrollWheelEvents.count == 2)
+        #expect(
+            scrollView.receivedScrollWheelEvents.last
+                === orphanedVerticalEvent
+        )
+
+        let quarantineCapture = PlayerScrollWheelSurfaceCapture(
+            anchorView: scrollCaptureView
+        )
+        quarantineCapture.cancelInputSession()
+        quarantineCapture.resetInputSessionForPointerExit()
+        quarantineCapture.handleScrollWheel(
+            orphanedVerticalEvent,
+            playerFallbackPolicy: .consume
+        )
+        #expect(scrollView.receivedScrollWheelEvents.count == 2)
+
+        let newVerticalGestureEvent = try makeScrollWheelEvent(
+            deltaX: 1,
+            deltaY: -12,
+            phase: .began
+        )
+        quarantineCapture.handleScrollWheel(
+            newVerticalGestureEvent,
+            playerFallbackPolicy: .consume
+        )
+        #expect(scrollView.receivedScrollWheelEvents.count == 3)
+        #expect(
+            scrollView.receivedScrollWheelEvents.last
+                === newVerticalGestureEvent
+        )
     }
 
     @Test(.timeLimit(.minutes(1)))
@@ -209,6 +382,41 @@ struct PlayerHostViewIdentityTests {
             )
         )
         #expect(scrollCaptureView.superview === playerView.contentOverlayView)
+        let scrollShieldView = try #require(
+            firstView(
+                ofType: PlayerScrollWheelShieldView.self,
+                in: hostingView
+            )
+        )
+        #expect(scrollShieldView.superview === playerView)
+        let playerSurfaceSubviews = playerView.subviews
+        let shieldIndex = try #require(
+            playerSurfaceSubviews.firstIndex { $0 === scrollShieldView }
+        )
+        #expect(shieldIndex == playerSurfaceSubviews.indices.last)
+        #expect(!scrollShieldView.isAccessibilityElement())
+        let lateAVKitSibling = NSView(frame: playerView.bounds)
+        playerView.addSubview(
+            lateAVKitSibling,
+            positioned: .above,
+            relativeTo: scrollShieldView
+        )
+        playerView.needsLayout = true
+        playerView.layoutSubtreeIfNeeded()
+        #expect(playerView.subviews.last === scrollShieldView)
+
+        scrollShieldView.removeFromSuperview()
+        playerView.setFrameSize(
+            NSSize(
+                width: playerView.bounds.width - 80,
+                height: playerView.bounds.height - 40
+            )
+        )
+        playerView.needsLayout = true
+        playerView.layoutSubtreeIfNeeded()
+        #expect(scrollShieldView.superview === playerView)
+        #expect(playerView.subviews.last === scrollShieldView)
+        #expect(scrollShieldView.frame == playerView.bounds)
         let danmakuOverlay = try #require(
             firstView(
                 ofType: DanmakuOverlayView.self,
@@ -241,9 +449,91 @@ struct PlayerHostViewIdentityTests {
         )
     }
 
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func windowShieldForwardsVerticalWheelThroughHostCoordinator()
+        async throws
+    {
+        let renderer = CoreAnimationDanmakuRenderer()
+        let controller = DanmakuPresentationController(
+            backend: renderer,
+            configuration: Self.emptyDanmakuConfiguration
+        )
+        let hostingView = NSHostingView(
+            rootView: PlayerHostView(
+                player: AVPlayer(),
+                danmakuRenderer: renderer,
+                danmakuController: controller
+            )
+            .frame(width: 800, height: 300)
+        )
+        hostingView.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        let scrollView = ScrollWheelRecordingScrollView(
+            frame: NSRect(x: 0, y: 0, width: 800, height: 300)
+        )
+        scrollView.documentView = hostingView
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 300),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = scrollView
+        window.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
+        window.orderFrontRegardless()
+        defer {
+            window.orderOut(nil)
+            window.contentView = NSView()
+        }
+        hostingView.layoutSubtreeIfNeeded()
+
+        #expect(
+            await waitUntil(in: hostingView) {
+                self.firstView(
+                    ofType: PlayerScrollWheelShieldView.self,
+                    in: hostingView
+                ) != nil
+            },
+            "普通窗口 shield 应随真实 PlayerHostView 完成挂载"
+        )
+        let shield = try #require(
+            firstView(
+                ofType: PlayerScrollWheelShieldView.self,
+                in: hostingView
+            )
+        )
+        let event = try makeScrollWheelEvent(deltaX: 0, deltaY: -80)
+        shield.scrollWheel(with: event)
+
+        #expect(scrollView.receivedScrollWheelEvents.count == 1)
+        #expect(scrollView.receivedScrollWheelEvents.first === event)
+
+        let lockedHorizontalEvent = try makeScrollWheelEvent(
+            deltaX: -12,
+            deltaY: 1,
+            phase: .began
+        )
+        shield.scrollWheel(with: lockedHorizontalEvent)
+        #expect(scrollView.receivedScrollWheelEvents.count == 1)
+
+        shield.handlePointerExit()
+
+        let orphanedVerticalEvent = try makeScrollWheelEvent(
+            deltaX: 1,
+            deltaY: -12,
+            phase: .changed
+        )
+        shield.scrollWheel(with: orphanedVerticalEvent)
+        #expect(scrollView.receivedScrollWheelEvents.count == 2)
+        #expect(
+            scrollView.receivedScrollWheelEvents.last
+                === orphanedVerticalEvent
+        )
+    }
+
     @Test
     @MainActor
-    func contentOverlayCaptureOnlyParticipatesInScrollWheelHitTesting() {
+    func contentOverlayCaptureOnlyParticipatesInScrollWheelHitTesting() throws {
         #expect(
             PlayerScrollWheelCaptureView.capturesEvent(
                 ofType: .scrollWheel
@@ -260,6 +550,57 @@ struct PlayerHostViewIdentityTests {
             )
         )
         #expect(!PlayerScrollWheelCaptureView.capturesEvent(ofType: nil))
+        #expect(
+            PlayerScrollWheelShieldView.capturesEvent(
+                ofType: .scrollWheel,
+                isPrecise: true
+            )
+        )
+        #expect(
+            !PlayerScrollWheelShieldView.capturesEvent(
+                ofType: .scrollWheel,
+                isPrecise: false
+            )
+        )
+        let shield = PlayerScrollWheelShieldView(frame: .zero)
+        var pointerExitCount = 0
+        shield.onPointerExited = { pointerExitCount += 1 }
+        shield.handlePointerExit()
+        #expect(pointerExitCount == 1)
+        #expect(
+            !PlayerScrollWheelShieldView.capturesEvent(
+                ofType: .leftMouseDown,
+                isPrecise: true
+            )
+        )
+        #expect(
+            !PlayerScrollWheelShieldView.capturesEvent(
+                ofType: .magnify,
+                isPrecise: true
+            )
+        )
+        #expect(
+            !PlayerScrollWheelShieldView.capturesEvent(
+                ofType: nil,
+                isPrecise: true
+            )
+        )
+        let mouseMoveEvent = NSEvent.mouseEvent(
+            with: .mouseMoved,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 0,
+            pressure: 0
+        )
+        #expect(
+            !PlayerScrollWheelShieldView.capturesEvent(
+                try #require(mouseMoveEvent)
+            )
+        )
     }
 
     @Test
@@ -293,6 +634,56 @@ struct PlayerHostViewIdentityTests {
                 deltaY: -12,
                 phase: .began,
                 momentumPhase: []
+            ) == .outerScroll
+        )
+
+        var boundaryRouter = PlayerScrollWheelRouter()
+        #expect(
+            boundaryRouter.route(
+                deltaX: 1,
+                deltaY: -12,
+                phase: .changed,
+                momentumPhase: [],
+                adoptsOrphanedVerticalGesture: true
+            ) == .outerScroll
+        )
+        #expect(
+            boundaryRouter.route(
+                deltaX: -20,
+                deltaY: -1,
+                phase: .changed,
+                momentumPhase: [],
+                adoptsOrphanedVerticalGesture: true
+            ) == .outerScroll
+        )
+        var orphanedHorizontalRouter = PlayerScrollWheelRouter()
+        #expect(
+            orphanedHorizontalRouter.route(
+                deltaX: -12,
+                deltaY: 1,
+                phase: .changed,
+                momentumPhase: [],
+                allowsMomentaryRate: true,
+                adoptsOrphanedVerticalGesture: true
+            ) == .player
+        )
+        var orphanedNoiseRouter = PlayerScrollWheelRouter()
+        #expect(
+            orphanedNoiseRouter.route(
+                deltaX: 0.1,
+                deltaY: 0.2,
+                phase: .changed,
+                momentumPhase: [],
+                adoptsOrphanedVerticalGesture: true
+            ) == .player
+        )
+        #expect(
+            orphanedNoiseRouter.route(
+                deltaX: 1,
+                deltaY: -12,
+                phase: .changed,
+                momentumPhase: [],
+                adoptsOrphanedVerticalGesture: true
             ) == .outerScroll
         )
         #expect(
@@ -912,7 +1303,9 @@ struct PlayerHostViewIdentityTests {
 
     private func makeScrollWheelEvent(
         deltaX: Int32,
-        deltaY: Int32
+        deltaY: Int32,
+        phase: NSEvent.Phase = [],
+        momentumPhase: NSEvent.Phase = []
     ) throws -> NSEvent {
         let event = try #require(
             CGEvent(
@@ -924,7 +1317,25 @@ struct PlayerHostViewIdentityTests {
                 wheel3: 0
             )
         )
+        event.setIntegerValueField(
+            .scrollWheelEventScrollPhase,
+            value: cgScrollPhaseValue(phase)
+        )
+        event.setIntegerValueField(
+            .scrollWheelEventMomentumPhase,
+            value: cgScrollPhaseValue(momentumPhase)
+        )
         return try #require(NSEvent(cgEvent: event))
+    }
+
+    private func cgScrollPhaseValue(_ phase: NSEvent.Phase) -> Int64 {
+        var value: Int64 = 0
+        if phase.contains(.began) { value |= 1 }
+        if phase.contains(.changed) { value |= 2 }
+        if phase.contains(.ended) { value |= 4 }
+        if phase.contains(.cancelled) { value |= 8 }
+        if phase.contains(.mayBegin) { value |= 128 }
+        return value
     }
 
     @MainActor

--- a/docs/validation/M5.0-player-input-fullscreen-pip-2026-08-07.md
+++ b/docs/validation/M5.0-player-input-fullscreen-pip-2026-08-07.md
@@ -6,14 +6,21 @@
 原生画中画的实现证据和失败路线。它用于防止后续再次依赖错误的 responder chain、误测
 旧 App，或把 AVKit 原生行为误判为产品实现。
 
-当前生产结果已经通过本地 App gate，并由用户在签名开发版、真实远端播放和真实触控板上
-确认以下行为：
+2026-08-07 当时的生产结果通过了本地 App gate，并由用户在签名开发版、真实远端播放和
+真实触控板上确认以下行为：
 
 - 指针位于视频区域时，纵向双指滚动可以滚动外层详情页；
 - 播放中横向双指手势分别提供临时 `2X`／`0.5X`，松开后恢复原速；
 - 详情页与 AVKit detached fullscreen 使用相同的手势和提示层；
 - 提示位于弹幕之上、AVKit 原生控制条之下；
 - 原生全屏按钮和原生画中画可用，退出后仍回到同一个播放器宿主。
+
+2026-08-11 又确认了一个此前未覆盖的边界：窗口态改用 `.default`／inline controls 后，
+`contentOverlayView` capture 位于原生控制条下方。指针从详情容器进入播放器控件区域时，
+同一触控板序列可能转由 AVKit 处理，表现为短暂停顿后触发原生横向 seek。当前生产契约因此
+补充为：普通窗口用一个 scroll-only direct-child shield 覆盖完整 AVPlayerView；AVKit detached
+fullscreen 仍使用随 `contentOverlayView` 迁移的原 capture。两个入口共享同一 router、临时
+倍速 session 和 badge owner，不创建第二个播放器或第二套手势状态。
 
 这不是对所有鼠标、触控板设置、macOS 版本或辅助技术的完整兼容性声明。当前实现和测试
 仍应以代码与质量 Gate 为准，本文只记录 2026-08-07 的决策与证据。
@@ -24,34 +31,66 @@
 | --- | --- |
 | 有明确纵向主轴的滚轮或触控板序列 | 交给播放器外层的详情 `NSScrollView` |
 | 播放中、有 phase 且有 precise delta 的横向触控板序列 | 达到阈值后临时 `2X`／`0.5X`，结束时恢复 |
-| 无 phase 的传统滚轮、非 precise 横向输入或倍速不可用 | 保留 AVPlayerView 原路径 |
+| 普通窗口内的 precise 横向输入，但倍速不可用 | 由 direct-child shield 消费，不回落 AVKit seek |
+| 普通窗口内 precise 但无 phase 的纵向输入 | 交给外层详情滚动 |
+| 普通窗口内 precise 但无 phase 的横向输入 | 由 shield 消费，不回落 AVKit seek |
+| 非 precise 输入 | 穿透 shield，保留 AVPlayerView 原路径 |
 | 斜向输入 | 缓冲初始噪声后按累计主轴锁定，整段序列只交给一个 owner |
 | momentum | 沿用已完成的路由；临时倍速在 momentum 前结束 |
 | 点击、双击、拖动、magnify、键盘和辅助功能 | 透明捕获层返回 `nil`，继续使用 AVKit 原行为 |
-| 全屏 | AVKit 携带同一个 `contentOverlayView`，不建立第二个 player host |
+| 全屏视频区域 | AVKit 携带同一个 `contentOverlayView` capture，不建立第二个 player host |
+| 全屏原生控制区域 | 继续由 AVKit 处理；不承诺自定义滚轮优先 |
 | 画中画 | 使用 AVKit 原生 PiP；当前不暂停详情播放器中的弹幕呈现 |
 
 横向方向先用 `NSEvent.isDirectionInvertedFromDevice` 归一化，因此产品的物理滑动方向不应
-随系统“自然滚动”偏好翻转。只有确认为纵向主轴的序列才允许越过 AVKit；横向、模糊或
-无法安全归属的序列不会被解释为 seek。
+随系统“自然滚动”偏好翻转。普通窗口中，direct-child shield 命中的 precise 序列不会再回落为
+AVKit seek；明确纵向序列交给外层详情滚动，明确横向序列在播放可用时进入临时倍速。全屏
+原生控制区域不在这项强保证内。
+
+从详情容器跨入播放器时，AppKit 可能只把后半段 `.changed` 事件交给 shield。窗口入口只在
+当前 delta 已明确纵向时接续这种 orphaned sequence，并在后续样本中锁定外层滚动；孤立横向
+changed 会被消费，但不会中途启动临时倍速，以免指针再次离开播放器后收不到结束事件。
 
 ## 最终视图层级
 
 ```text
 DanmakuPlayerView : AVPlayerView
 ├─ AVKit video content
-├─ contentOverlayView
+├─ contentOverlayView（随 detached fullscreen 迁移）
 │  ├─ DanmakuOverlayView
 │  │  └─ CoreAnimationDanmakuRenderer.rootLayer
-│  └─ PlayerScrollWheelCaptureView（显式位于弹幕之上）
+│  └─ PlayerScrollWheelCaptureView（唯一 router/session/badge owner）
 │     └─ PlayerMomentaryRateBadgeHostingView（仅激活期间存在）
-└─ AVKit native controls
+├─ AVKit native controls
+└─ PlayerScrollWheelShieldView（普通窗口 direct child，仅 precise scroll 命中）
 ```
 
 `contentOverlayView` 是 AVKit 用于把自定义内容放在视频和原生控制之间的公开 API。弹幕、
-滚轮捕获层和临时倍速提示统一由这个 surface 承载；`DanmakuOverlayView.hitTest` 继续始终
-返回 `nil`。捕获层只在当前 AppKit event 是 `.scrollWheel` 时参与 hit testing，因此把它
-放在弹幕上方不会遮挡控制条、点击或拖动。
+唯一滚轮 coordinator 和临时倍速提示仍统一由这个 surface 承载；
+`DanmakuOverlayView.hitTest` 继续始终返回 `nil`。普通窗口的 direct-child shield 不拥有 router
+或播放状态，只把 precise scroll 转发给该 coordinator；点击、拖动、magnify、键盘、辅助
+功能和非 precise 滚轮都返回 `nil`，继续命中 AVKit。现有 probe 中 detached fullscreen
+没有迁移这个 direct child，运行时因此回到 `contentOverlayView` 入口；这不是 AVKit 的公开
+迁移保证，生产改动后仍需全屏往返复测。
+
+## 2026-08-11：控制条上方的普通窗口 scroll 命中入口
+
+此前“capture 位于 `contentOverlayView`”只证明视频区域与 detached fullscreen 可以共用
+入口，没有证明 inline controls 上方的真实 hit target。后来测试也只直接调用 capture 和
+纯 router，未覆盖从详情容器跨进控制区的物理触控板序列。因此 controls style 从
+`.floating` 变为 `.default` 后，AVKit 可以先命中控制区并恢复原生 seek。
+
+只读 local monitor 即使返回 `nil`，也不能保证 AVKit 没有从更早的内部观察或相关 gesture
+stream 获得同一输入；在 `.inline`、`.floating`、`.minimal` 与 `.none` 四种样式的 probe 中，
+monitor 均看到了事件，但播放器时间仍从 30 秒明显前进。相反，普通窗口的 direct-child shield
+改变了真实 hit target：真实触控板横向滑动时 shield 收到 143 个事件，时间保持 30.00 秒；
+随后直接拖动原生进度条仍能把时间移动到 76.96 秒。这证明它只隔离 scroll，没有破坏点击
+与拖动。
+
+probe 中同一 shield 未被 AVKit 携带进 detached fullscreen；直接 child 没有公共迁移保证。
+因此当前选择显式的不对称运行时边界：窗口态在完整播放器区域保证自定义 precise scroll
+优先；全屏视频区域继续由 `contentOverlayView` capture 处理，全屏原生控制区域保持 AVKit 原生。
+这比自建控制条或 App 管理整窗全屏复杂度低，也避免了后者曾出现的整窗白边问题。
 
 ## 踩过的坑与结论
 
@@ -104,8 +143,9 @@ seek；长距离滑动中还可能从暂停式扫描转为 seek。它是合理�
 全屏重挂载或未来复用 host 时，捕获层的 responder chain 不一定包含详情 `NSScrollView`。
 仅检查 `nextResponder != nil` 会把纵向事件送进一个没有详情 scroll owner 的链并吞掉。
 
-当前实现只在确认穿过 AVPlayerView 后找到外层 `NSScrollView` 时转交纵向序列；找不到时
-回退 AVKit 原路径。
+当前实现只在确认穿过 AVPlayerView 后找到外层 `NSScrollView` 时转交纵向序列；找不到时，
+全屏 `contentOverlayView` 入口回退 AVKit 原路径，普通窗口 shield 入口则消费 precise 序列，
+避免重新触发原生 seek。
 
 ### 6. 生命周期取消必须隔离旧手势尾流
 
@@ -169,26 +209,43 @@ PiP 后详情播放器的弹幕呈现继续运行，以换取退出 PiP 时自�
 - 把滚轮解释为 seek；
 - 向 AVKit 私有子视图重放事件；
 - 依赖 AVKit 私有 class、selector 或 view hierarchy；
-- 为详情页与全屏分别维护两套捕获层或提示状态；
+- 为详情页与全屏分别维护两套 router、session 或提示状态；
 - 新建第二个 `AVPlayerView`／player host；
 - 自制播放器控制条代替 AVKit；
 - 用大量 XCUITest 模拟系统滚轮 routing 并把它当成真实触控板证据。
 
 ## 自动化与人工证据
 
-验证环境为 Xcode 26.6（17F113）、macOS arm64 签名开发版。最高适用
-`sh Scripts/run-quality-gates.sh app` 在最终改动上通过，覆盖：
+验证环境为 Xcode 26.6（17F113）、macOS arm64 签名开发版。2026-08-07 的生产基线通过了
+最高适用 `sh Scripts/run-quality-gates.sh app`。2026-08-11 的 direct-child 改动通过
+`PlayerHostViewIdentityTests` 专属 suite，本次完整 app iteration 也已通过。fresh closure 只失败于
+既有 `VideoDetailLifecycleTests.replacementKeepsPlayerSurfaceUntilReset()` 的滚动位置时序断言；
+同一 `HEAD` 的无改动临时副本此前已在 fresh closure 中复现相同失败。因此本轮不能把
+closure 记为通过，也没有放宽或修改该断言。已有自动化覆盖：
 
 - axis 初始噪声、斜向累计判定、phase/momentum 和 non-precise 序列；
 - natural scrolling 的横向方向归一；
 - 临时倍速阈值、结束、item replacement、stop、pause、用户改速与旧 token 隔离；
 - failure/clear 路径有源码清理守卫，但没有在临时 session 激活时分别触发的专门断言；
 - 生命周期 cancel 后的 stale changed/momentum quarantine；
+- pointer-exit helper 与生产 closure wiring 会重置旧 router/pending/rate；明确纵向的后续 orphaned
+  `.changed` 仍可接续外层滚动。`NSTrackingArea` 的真实系统投递尚未由自动测试覆盖；
+- pending 与 momentum 的 fallback policy 按输入序列锁定，入口切换不会改变旧序列 owner；
 - 外层详情 ScrollView 的真实宿主路由；无详情 scroll ancestor 回退目前只有源码守卫和
   全屏人工路径，没有独立宿主断言；
 - capture 只参与 scroll-wheel hit testing；
+- 普通窗口 direct-child shield 只命中 precise scroll，位于 AVPlayerView 原生子视图上方，
+  并在 AVKit fallback 路径消费序列；content overlay 入口仍保留自己的 AVKit fallback；
+- AVKit 后插 sibling 或移除 shield 后，layout 使用同一个 shield identity 幂等恢复 topmost；
 - 唯一 badge ownership、badge/danmaku 相对层级；
 - 全屏与画中画开关，以及真实 AVPlayerView identity/dismantle 连续性。
+
+2026-08-11 的首次签名 App 复测发现并关闭了一个启动级回归：AppKit 在 tracking-area／cursor
+刷新期间会用非 scroll-wheel 当前事件执行 shield `hitTest`，而直接读取该事件的
+`hasPreciseScrollingDeltas` 会抛 Objective-C exception。修复后只有先确认事件类型为
+`.scrollWheel` 才读取 precise 属性；单元测试用真实 `.mouseMoved` `NSEvent` 锁定该边界。
+重新 Apple Development 签名后，真实账号产品已能打开视频卡片并稳定显示原生播放器、全屏、
+PiP、时间线和弹幕控件；复测后没有生成新的 crash report。此观察仍不等于物理触控板手势通过。
 
 用户在多轮签名 App 观察中确认：
 
@@ -197,6 +254,8 @@ PiP 后详情播放器的弹幕呈现继续运行，以换取退出 PiP 时自�
 - 全屏入口、全屏左右临时倍速和提示位置；
 - 提示不再被弹幕遮挡；
 - 画中画进入／退出正常，弹幕继续呈现可接受。
+- 最终签名产品中，普通窗口跨播放器滚动成功；进入全屏后继续使用原有
+  `contentOverlayView` 捕获路径，行为保持不变。
 
 自动测试不能替代这些触控板与 AVKit detached window 观察；反过来，一次人工成功也不能
 替代 router、rate owner 和资源清理测试。
@@ -209,13 +268,19 @@ PiP 后详情播放器的弹幕呈现继续运行，以换取退出 PiP 时自�
 - 不同触控板硬件、传统鼠标、Intel 和其他 macOS 版本没有本轮真实矩阵；
 - AVKit 内部控件与 detached fullscreen 结构不是公开稳定契约；实现只能依赖
   `contentOverlayView`、公开 customization property 和标准 responder 行为。
+- 普通窗口 direct-child shield 的物理触控板 probe 已覆盖 inline timeline 上方横向滚动与随后
+  鼠标拖动；用户也已确认最终签名产品进入 detached fullscreen 后保持原有
+  `contentOverlayView` 捕获逻辑。自动测试仍只锁定结构、fallback policy 与唯一
+  AVPlayerView identity，未覆盖不同硬件和系统设置矩阵。
 
 ## 后续修改前检查表
 
 1. 确认测试的 executable 完整路径和 PID，排除同 Bundle ID 的旧进程。
 2. 保持唯一 `PlayerHostView`／`AVPlayerView`／`AVPlayer`，不要为全屏或 PiP 建第二套 surface。
-3. 自定义视频覆盖内容优先放在公开 `contentOverlayView`，并显式测试 sibling z-order。
-4. 新输入只能扩展现有 router/session owner；不能增加全局 monitor 或跨 responder 重放。
+3. 自定义视频覆盖内容优先放在公开 `contentOverlayView`，并显式测试 sibling z-order；若
+   窗口态必须覆盖 inline controls，只增加无状态的 scroll-only direct-child 入口。
+4. 新输入只能扩展现有 router/session owner；不能增加全局／local monitor 或跨 responder
+   重放。
 5. 临时播放状态由 engine/timeline 拥有，UI 只显示 session 结果。
 6. 修改 event routing、rate lifecycle 或 overlay hierarchy 后运行 App gate，并使用签名 App
    完成一次真实触控板的详情／全屏／PiP 往返。


### PR DESCRIPTION
## 变化

- 在普通窗口的 `AVPlayerView` 顶层增加只命中 precise scroll-wheel 的无状态 shield，覆盖 inline controls 上方区域；点击、拖动、缩放、键盘、辅助功能和非 precise 滚轮仍交给 AVKit。
- 让普通窗口 shield 与 `contentOverlayView` capture 共用唯一的滚轮 router、临时倍速 session 和提示 owner；detached fullscreen 保持原有 `contentOverlayView` 路径。
- 对跨边界缺失起始 phase 的明确纵向 `.changed` 做有限接续，并按完整输入序列锁定 AVKit fallback policy。
- 在 pointer exit 时重置普通输入状态，但保留 lifecycle cancel 已建立的旧尾流 quarantine。
- 补充真实 `PlayerHostView` 层级、跨入口 `.mayBegin → .began → .changed`、pointer exit、旧尾流隔离、hit testing、层级恢复和资源清理测试，并同步验证记录。

## 原因与用户影响

`AVPlayerView.controlsStyle = .default` 在当前 SDK 中等同 inline controls。原来的捕获层位于 `contentOverlayView`，处在原生控制条下方；指针从外层详情容器滑入播放器控件区域时，同一触控板序列可能转交给 AVKit，表现为短暂停顿后恢复原生横向 seek。

修复后，普通窗口完整播放器区域内的 precise scroll 优先进入现有自定义路由：纵向继续滚动详情，播放可用时横向进入临时倍速，不可用时不会回落为 AVKit seek。原生控制条的点击和拖动仍保留；全屏不增加第二套播放器或输入状态。

## 验证

- `sh Scripts/run-quality-gates.sh app`：通过，包含 static、Swift Package、App build-for-testing 和全部 App unit tests。
- `sh Scripts/run-quality-gates.sh app closure`：static、Swift Package、App build-for-testing 和本次全部播放器测试通过；仅失败于既有 `VideoDetailLifecycleTests.replacementKeepsPlayerSurfaceUntilReset()` 滚动位置时序断言。同一无改动基线此前可复现，未修改或放宽该测试。
- 文档更新后的 `sh Scripts/run-quality-gates.sh static`：通过。
- `git diff --check`：通过。
- 两轮只读 agent 审查：最终未发现 P0–P2 或其他 actionable finding。
- 签名 App 人工观察：普通窗口跨播放器滚动成功；进入 detached fullscreen 后保持原有 `contentOverlayView` 捕获逻辑。

## 未覆盖边界

- 自动测试未模拟 `NSTrackingArea.mouseExited` 的真实系统投递。
- 尚未覆盖不同触控板硬件、传统鼠标、Intel、其他 macOS 版本，以及“自然滚动”开／关的完整人工矩阵。
- 全屏原生控制区域继续由 AVKit 处理，不承诺自定义滚轮优先。
- VoiceOver、Full Keyboard Access、Reduce Motion 和较大文字未在本轮重新验证。
