### PR TITLE
refactor: 删除死亡生产接口与侧栏接缝

### DIFF
--- a/BiliKitMac/App/AppRootView.swift
+++ b/BiliKitMac/App/AppRootView.swift
@@ -18,13 +18,7 @@ struct AppRootView: View {
     @State private var windowOwner: AppWindowOwner
     @State private var isAuthenticationPresented = false
     @State private var submittedSearchQuery: String?
-    private let playbackSidebarContent:
-        (
-            (String, @escaping (String) -> Void) -> AnyView
-        )?
-
     init(environment: AppEnvironment = .live()) {
-        playbackSidebarContent = nil
         _windowOwner = State(
             initialValue: AppWindowOwner(environment: environment)
         )
@@ -37,12 +31,8 @@ struct AppRootView: View {
         danmakuModel: DanmakuControlsViewModel,
         authenticationModel: AuthenticationViewModel,
         historyModel: WatchHistoryViewModel,
-        playerContent: AnyView,
-        playbackSidebarContent: (
-            (String, @escaping (String) -> Void) -> AnyView
-        )? = nil
+        playerContent: AnyView
     ) {
-        self.playbackSidebarContent = playbackSidebarContent
         _windowOwner = State(
             initialValue: AppWindowOwner(
                 navigationCoordinator: navigationCoordinator,
@@ -67,8 +57,7 @@ struct AppRootView: View {
             playerContent: playerContent,
             isAuthenticationPresented: $isAuthenticationPresented,
             submittedSearchQuery: submittedSearchQuery,
-            onSubmitSearch: performSearch,
-            playbackSidebarContent: playbackSidebarContent
+            onSubmitSearch: performSearch
         )
         .task(id: browseActivation) {
             await applyBrowseActivation(for: browseActivation)

--- a/BiliKitMac/App/AppShellView.swift
+++ b/BiliKitMac/App/AppShellView.swift
@@ -18,10 +18,6 @@ struct AppShellView: View {
     @Binding var isAuthenticationPresented: Bool
     let submittedSearchQuery: String?
     let onSubmitSearch: () -> Void
-    let playbackSidebarContent:
-        (
-            (String, @escaping (String) -> Void) -> AnyView
-        )?
     @State private var columnVisibility = NavigationSplitViewVisibility.all
     @State private var popularScrollPosition = ScrollPosition(
         idType: String.self
@@ -102,17 +98,10 @@ struct AppShellView: View {
 
     @ViewBuilder
     private func playbackSidebar(for bvid: String) -> some View {
-        if let playbackSidebarContent {
-            playbackSidebarContent(
-                bvid,
-                navigationCoordinator.openPlayback
-            )
-        } else {
-            PlaybackContextSidebar(
-                model: videoModel,
-                onRetry: navigationCoordinator.retryPlayback
-            )
-        }
+        PlaybackContextSidebar(
+            model: videoModel,
+            onRetry: navigationCoordinator.retryPlayback
+        )
     }
 
     private var sidebarMinimumWidth: CGFloat {

--- a/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliGuestRepository.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliGuestRepository.swift
@@ -78,8 +78,6 @@ public struct BiliGuestRepository: GuestContentRepository, RelatedVideoRepositor
             throw CancellationError()
         } catch let error as BiliAPIError {
             throw error.applicationError
-        } catch let error as GuestApplicationError {
-            throw error
         } catch {
             throw GuestApplicationError.unavailable
         }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Session/DanmakuSession.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Session/DanmakuSession.swift
@@ -30,7 +30,6 @@ public final class DanmakuSession: DanmakuPresentationControlling {
     private var loadTasks: [Int: Task<Void, Never>] = [:]
     private var failedSegmentIndices: Set<Int> = []
     private var authenticationInvalidationReported = false
-    private var continuations: [UUID: AsyncStream<DanmakuBatch>.Continuation] = [:]
 
     public init(
         useCase: DanmakuSegmentUseCase,
@@ -47,24 +46,6 @@ public final class DanmakuSession: DanmakuPresentationControlling {
         for task in loadTasks.values {
             task.cancel()
         }
-        for continuation in continuations.values {
-            continuation.finish()
-        }
-    }
-
-    /// 提供观察用的有界 batch 流；production presentation 仍以 sink 为主路径。
-    public func batches() -> AsyncStream<DanmakuBatch> {
-        let id = UUID()
-        let stream = AsyncStream<DanmakuBatch>.makeStream(
-            bufferingPolicy: .bufferingNewest(4)
-        )
-        continuations[id] = stream.continuation
-        stream.continuation.onTermination = { [weak self] _ in
-            Task { @MainActor in
-                self?.continuations.removeValue(forKey: id)
-            }
-        }
-        return stream.stream
     }
 
     public func start(for identity: PlaybackItemIdentity) {
@@ -169,11 +150,6 @@ public final class DanmakuSession: DanmakuPresentationControlling {
         presentationSink?.apply(
             DanmakuPresentationUpdate(snapshot: snapshot, batch: batch)
         )
-        if let batch {
-            for continuation in continuations.values {
-                continuation.yield(batch)
-            }
-        }
         let required = scheduler.desiredSegmentIndices(for: snapshot)
         for index in required
         where

--- a/Packages/BiliKitCore/Sources/BiliLibraryFeature/History/WatchHistoryViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliLibraryFeature/History/WatchHistoryViewModel.swift
@@ -136,11 +136,6 @@ public final class WatchHistoryViewModel {
         state = .idle
     }
 
-    @available(*, deprecated, message: "Use deactivateRoute() for route cancellation.")
-    public func cancelTransientWork() {
-        deactivateRoute()
-    }
-
     /// 停用页面请求而不抹掉已加载条目；迟到结果仍由 generation 拒绝。
     public func deactivateRoute() {
         generation += 1


### PR DESCRIPTION
## 变化

- 删除零调用的 `DanmakuSession.batches()` 及其 continuation broadcast。
- 删除 `WatchHistoryViewModel.cancelTransientWork()` 废弃 alias。
- 删除 `BiliGuestRepository` 对当前调用链不可达的 `GuestApplicationError` passthrough catch。
- 删除 AX fixture 清理后失去唯一 producer 的 `playbackSidebarContent` closure/`AnyView` seam，固定使用真实 `PlaybackContextSidebar`。

共修改 5 个 production 文件，6 行新增、59 行删除，净删 53 行。

## 原因

这些接口或分支在最新 `main` 上已经没有真实调用者，或由当前类型和调用链证明不可达。保留它们会继续暴露测试/历史 fixture 驱动的生产表面，并让真实 sidebar 路径带有恒为 nil 的分支。

## 用户与开发影响

产品行为不变。弹幕仍通过 `presentationSink` 呈现，History 的取消、分页、cursor、去重和 reset 保持不变；播放侧栏继续使用真实 `PlaybackContextSidebar`。AppWindowOwner、播放器 owner、generation、取消和资源清理未改变。

远端 Content-Type、大小、redirect、业务码校验，以及认证、Cookie、Keychain 和 loopback 安全边界均未修改。

## 验证

- 相关 deterministic tests：82 tests / 7 suites 通过。
- `sh Scripts/run-quality-gates.sh app` 通过：
  - static、架构、秘密与格式检查通过；
  - 378 个 Package tests 通过；
  - App build-for-testing 通过；
  - 无签名 App tests 通过。
- `git diff --check` 通过。
- 全仓 orphan symbol/reference 检查通过。

## 未进入本批

`*SnapshotForTesting` hooks 仍被 14 个确定性并发测试使用，本批不删除，也不以新 hook、token 或等待器替换。uploader URL、Related shelf、VideoOwner signature、重复 identity、QR 双上限、播放器 observer、评论与 AppKit feed 均留给独立后续批次。