### PR TITLE
fix(ci): 保留质量 Gate 原始退出状态

### DIFF
--- a/Scripts/run-quality-gates.sh
+++ b/Scripts/run-quality-gates.sh
@@ -25,9 +25,16 @@ export DEVELOPER_DIR="$developer_dir"
 
 artifact_root=$(mktemp -d "${TMPDIR:-/tmp}/BiliKit-quality-gate.XXXXXX")
 cleanup() {
-    rm -rf -- "$artifact_root"
+    status=$?
+    if ! rm -rf -- "$artifact_root" 2>/dev/null; then
+        echo "[Gate] warning: 未能完整清理临时产物：$artifact_root" >&2
+    fi
+    exit "$status"
 }
-trap cleanup EXIT HUP INT TERM
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 echo "[Gate] static"
 sh Scripts/check-architecture.sh


### PR DESCRIPTION
## 变化

- cleanup 在删除临时产物前保存质量 Gate 的原始退出码
- Xcode 管理的 busy/read-only mount 无法删除时只输出一条警告，不再把成功测试改写成失败
- HUP、INT、TERM 分别保留标准退出码
- 不增加重试、轮询、unmount 或新的 artifact runner

## 根因

PR #55 的 CI 全绿，但合并后的 [main run 31487274293](https://github.com/shiinayane/BiliKit-Mac/actions/runs/31487274293) 在 macOS 26 失败。

该 run 中 378 个 Package tests 与 34 个 App tests 实际全部通过。失败发生在 EXIT cleanup：Xcode 26 偶发在隔离 `HOME` 下留下仍挂载的只读 Metal toolchain，`rm -rf` 返回 `Read-only file system / Resource busy`，覆盖了真实 gate 结果。

PR synthetic merge 与真实 merge 的 Git tree 相同，runner image、Xcode 版本和 gate mode 也一致，因此这是 DVT mount 生命周期的时序 flake，不是产品或测试回归。

## 影响

质量 Gate 仍会报告真实 build/test 失败；只有临时目录中 Xcode 所有的活动 mount 无法删除时改为 cleanup warning。普通临时产物仍照常删除。

## 验证

- 模拟 cleanup 删除失败：
  - 原始成功保持 exit 0
  - 原始失败保持 exit 7
- `sh -n Scripts/run-quality-gates.sh`
- `git diff --check`
- `sh Scripts/run-quality-gates.sh app`
  - static：通过
  - Package：378 tests / 45 suites，通过
  - App build-for-testing：通过
  - App tests：34 个通过；signed Keychain smoke 按无签名条件跳过

## 未验证

GitHub macOS 26 runner 是否再次触发只读 Metal mount，等待本 PR CI 提供远端证据。
