### PR TITLE
fix(playback): 修正生成字幕名称并切换推荐时回顶

### DIFF
--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoPlaybackView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoPlaybackView.swift
@@ -65,24 +65,40 @@ public struct VideoPlaybackView<PlayerContent: View>: View {
     }
 
     private var detailSurface: some View {
-        ScrollView {
-            detailSurfaceContent
-                .overlay(alignment: .topLeading) {
-                    if currentContext != nil, isLoadingReplacement {
-                        replacementLoadingOverlay
-                            .frame(
-                                maxWidth: .infinity,
-                                maxHeight: .infinity,
-                                alignment: .topLeading
-                            )
-                            .background(.background)
-                            .transition(.opacity)
+        ScrollViewReader { proxy in
+            ScrollView {
+                detailSurfaceContent
+                    .id(PlaybackDetailScrollAnchor.top)
+                    .overlay(alignment: .topLeading) {
+                        if currentContext != nil, isLoadingReplacement {
+                            replacementLoadingOverlay
+                                .frame(
+                                    maxWidth: .infinity,
+                                    maxHeight: .infinity,
+                                    alignment: .topLeading
+                                )
+                                .background(.background)
+                                .transition(.opacity)
+                        }
                     }
-                }
+            }
+            .onChange(of: presentedBVID) { previousBVID, bvid in
+                guard
+                    PlaybackDetailScrollResetPolicy.shouldReset(
+                        from: previousBVID,
+                        to: bvid
+                    )
+                else { return }
+                proxy.scrollTo(PlaybackDetailScrollAnchor.top, anchor: .top)
+            }
+            .overlay {
+                replacementFailureOverlay
+            }
         }
-        .overlay {
-            replacementFailureOverlay
-        }
+    }
+
+    private var presentedBVID: String? {
+        currentContext?.detail.bvid
     }
 
     private var isLoadingReplacement: Bool {
@@ -231,5 +247,16 @@ public struct VideoPlaybackView<PlayerContent: View>: View {
         } else {
             onRetry()
         }
+    }
+}
+
+enum PlaybackDetailScrollAnchor: Hashable {
+    case top
+}
+
+enum PlaybackDetailScrollResetPolicy {
+    static func shouldReset(from previousBVID: String?, to bvid: String?) -> Bool {
+        guard let previousBVID, let bvid else { return false }
+        return previousBVID != bvid
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Bridge/DASHToHLSBridge.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Bridge/DASHToHLSBridge.swift
@@ -491,6 +491,21 @@ public struct DASHToHLSBridge: Sendable {
             by: { primaryLanguageSubtag($0.languageTag) }
         )
         for (language, languageEntries) in subtitleLanguageGroups
+        where language != "und" {
+            let translations = localizedLanguageNames(for: language)
+            guard !translations.isEmpty else { continue }
+            for entry in languageEntries
+            where entry.characteristics.contains("public.machine-generated")
+                && localizedNames[entry.label] == nil
+            {
+                // AVFoundation localizes the machine-generated characteristic
+                // separately. Give it the language's base name so a source
+                // label such as "中文（AI）" does not become
+                // "中文（AI）（生成）" when it is the only rendition.
+                localizedNames[entry.label] = translations
+            }
+        }
+        for (language, languageEntries) in subtitleLanguageGroups
         where language != "und" && languageEntries.count > 1 {
             let labelGroups = Dictionary(
                 grouping: languageEntries,

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/VideoPlaybackViewTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/VideoPlaybackViewTests.swift
@@ -1,0 +1,33 @@
+import Testing
+
+@testable import BiliBrowseFeature
+
+struct VideoPlaybackViewTests {
+    @Test
+    func detailScrollResetsOnlyForAReplacementPresentedBVID() {
+        #expect(
+            !PlaybackDetailScrollResetPolicy.shouldReset(
+                from: nil,
+                to: "BV1Initial"
+            )
+        )
+        #expect(
+            PlaybackDetailScrollResetPolicy.shouldReset(
+                from: "BV1A",
+                to: "BV1B"
+            )
+        )
+        #expect(
+            !PlaybackDetailScrollResetPolicy.shouldReset(
+                from: "BV1A",
+                to: "BV1A"
+            )
+        )
+        #expect(
+            !PlaybackDetailScrollResetPolicy.shouldReset(
+                from: "BV1A",
+                to: nil
+            )
+        )
+    }
+}

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
@@ -2587,7 +2587,7 @@ struct LoopbackPlaybackServerTests {
         #expect(automaticSubtitles.count == 2)
         #expect(localizedNames["中文"]?["zh"] == "中文")
         #expect(localizedNames["中文（AI）"]?["zh"] == "中文")
-        #expect(localizedNames["English（AI）"] == nil)
+        #expect(localizedNames["English（AI）"]?["en"] == "English")
         #expect(
             group.options.allSatisfy {
                 !$0.hasMediaCharacteristic(.isOriginalContent)


### PR DESCRIPTION
## 变化

- 为所有语言有效的 machine-generated 字幕提供系统语言基础名，同时保留 `public.machine-generated`、原始 HLS `NAME`、语言和默认关闭属性。
- 在相关推荐从已呈现视频 A 切换到不同 BVID 的 B、且 B 的详情 context 真正呈现时，将整个视频详情纵向滚动区域定位到顶部。
- 增加 presented BVID 滚动触发契约，并更新原生字幕 localized rendition name 集成断言。

## 原因与用户影响

单独只有中文 AI 字幕时，App 生成的 `NAME="中文（AI）"` 会与 AVFoundation 根据 `public.machine-generated` 添加的系统“（生成）”语义叠加，最终显示为“中文（AI）（生成）”。此前 localized rendition names 只有同语言人工与 AI 轨并存时才提供共同基础名。

现在单独 AI 轨也向系统提供对应语言的基础名，由 AVFoundation 负责追加本地化的生成语义；已在中文系统真实观察为“中文（生成）”。同一逻辑适用于英文等其他有效语言，不删除或伪造 AI 语义。

相关推荐切换方面，回顶由 `VideoPlaybackView` 的外层详情 `ScrollView` 持有，只响应 `presentedContext.detail.bvid` 从非空 A 变为不同非空 B。首次呈现、同一 BVID 的状态变化、相关推荐重载、失败重试与分 P 切换不会触发，也不会通过动态 `.id(bvid)` 重建 player host。

## 验证

- `sh Scripts/run-quality-gates.sh app`
  - static 检查通过；
  - Package 379 tests / 46 suites 通过；
  - App build-for-testing 与 App unit tests 通过。
- 使用工程正式 Team、Bundle ID 与 Apple Development 配置构建并启动 Debug App：
  - 用户确认单独中文 AI 字幕显示为“中文（生成）”；
  - 用户确认相关推荐 A → B 后整个详情视图回到顶部。
- 独立聚焦审查确认回顶时机、same-BVID、failure/retry、单 player host 与 Reduce Motion 边界无问题。

## 未覆盖边界

- AVFoundation 最终逐字文案仍随 macOS 版本和界面语言变化。
- 未观察 B 站返回 script/region 限定的 AI 字幕标签；若未来出现，需基于真实目录重新审计显示策略。
- 未重新执行 VoiceOver、Full Keyboard Access 与其他系统语言的真人检查。
- 仓库 App Gate 中的无签名 build-for-testing 不作为 Keychain、entitlements 或真实账号证据；真实菜单观察来自另行正式签名 Debug App。
