### PR TITLE
fix(ui): 对齐视频元数据骨架结构

### DIFF
--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoDetailView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoDetailView.swift
@@ -68,40 +68,20 @@ struct GuestVideoDetailView<PlayerContent: View>: View {
                 .font(.title.weight(.semibold))
                 .textSelection(.enabled)
 
-            ViewThatFits(in: .horizontal) {
-                HStack(spacing: 16) {
-                    metadataItems
-                }
-
-                VStack(alignment: .leading, spacing: 8) {
-                    metadataItems
-                }
-            }
-            .font(.body)
-            .foregroundStyle(.secondary)
+            VideoDetailMetadataView(
+                content: VideoDetailMetadataContent(
+                    viewCount: VideoMetadataFormatting.compactCount(
+                        context.detail.statistics.viewCount
+                    ),
+                    danmakuCount: VideoMetadataFormatting.compactCount(
+                        context.detail.statistics.danmakuCount
+                    ),
+                    publishedAt: VideoMetadataFormatting.fullPublishedDate(
+                        context.detail.publishedAt
+                    )
+                )
+            )
         }
-    }
-
-    @ViewBuilder
-    private var metadataItems: some View {
-        Label(
-            VideoMetadataFormatting.compactCount(
-                context.detail.statistics.viewCount
-            ),
-            systemImage: "play"
-        )
-        Label(
-            VideoMetadataFormatting.compactCount(
-                context.detail.statistics.danmakuCount
-            ),
-            systemImage: "text.bubble"
-        )
-        Label(
-            VideoMetadataFormatting.fullPublishedDate(
-                context.detail.publishedAt
-            ),
-            systemImage: "calendar"
-        )
     }
 
     private var player: some View {
@@ -132,6 +112,84 @@ struct GuestVideoDetailView<PlayerContent: View>: View {
         .frame(maxWidth: .infinity)
         .background(.black)
         .accessibilityIdentifier("playback.player.container")
+    }
+}
+
+struct VideoDetailMetadataContent {
+    let viewCount: String
+    let danmakuCount: String
+    let publishedAt: String
+
+    static let placeholder = VideoDetailMetadataContent(
+        viewCount: "888.8 万",
+        danmakuCount: "888.8 万",
+        publishedAt: "8888年88月88日 88:88:88"
+    )
+
+    var items: [VideoDetailMetadataItem] {
+        VideoDetailMetadataSlot.allCases.map { slot in
+            VideoDetailMetadataItem(slot: slot, text: text(for: slot))
+        }
+    }
+
+    private func text(for slot: VideoDetailMetadataSlot) -> String {
+        switch slot {
+        case .viewCount:
+            viewCount
+        case .danmakuCount:
+            danmakuCount
+        case .publishedAt:
+            publishedAt
+        }
+    }
+}
+
+struct VideoDetailMetadataItem: Equatable {
+    let slot: VideoDetailMetadataSlot
+    let text: String
+}
+
+enum VideoDetailMetadataSlot: CaseIterable, Hashable {
+    case viewCount
+    case danmakuCount
+    case publishedAt
+
+    var systemImage: String {
+        switch self {
+        case .viewCount:
+            "play"
+        case .danmakuCount:
+            "text.bubble"
+        case .publishedAt:
+            "calendar"
+        }
+    }
+}
+
+struct VideoDetailMetadataView: View {
+    let content: VideoDetailMetadataContent
+    var isPlaceholder = false
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 16) {
+                metadataItems
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                metadataItems
+            }
+        }
+        .font(.body)
+        .foregroundStyle(.secondary)
+        .redacted(reason: isPlaceholder ? .placeholder : [])
+    }
+
+    @ViewBuilder
+    private var metadataItems: some View {
+        ForEach(content.items, id: \.slot) { item in
+            Label(item.text, systemImage: item.slot.systemImage)
+        }
     }
 }
 

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoLoadingSkeletons.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoLoadingSkeletons.swift
@@ -29,34 +29,10 @@ struct VideoDetailSkeleton: View {
                 .frame(maxWidth: 520)
                 .frame(height: 30)
 
-            ViewThatFits(in: .horizontal) {
-                HStack(spacing: 16) {
-                    metadataItems
-                }
-
-                VStack(alignment: .leading, spacing: 8) {
-                    metadataItems
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var metadataItems: some View {
-        metadataItem(width: 120)
-        metadataItem(width: 84)
-        metadataItem(width: 84)
-        metadataItem(width: 104)
-    }
-
-    private func metadataItem(width: CGFloat) -> some View {
-        HStack(spacing: 7) {
-            Circle()
-                .fill(.quinary)
-                .frame(width: 14, height: 14)
-            RoundedRectangle(cornerRadius: 3)
-                .fill(.quinary)
-                .frame(width: width, height: 14)
+            VideoDetailMetadataView(
+                content: .placeholder,
+                isPlaceholder: true
+            )
         }
     }
 

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/VideoDetailMetadataLayoutTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/VideoDetailMetadataLayoutTests.swift
@@ -1,0 +1,38 @@
+import Testing
+
+@testable import BiliBrowseFeature
+
+struct VideoDetailMetadataLayoutTests {
+    @Test
+    func loadedAndPlaceholderContentShareThreeMetadataSlots() {
+        let loaded = VideoDetailMetadataContent(
+            viewCount: "播放数",
+            danmakuCount: "弹幕数",
+            publishedAt: "发布日期"
+        )
+        let expectedSlots: [VideoDetailMetadataSlot] = [
+            .viewCount,
+            .danmakuCount,
+            .publishedAt,
+        ]
+
+        #expect(loaded.items.map(\.slot) == expectedSlots)
+        #expect(
+            loaded.items.map(\.text)
+                == ["播放数", "弹幕数", "发布日期"]
+        )
+        #expect(
+            VideoDetailMetadataContent.placeholder.items.map(\.slot)
+                == expectedSlots
+        )
+        #expect(
+            loaded.items.map { $0.slot.systemImage }
+                == ["play", "text.bubble", "calendar"]
+        )
+        #expect(
+            VideoDetailMetadataContent.placeholder.items.map {
+                $0.slot.systemImage
+            } == ["play", "text.bubble", "calendar"]
+        )
+    }
+}


### PR DESCRIPTION
## 变化

- 为视频详情元数据建立唯一的三 slot 契约：播放量、弹幕数、发布日期。
- 让 loaded 与 placeholder 通过同一个 `VideoDetailMetadataView` 按同一顺序和 SF Symbol 渲染。
- 删除 skeleton 中已失效的第四个占位，并新增聚焦结构契约测试。

## 原因

主内容区删除重复 UP 主昵称后，loaded 元数据从四项变为三项，但 skeleton 仍保留四个独立占位。原先用于减少 loading/loaded 位移的重复布局结构因此发生漂移，而现有测试只覆盖文案格式化和 uploader 状态，没有直接约束两种状态的 slot 结构。

## 用户影响

加载完成前后的元数据现在保持相同的三项语义、顺序和图标，不再出现多余的昵称占位。视频标题继续自然不限行并保留文本选择，没有加入截断、固定行数或定高。

## 验证

- 聚焦 `VideoDetailMetadataLayoutTests`：1 个 suite、1 个 test 通过。
- `sh Scripts/run-quality-gates.sh app`：通过。
- `sh Scripts/run-quality-gates.sh app closure`：最终 fresh 隔离重跑通过；前一次重跑仅有既存 `VideoDetailLifecycleTests.replacementKeepsPlayerSurfaceUntilReset()` 单一断言失败，代码未变后使用另一套 fresh 环境完整通过。
- 独立聚焦 review：初审发现 placeholder 虚构标题可交互，随后将共用范围收窄为 metadata renderer、恢复原 skeleton 标题；最终复核无未解决 finding。
- `git diff --check`：通过。

## 未覆盖边界

- 未修改网格骨架、历史卡片、相关推荐、sidebar、播放器、弹幕、导航或生命周期。
- 未进行真实窗口的可见 UI、VoiceOver 或 Full Keyboard Access 验证；自动测试、build 与 closure 不作为可见 UI 证明。
