### PR TITLE
docs: 收紧验证产物治理

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,12 +12,10 @@
 
 ## 验证
 
-<!-- 列出实际运行的命令、测试和真实观察；没有运行的项目不要勾选或推断。 -->
+<!-- 只勾选并填写实际运行的唯一最高适用 Gate；没有运行的项目不要勾选或推断。 -->
 
-- [ ] `sh Scripts/run-quality-gates.sh static`
-- [ ] `sh Scripts/run-quality-gates.sh package`
-- [ ] `sh Scripts/run-quality-gates.sh app`
-- [ ] 与本次变化直接相关的真实 UI、签名、网络或性能检查
+- [ ] 唯一最高适用 Gate（`static` / `package` / `app`；实际命令：）
+- [ ] 必要的真实 UI、签名、网络或性能检查（实际检查：）
 
 ## 未覆盖边界
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,13 +43,18 @@ Bili*Feature -> BiliApplication -> BiliModels
   判断完成，固定时长只作超时。
 - 默认使用独立 Codex managed worktree；保留已有改动。未经要求不 commit、push、创建 PR、
   改写历史或修改其他 worktree。
-- 只运行覆盖改动的最高一层：
+- 迭代期间只做最小定向验证；交付前只运行一次覆盖改动的最高适用 Gate：
 
 ```sh
 sh Scripts/run-quality-gates.sh static
 sh Scripts/run-quality-gates.sh package
 sh Scripts/run-quality-gates.sh app
 ```
+
+- 手写 `xcodebuild`、XCUI 和 App 启动统一使用本任务唯一的临时产物根目录，任务结束时清理。
+  其他 worktree 或旧共享 DerivedData 不算 fresh closure；若只用于临时运行时诊断，需注明证据边界。
+- 仅在明确的性能裁决中运行 Instruments/`xctrace`；事前限定问题、时长、次数和产物目录。
+  摘要完成后默认删除 raw trace，并退出 Instruments、确认没有开放 trace、清理临时产物。
 
 ## 提交文本
 

--- a/docs/development/QUALITY-GATES.md
+++ b/docs/development/QUALITY-GATES.md
@@ -1,6 +1,6 @@
 # 开发验证入口
 
-按改动范围只运行最高适用命令：
+迭代期间只做最小定向验证；交付前只运行一次覆盖改动的最高适用 Gate：
 
 ```sh
 sh Scripts/run-quality-gates.sh static
@@ -13,7 +13,12 @@ sh Scripts/run-quality-gates.sh app
 - `app`：包含 `package`，并执行 App build-for-testing 与 App unit tests。
 
 Gate 每次使用私有临时目录保存 SwiftPM 与 Xcode 产物，退出时清理；不修改全局
-`xcode-select`。CI 使用同一入口。
+`xcode-select`。手写 `xcodebuild`、XCUI 和 App 启动也必须统一使用本任务唯一的临时产物
+根目录，并在任务结束时清理。其他 worktree 或旧共享 DerivedData 不算 fresh closure；仅用于
+临时运行时诊断时需注明证据边界。CI 使用同一入口。
+
+仅在明确的性能裁决中运行 Instruments/`xctrace`；事前限定问题、时长、次数和产物目录。
+摘要完成后默认删除 raw trace，并退出 Instruments、确认没有开放 trace、清理临时产物。
 
 测试服务于产品：优先用简单 unit/model/ViewModel 测试固定状态、identity、generation、
 取消与资源清理。不得为了自动化改变用户 accessibility 语义。XCUI 只在更低层无法证明的


### PR DESCRIPTION
## 变化

- 明确迭代期间只做最小定向验证，交付前只运行一次最高适用 Gate。
- 要求手写 xcodebuild、XCUI 与 App 启动共用任务唯一临时产物根目录并在结束时清理。
- 限定 Instruments/xctrace 仅用于事前有界的性能裁决，并要求删除 raw trace、退出工具及完成收尾。
- 将 PR 模板的三个包含式 Gate 复选框合并为唯一最高适用 Gate。

## 原因

现有文案没有清楚区分迭代验证与交付 Gate，也未约束手写 Xcode、XCUI、App 和 trace 产物的任务级生命周期；PR 模板还容易诱导重复运行包含关系中的多个 Gate。

## 用户影响

无直接用户影响。开发验证更节制，产物归属与证据边界更容易审计。

## 验证

- [x] 唯一最高适用 Gate（实际命令：`sh Scripts/run-quality-gates.sh static`）
- [ ] 必要的真实 UI、签名、网络或性能检查（本次纯文档变更不需要）

三处文案一致性检查与 `git diff --check` 通过。

## 未覆盖边界

未运行 Package/App Gate、XCUI、App、签名、真实网络、Instruments 或 xctrace；文档约束的实际长期执行效果仍需后续任务遵守与观察。
