### PR TITLE
feat(search): 接入原生无限视频流

### DIFF
--- a/BiliKitMac/App/AppShellView.swift
+++ b/BiliKitMac/App/AppShellView.swift
@@ -20,9 +20,7 @@ struct AppShellView: View {
     let onSubmitSearch: () -> Void
     @State private var columnVisibility = NavigationSplitViewVisibility.all
     @State private var popularScrollOffsetY: CGFloat = 0
-    @State private var searchScrollPosition = ScrollPosition(
-        idType: String.self
-    )
+    @State private var searchScrollOffsetY: CGFloat = 0
     @State private var historyScrollOffsetY: CGFloat = 0
 
     var body: some View {
@@ -72,7 +70,7 @@ struct AppShellView: View {
         }
         .onChange(of: submittedSearchQuery) { previousQuery, query in
             guard previousQuery != query else { return }
-            searchScrollPosition = ScrollPosition(idType: String.self)
+            searchScrollOffsetY = 0
         }
         .onChange(of: historyAccountScope) { previousScope, scope in
             guard AccountSessionScope.isResolvedChange(from: previousScope, to: scope)
@@ -124,7 +122,7 @@ struct AppShellView: View {
                     set: { navigationCoordinator.searchDraft = $0 }
                 ),
                 submittedSearchQuery: submittedSearchQuery,
-                scrollPosition: $searchScrollPosition,
+                scrollOffsetY: $searchScrollOffsetY,
                 onSelect: navigationCoordinator.openPlayback,
                 onSubmit: onSubmitSearch
             )

--- a/BiliKitMac/App/AppSourceRootViews.swift
+++ b/BiliKitMac/App/AppSourceRootViews.swift
@@ -34,7 +34,7 @@ struct SearchTabRoot: View {
     let model: GuestBrowseViewModel
     @Binding var searchDraft: String
     let submittedSearchQuery: String?
-    @Binding var scrollPosition: ScrollPosition
+    @Binding var scrollOffsetY: CGFloat
     let onSelect: (String) -> Void
     let onSubmit: () -> Void
 
@@ -42,7 +42,26 @@ struct SearchTabRoot: View {
         VideoSearchView(
             model: model,
             submittedSearchQuery: submittedSearchQuery,
-            scrollPosition: $scrollPosition,
+            scrollOffsetY: $scrollOffsetY,
+            makeLoadedContent: {
+                presentations,
+                scrollOffsetY,
+                canLoadMore,
+                tailIdentity,
+                isLoading,
+                onNearEnd,
+                onSelect in
+                SearchNativeGridView(
+                    presentations: presentations,
+                    scrollOffsetY: scrollOffsetY,
+                    canLoadMore: canLoadMore,
+                    tailIdentity: tailIdentity,
+                    isLoading: isLoading,
+                    onNearEnd: onNearEnd,
+                    onSelect: onSelect
+                )
+                .ignoresSafeArea(.container, edges: .top)
+            },
             onSelect: onSelect
         )
         .navigationTitle("搜索")

--- a/BiliKitMac/Platform/SearchNativeGridView.swift
+++ b/BiliKitMac/Platform/SearchNativeGridView.swift
@@ -1,0 +1,54 @@
+import BiliBrowseFeature
+import SwiftUI
+
+struct SearchNativeGridView: View {
+    @State private var imageOwner = NativeVideoImagePipelineOwner()
+    let presentations: [SearchVideoCardPresentation]
+    @Binding var scrollOffsetY: CGFloat
+    let canLoadMore: Bool
+    let tailIdentity: String?
+    let isLoading: Bool
+    let onNearEnd: () -> Void
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        NativeVideoGridView(
+            items: presentations.map(Self.makePresentation),
+            scrollOffsetY: $scrollOffsetY,
+            accessibilityLabel: "搜索结果视频",
+            tailState: NativeVideoGridTailState(
+                canLoadMore: canLoadMore,
+                tailIdentity: tailIdentity,
+                isLoading: isLoading
+            ),
+            imagePipeline: imageOwner.pipeline,
+            onNearEnd: onNearEnd,
+            onSelect: onSelect
+        )
+    }
+
+    static func makePresentation(
+        _ presentation: SearchVideoCardPresentation
+    ) -> NativeVideoCardPresentation {
+        NativeVideoCardPresentation(
+            id: presentation.bvid,
+            title: presentation.title,
+            coverURL: presentation.coverURL,
+            avatarURL: presentation.avatarURL,
+            showsAvatar: true,
+            coverMetrics: [
+                NativeVideoCardMetric(
+                    text: presentation.viewCountText,
+                    systemImage: "play.fill"
+                ),
+                NativeVideoCardMetric(
+                    text: presentation.danmakuCountText,
+                    systemImage: "text.bubble.fill"
+                ),
+            ],
+            coverTrailingText: presentation.durationText,
+            footerLeadingText: presentation.footerText,
+            accessibilityLabel: presentation.accessibilityLabel
+        )
+    }
+}

--- a/BiliKitMacTests/PopularNativeGridTests.swift
+++ b/BiliKitMacTests/PopularNativeGridTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import BiliBrowseFeature
 import BiliLibraryFeature
 import BiliModels
 import CoreGraphics
@@ -463,6 +464,39 @@ struct PopularNativeGridTests {
         #expect(content.coverTrailingText == "2:05")
         #expect(content.showsAvatar)
         #expect(content.accessibilityLabel.contains("时长 2:05"))
+    }
+
+    @Test @MainActor
+    func searchMappingKeepsStableBVIDAndFeatureFormattedSlots() throws {
+        let video = SearchVideo(
+            bvid: "BV-search-stable",
+            title: "搜索原生卡片",
+            coverURL: URL(string: "https://i0.hdslb.com/search.jpg"),
+            owner: VideoOwner(
+                id: 2,
+                name: "搜索作者",
+                avatarURL: URL(string: "https://i1.hdslb.com/avatar.jpg")
+            ),
+            statistics: VideoStatistics(
+                viewCount: 23_456,
+                danmakuCount: 89,
+                likeCount: 10
+            ),
+            durationSeconds: 185,
+            publishedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        let featurePresentation = SearchVideoCardPresentation(video: video)
+        let content = SearchNativeGridView.makePresentation(featurePresentation)
+
+        #expect(content.id == "BV-search-stable")
+        #expect(content.title == "搜索原生卡片")
+        #expect(content.coverURL?.absoluteString.hasSuffix("@640w_360h_1c.webp") == true)
+        #expect(content.avatarURL?.absoluteString.hasSuffix("@96w_96h_1c.webp") == true)
+        #expect(content.coverMetrics.map(\.text) == ["2.3万", "89"])
+        #expect(content.coverTrailingText == "3:05")
+        #expect(content.footerLeadingText.contains("搜索作者"))
+        #expect(content.accessibilityLabel.contains("时长 3:05"))
     }
 
     @Test @MainActor

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/BrowseScene/GuestBrowseViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/BrowseScene/GuestBrowseViewModel.swift
@@ -1,4 +1,5 @@
 import BiliApplication
+import BiliModels
 import Foundation
 import Observation
 
@@ -13,6 +14,13 @@ struct GuestFeedPresentation: Sendable, Equatable {
     let state: GuestFeedState
     let isRefreshing: Bool
     let refreshError: GuestApplicationError?
+}
+
+struct SearchPaginationPresentation: Sendable, Equatable {
+    let canLoadMore: Bool
+    let tailIdentity: String?
+    let isLoadingMore: Bool
+    let loadMoreError: GuestApplicationError?
 }
 
 @MainActor
@@ -49,10 +57,10 @@ public final class GuestBrowseViewModel {
         activateWorkset(request, workset: workset)
     }
 
-    public func activateSearch(_ query: String, page: Int = 1) {
+    public func activateSearch(_ query: String) {
         let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        let request = GuestFeedRequest.search(query: normalizedQuery, page: page)
-        guard isValidSearch(normalizedQuery, page: page) else {
+        let request = GuestFeedRequest.search(query: normalizedQuery, page: 1)
+        guard isValidSearch(normalizedQuery) else {
             fail(request: request, error: .invalidRequest)
             return
         }
@@ -71,10 +79,10 @@ public final class GuestBrowseViewModel {
         refresh(.popular(page: page, pageSize: pageSize))
     }
 
-    public func search(_ query: String, page: Int = 1) {
+    public func search(_ query: String) {
         let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        let request = GuestFeedRequest.search(query: normalizedQuery, page: page)
-        guard isValidSearch(normalizedQuery, page: page) else {
+        let request = GuestFeedRequest.search(query: normalizedQuery, page: 1)
+        guard isValidSearch(normalizedQuery) else {
             fail(request: request, error: .invalidRequest)
             return
         }
@@ -82,6 +90,43 @@ public final class GuestBrowseViewModel {
             searchWorkset = FeedWorkset(request: request)
         }
         refresh(request)
+    }
+
+    public func loadMoreSearch() {
+        guard
+            case .search(let query, 1) = activeRequestIdentity,
+            case .loaded(.search(let loadedQuery, let page)) = state,
+            loadedQuery == query,
+            page.pageNumber < page.totalPages,
+            !isRefreshing,
+            !searchWorkset.isLoadingMore,
+            loadTask == nil
+        else {
+            return
+        }
+
+        let baseRequest = GuestFeedRequest.search(query: query, page: 1)
+        let nextRequest = GuestFeedRequest.search(
+            query: query,
+            page: page.pageNumber + 1
+        )
+        generation += 1
+        let currentGeneration = generation
+        searchWorkset.isLoadingMore = true
+        searchWorkset.loadMoreError = nil
+        storeActiveWorkset()
+        loadTask = Task { [weak self] in
+            await self?.performSearchAppend(
+                nextRequest,
+                baseRequest: baseRequest,
+                generation: currentGeneration
+            )
+        }
+    }
+
+    public func retrySearchLoadMore() {
+        guard searchWorkset.loadMoreError != nil else { return }
+        loadMoreSearch()
     }
 
     func retry(_ request: GuestFeedRequest) {
@@ -132,6 +177,35 @@ public final class GuestBrowseViewModel {
         )
     }
 
+    func searchPagination(
+        for query: String
+    ) -> SearchPaginationPresentation {
+        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let request = GuestFeedRequest.search(query: normalizedQuery, page: 1)
+        guard
+            searchWorkset.request == request,
+            case .loaded(.search(let loadedQuery, let page)) = searchWorkset.state,
+            loadedQuery == normalizedQuery
+        else {
+            return SearchPaginationPresentation(
+                canLoadMore: false,
+                tailIdentity: nil,
+                isLoadingMore: false,
+                loadMoreError: nil
+            )
+        }
+        let canLoadMore = page.pageNumber < page.totalPages
+        let tailIdentity = page.videos.last.map {
+            "\(normalizedQuery)|\(page.pageNumber)|\($0.bvid)"
+        }
+        return SearchPaginationPresentation(
+            canLoadMore: canLoadMore,
+            tailIdentity: canLoadMore ? tailIdentity : nil,
+            isLoadingMore: searchWorkset.isLoadingMore,
+            loadMoreError: searchWorkset.loadMoreError
+        )
+    }
+
     public func waitForCurrentTask() async {
         await loadTask?.value
     }
@@ -170,6 +244,10 @@ public final class GuestBrowseViewModel {
         let currentGeneration = generation
         loadTask?.cancel()
         refreshError = nil
+        if case .search = request {
+            searchWorkset.isLoadingMore = false
+            searchWorkset.loadMoreError = nil
+        }
 
         if case .loaded = state {
             isRefreshing = true
@@ -203,7 +281,10 @@ public final class GuestBrowseViewModel {
             guard generation == currentGeneration, activeRequestIdentity == request else {
                 return
             }
-            state = .loaded(content)
+            guard contentMatches(content, request: request) else {
+                throw GuestApplicationError.invalidResponse
+            }
+            state = .loaded(normalizedContent(content))
             isRefreshing = false
             refreshError = nil
         } catch is CancellationError {
@@ -229,6 +310,72 @@ public final class GuestBrowseViewModel {
         }
     }
 
+    private func performSearchAppend(
+        _ request: GuestFeedRequest,
+        baseRequest: GuestFeedRequest,
+        generation currentGeneration: Int
+    ) async {
+        do {
+            let content = try await useCase.execute(request)
+            try Task.checkCancellation()
+            guard
+                generation == currentGeneration,
+                activeRequestIdentity == baseRequest,
+                case .search(let requestedQuery, let requestedPage) = request,
+                case .search(let responseQuery, let responsePage) = content,
+                requestedQuery == responseQuery,
+                requestedPage == responsePage.pageNumber,
+                responsePage.pageNumber <= responsePage.totalPages,
+                case .loaded(.search(let loadedQuery, let loadedPage)) = state,
+                loadedQuery == requestedQuery,
+                loadedPage.pageNumber + 1 == responsePage.pageNumber
+            else {
+                throw GuestApplicationError.invalidResponse
+            }
+
+            var seen = Set(loadedPage.videos.map(\.bvid))
+            let appended = responsePage.videos.filter {
+                seen.insert($0.bvid).inserted
+            }
+            state = .loaded(
+                .search(
+                    query: requestedQuery,
+                    page: SearchPage(
+                        videos: loadedPage.videos + appended,
+                        pageNumber: responsePage.pageNumber,
+                        pageSize: responsePage.pageSize,
+                        totalResults: responsePage.totalResults,
+                        totalPages: responsePage.totalPages
+                    )
+                )
+            )
+            searchWorkset.isLoadingMore = false
+            searchWorkset.loadMoreError = nil
+        } catch is CancellationError {
+            guard generation == currentGeneration, activeRequestIdentity == baseRequest else {
+                return
+            }
+            searchWorkset.isLoadingMore = false
+        } catch let error as GuestApplicationError {
+            guard generation == currentGeneration, activeRequestIdentity == baseRequest else {
+                return
+            }
+            searchWorkset.isLoadingMore = false
+            searchWorkset.loadMoreError = error
+        } catch {
+            guard generation == currentGeneration, activeRequestIdentity == baseRequest else {
+                return
+            }
+            searchWorkset.isLoadingMore = false
+            searchWorkset.loadMoreError = .unavailable
+        }
+
+        if generation == currentGeneration, activeRequestIdentity == baseRequest {
+            loadTask = nil
+            storeActiveWorkset()
+        }
+    }
+
     private func handleFailure(
         _ error: GuestApplicationError,
         request: GuestFeedRequest
@@ -241,12 +388,55 @@ public final class GuestBrowseViewModel {
         }
     }
 
+    private func contentMatches(
+        _ content: GuestFeedContent,
+        request: GuestFeedRequest
+    ) -> Bool {
+        switch (request, content) {
+        case (.popular(let requestedPage, let requestedSize), .popular(let page)):
+            page.pageNumber == requestedPage && page.pageSize == requestedSize
+        case (
+            .search(let requestedQuery, let requestedPage),
+            .search(let responseQuery, let page)
+        ):
+            responseQuery == requestedQuery
+                && page.pageNumber == requestedPage
+                && page.pageSize > 0
+                && page.totalResults >= 0
+                && (page.totalPages >= page.pageNumber
+                    || (page.totalPages == 0 && page.videos.isEmpty))
+        default:
+            false
+        }
+    }
+
+    private func normalizedContent(
+        _ content: GuestFeedContent
+    ) -> GuestFeedContent {
+        guard case .search(let query, let page) = content else {
+            return content
+        }
+        var seen: Set<String> = []
+        let videos = page.videos.filter { seen.insert($0.bvid).inserted }
+        return .search(
+            query: query,
+            page: SearchPage(
+                videos: videos,
+                pageNumber: page.pageNumber,
+                pageSize: page.pageSize,
+                totalResults: page.totalResults,
+                totalPages: page.totalPages
+            )
+        )
+    }
+
     private func normalizeInterruptedLoad() {
         isRefreshing = false
         refreshError = nil
         if case .loading = state {
             state = .idle
         }
+        searchWorkset.isLoadingMore = false
     }
 
     private func apply(_ workset: FeedWorkset) {
@@ -257,11 +447,17 @@ public final class GuestBrowseViewModel {
 
     private func storeActiveWorkset() {
         guard let activeRequestIdentity else { return }
+        let searchIsLoadingMore = searchWorkset.isLoadingMore
+        let searchLoadMoreError = searchWorkset.loadMoreError
         updateWorkset(for: activeRequestIdentity) {
             $0.request = activeRequestIdentity
             $0.state = state
             $0.isRefreshing = isRefreshing
             $0.refreshError = refreshError
+            if case .search = activeRequestIdentity {
+                $0.isLoadingMore = searchIsLoadingMore
+                $0.loadMoreError = searchLoadMoreError
+            }
         }
     }
 
@@ -288,8 +484,8 @@ public final class GuestBrowseViewModel {
         }
     }
 
-    private func isValidSearch(_ query: String, page: Int) -> Bool {
-        !query.isEmpty && query.count <= 100 && page > 0
+    private func isValidSearch(_ query: String) -> Bool {
+        !query.isEmpty && query.count <= 100
     }
 }
 
@@ -298,4 +494,6 @@ private struct FeedWorkset {
     var state: GuestFeedState = .idle
     var isRefreshing = false
     var refreshError: GuestApplicationError?
+    var isLoadingMore = false
+    var loadMoreError: GuestApplicationError?
 }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/Feed/GuestVideoCard.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/Feed/GuestVideoCard.swift
@@ -1,61 +1,6 @@
 import BiliModels
 import BiliUI
 import Foundation
-import SwiftUI
-
-struct GuestVideoCard: View {
-    private let title: String
-    private let coverURL: URL?
-    private let ownerName: String
-    private let ownerAvatarURL: URL?
-    private let viewCount: Int64
-    private let danmakuCount: Int64
-    private let durationSeconds: Int?
-    private let publishedAt: Date
-
-    init(video: SearchVideo) {
-        title = video.title
-        coverURL = optimizedBiliImageURL(
-            video.coverURL,
-            width: 640,
-            height: 360
-        )
-        ownerName = video.owner.name
-        ownerAvatarURL = optimizedBiliImageURL(
-            video.owner.avatarURL,
-            width: 96,
-            height: 96
-        )
-        viewCount = video.statistics.viewCount
-        danmakuCount = video.statistics.danmakuCount
-        durationSeconds = video.durationSeconds
-        publishedAt = video.publishedAt
-    }
-
-    var body: some View {
-        VideoCard(
-            coverURL: coverURL,
-            avatarURL: ownerAvatarURL,
-            showsAvatar: true,
-            title: title,
-            coverMetrics: [
-                VideoCardMetric(
-                    VideoMetadataFormatting.compactCount(viewCount),
-                    systemImage: "play.fill"
-                ),
-                VideoCardMetric(
-                    VideoMetadataFormatting.compactCount(danmakuCount),
-                    systemImage: "text.bubble.fill"
-                ),
-            ],
-            coverTrailingText: durationSeconds.map {
-                VideoDurationFormatting.string(seconds: $0)
-            },
-            footerLeadingText: "\(ownerName) · "
-                + VideoMetadataFormatting.publishedDate(publishedAt)
-        )
-    }
-}
 
 public struct PopularVideoCardPresentation: Sendable, Equatable {
     public let bvid: String
@@ -94,6 +39,58 @@ public struct PopularVideoCardPresentation: Sendable, Equatable {
         footerText =
             "\(video.owner.name) · "
             + VideoMetadataFormatting.publishedDate(video.publishedAt)
+    }
+}
+
+public struct SearchVideoCardPresentation: Sendable, Equatable {
+    public let bvid: String
+    public let title: String
+    public let coverURL: URL?
+    public let avatarURL: URL?
+    public let ownerName: String
+    public let viewCountText: String
+    public let danmakuCountText: String
+    public let durationText: String?
+    public let footerText: String
+    public let accessibilityLabel: String
+
+    public init(video: SearchVideo) {
+        bvid = video.bvid
+        title = video.title
+        coverURL = optimizedBiliImageURL(
+            video.coverURL,
+            width: 640,
+            height: 360
+        )
+        avatarURL = optimizedBiliImageURL(
+            video.owner.avatarURL,
+            width: 96,
+            height: 96
+        )
+        ownerName = video.owner.name
+        viewCountText = VideoMetadataFormatting.compactCount(
+            video.statistics.viewCount
+        )
+        danmakuCountText = VideoMetadataFormatting.compactCount(
+            video.statistics.danmakuCount
+        )
+        durationText = video.durationSeconds.map {
+            VideoDurationFormatting.string(seconds: $0)
+        }
+        let publishedDateText = VideoMetadataFormatting.publishedDate(
+            video.publishedAt
+        )
+        footerText = "\(video.owner.name) · \(publishedDateText)"
+        accessibilityLabel = [
+            video.title,
+            video.owner.name,
+            "播放 \(viewCountText)",
+            "弹幕 \(danmakuCountText)",
+            durationText.map { "时长 \($0)" },
+            "发布 \(publishedDateText)",
+        ]
+        .compactMap { $0 }
+        .joined(separator: "，")
     }
 }
 

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/Search/VideoSearchView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/Search/VideoSearchView.swift
@@ -3,22 +3,43 @@ import BiliModels
 import BiliUI
 import SwiftUI
 
-public struct VideoSearchView: View {
+public struct VideoSearchView<LoadedContent: View>: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let model: GuestBrowseViewModel
     private let submittedSearchQuery: String?
-    @Binding private var scrollPosition: ScrollPosition
+    @Binding private var scrollOffsetY: CGFloat
+    private let makeLoadedContent:
+        (
+            [SearchVideoCardPresentation],
+            Binding<CGFloat>,
+            Bool,
+            String?,
+            Bool,
+            @escaping () -> Void,
+            @escaping (String) -> Void
+        ) -> LoadedContent
     private let onSelect: (String) -> Void
 
     public init(
         model: GuestBrowseViewModel,
         submittedSearchQuery: String?,
-        scrollPosition: Binding<ScrollPosition>,
+        scrollOffsetY: Binding<CGFloat>,
+        makeLoadedContent:
+            @escaping (
+                [SearchVideoCardPresentation],
+                Binding<CGFloat>,
+                Bool,
+                String?,
+                Bool,
+                @escaping () -> Void,
+                @escaping (String) -> Void
+            ) -> LoadedContent,
         onSelect: @escaping (String) -> Void
     ) {
         self.model = model
         self.submittedSearchQuery = submittedSearchQuery
-        _scrollPosition = scrollPosition
+        _scrollOffsetY = scrollOffsetY
+        self.makeLoadedContent = makeLoadedContent
         self.onSelect = onSelect
     }
 
@@ -82,18 +103,34 @@ public struct VideoSearchView: View {
                     Spacer()
                     Text("约 \(page.totalResults.formatted()) 条结果")
                         .foregroundStyle(.secondary)
+                    if presentation.isRefreshing {
+                        ProgressView()
+                            .controlSize(.small)
+                            .accessibilityLabel("正在刷新搜索结果")
+                    } else {
+                        Button {
+                            model.search(query)
+                        } label: {
+                            Label("刷新搜索结果", systemImage: "arrow.clockwise")
+                                .labelStyle(.iconOnly)
+                        }
+                        .buttonStyle(.borderless)
+                        .accessibilityHint("从第 1 页重新加载当前搜索")
+                    }
                 }
                 .font(.caption)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
 
-                SearchResultsGrid(
-                    model: model,
-                    query: query,
-                    page: page,
-                    scrollPosition: $scrollPosition,
-                    onSelect: onSelect
-                )
+                loadedResults(query: query, page: page)
+            }
+            .overlay(alignment: .top) {
+                if let error = presentation.refreshError {
+                    Text(error.guestMessage)
+                        .font(.caption)
+                        .padding(8)
+                        .background(.regularMaterial, in: Capsule())
+                }
             }
         case .failed(request: .search(_, _), let error):
             BrowseFailureView(
@@ -103,6 +140,42 @@ public struct VideoSearchView: View {
             )
         default:
             searchPrompt
+        }
+    }
+
+    private func loadedResults(
+        query: String,
+        page: SearchPage
+    ) -> some View {
+        let pagination = model.searchPagination(for: query)
+        return makeLoadedContent(
+            page.videos.map(SearchVideoCardPresentation.init),
+            $scrollOffsetY,
+            pagination.canLoadMore,
+            pagination.tailIdentity,
+            pagination.isLoadingMore,
+            model.loadMoreSearch,
+            onSelect
+        )
+        .overlay(alignment: .bottom) {
+            if pagination.isLoadingMore {
+                ProgressView()
+                    .controlSize(.small)
+                    .padding(8)
+                    .background(.regularMaterial, in: Capsule())
+                    .accessibilityLabel("正在加载更多搜索结果")
+            } else if let error = pagination.loadMoreError {
+                HStack(spacing: 8) {
+                    Text(error.guestMessage)
+                        .lineLimit(2)
+                    Button("重试") {
+                        model.retrySearchLoadMore()
+                    }
+                }
+                .font(.caption)
+                .padding(8)
+                .background(.regularMaterial, in: Capsule())
+            }
         }
     }
 
@@ -141,102 +214,5 @@ extension GuestFeedRequest {
     fileprivate var searchQuery: String? {
         guard case .search(let query, _) = self else { return nil }
         return query
-    }
-}
-
-private struct SearchResultsGrid: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    let model: GuestBrowseViewModel
-    let query: String
-    let page: SearchPage
-    @Binding var scrollPosition: ScrollPosition
-    let onSelect: (String) -> Void
-    let request: GuestFeedRequest
-
-    init(
-        model: GuestBrowseViewModel,
-        query: String,
-        page: SearchPage,
-        scrollPosition: Binding<ScrollPosition>,
-        onSelect: @escaping (String) -> Void
-    ) {
-        let request = GuestFeedRequest.search(
-            query: query,
-            page: page.pageNumber
-        )
-        self.model = model
-        self.query = query
-        self.page = page
-        _scrollPosition = scrollPosition
-        self.onSelect = onSelect
-        self.request = request
-    }
-
-    var body: some View {
-        GeometryReader { geometry in
-            ScrollView {
-                LazyVGrid(
-                    columns: VideoCardGridLayout.columns(
-                        for: geometry.size.width
-                    ),
-                    alignment: .leading,
-                    spacing: VideoCardGridLayout.verticalSpacing
-                ) {
-                    ForEach(page.videos) { video in
-                        Button {
-                            onSelect(video.bvid)
-                        } label: {
-                            GuestVideoCard(video: video)
-                        }
-                        .buttonStyle(VideoCardButtonStyle())
-                        .accessibilityHint("播放视频")
-                    }
-                }
-                .padding(VideoCardGridLayout.contentPadding)
-                .scrollTargetLayout()
-            }
-            .scrollPosition($scrollPosition)
-            .refreshable {
-                model.search(query, page: page.pageNumber)
-                await model.waitForCurrentTask()
-            }
-            .overlay(alignment: .top) {
-                ZStack {
-                    refreshStatus
-                }
-                .animation(
-                    LoadingStateTransition.animation(
-                        reduceMotion: reduceMotion
-                    ),
-                    value: refreshVisualPhase
-                )
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var refreshStatus: some View {
-        let presentation = model.presentation(for: request)
-        if presentation.isRefreshing {
-            ProgressView()
-                .controlSize(.small)
-                .padding(8)
-                .background(.regularMaterial, in: Capsule())
-                .accessibilityLabel("正在刷新搜索结果")
-                .transition(.opacity)
-        } else if let error = presentation.refreshError {
-            Text(error.guestMessage)
-                .font(.caption)
-                .padding(8)
-                .background(.regularMaterial, in: Capsule())
-                .transition(.opacity)
-        }
-    }
-
-    private var refreshVisualPhase: LoadingVisualPhase {
-        let presentation = model.presentation(for: request)
-        if presentation.isRefreshing { return .loading }
-        if presentation.refreshError != nil { return .failure }
-        return .idle
     }
 }

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
@@ -93,17 +93,17 @@ struct GuestBrowseAndVideoViewModelTests {
             )
         )
 
-        model.search("macOS", page: 2)
+        model.search("macOS")
         await model.waitForCurrentTask()
         #expect(
             model.state
                 == .failed(
-                    request: .search(query: "macOS", page: 2),
+                    request: .search(query: "macOS", page: 1),
                     error: .requestRestricted
                 )
         )
 
-        model.retry(.search(query: "macOS", page: 2))
+        model.retry(.search(query: "macOS", page: 1))
         await model.waitForCurrentTask()
         #expect(
             model.state
@@ -112,7 +112,7 @@ struct GuestBrowseAndVideoViewModelTests {
                         query: "macOS",
                         page: SearchPage(
                             videos: [fixture.searchVideo],
-                            pageNumber: 2,
+                            pageNumber: 1,
                             pageSize: 20,
                             totalResults: 1,
                             totalPages: 1
@@ -120,6 +120,105 @@ struct GuestBrowseAndVideoViewModelTests {
                     )
                 )
         )
+    }
+
+    @Test
+    @MainActor
+    func searchNearEndAppendsDeduplicatesAndBackpressuresSameTail() async {
+        let first = GuestFixtures(bvid: "BV1SearchA01", title: "第一页")
+        let second = GuestFixtures(bvid: "BV1SearchB02", title: "第二页")
+        let repository = SearchPaginationRepositoryStub(
+            first: first,
+            second: second
+        )
+        let model = GuestBrowseViewModel(
+            useCase: GuestFeedUseCase(repository: repository)
+        )
+
+        model.search("macOS")
+        await model.waitForCurrentTask()
+        let firstTail = model.searchPagination(for: "macOS")
+        #expect(firstTail.canLoadMore)
+        #expect(firstTail.tailIdentity?.contains("|1|") == true)
+
+        model.loadMoreSearch()
+        model.loadMoreSearch()
+        await model.waitForCurrentTask()
+
+        guard case .loaded(.search(_, let page)) = model.state else {
+            Issue.record("搜索结果应保持 loaded")
+            return
+        }
+        #expect(page.videos.map(\.bvid) == [first.bvid, second.bvid])
+        #expect(page.pageNumber == 2)
+        #expect(await repository.searchCallCount == 2)
+        #expect(!model.searchPagination(for: "macOS").canLoadMore)
+    }
+
+    @Test
+    @MainActor
+    func failedSearchAppendKeepsCardsAndRetriesOnlyNextPage() async {
+        let first = GuestFixtures(bvid: "BV1SearchC03", title: "保留卡片")
+        let second = GuestFixtures(bvid: "BV1SearchD04", title: "重试追加")
+        let repository = SearchPaginationRepositoryStub(
+            first: first,
+            second: second,
+            failFirstSecondPage: true
+        )
+        let model = GuestBrowseViewModel(
+            useCase: GuestFeedUseCase(repository: repository)
+        )
+
+        model.search("Swift")
+        await model.waitForCurrentTask()
+        let loadedState = model.state
+
+        model.loadMoreSearch()
+        await model.waitForCurrentTask()
+        #expect(model.state == loadedState)
+        #expect(
+            model.searchPagination(for: "Swift").loadMoreError
+                == .transportFailure
+        )
+
+        model.retrySearchLoadMore()
+        await model.waitForCurrentTask()
+        guard case .loaded(.search(_, let page)) = model.state else {
+            Issue.record("重试后搜索结果应保持 loaded")
+            return
+        }
+        #expect(page.videos.map(\.bvid) == [first.bvid, second.bvid])
+        #expect(await repository.searchCallCount == 3)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func newQueryCancelsAndRejectsLateSearchAppend() async throws {
+        let old = GuestFixtures(bvid: "BV1SearchE05", title: "旧查询")
+        let fresh = GuestFixtures(bvid: "BV1SearchF06", title: "新查询")
+        let repository = BlockingSearchAppendRepositoryStub(old: old, fresh: fresh)
+        let model = GuestBrowseViewModel(
+            useCase: GuestFeedUseCase(repository: repository)
+        )
+
+        model.search("旧查询")
+        await model.waitForCurrentTask()
+        model.loadMoreSearch()
+        try await repository.waitForOldAppendStart()
+        let oldAppendTask = try #require(model.taskSnapshotForTesting())
+
+        model.search("新查询")
+        await model.waitForCurrentTask()
+        await repository.releaseOldAppend()
+        await oldAppendTask.value
+
+        guard case .loaded(.search(let query, let page)) = model.state else {
+            Issue.record("新查询应保持 loaded")
+            return
+        }
+        #expect(query == "新查询")
+        #expect(page.videos.map(\.bvid) == [fresh.bvid])
+        #expect(page.pageNumber == 1)
     }
 
     @Test
@@ -1016,6 +1115,126 @@ private actor WorksetRepositoryStub: GuestContentRepository {
 
     func failNextPopularRequest() {
         shouldFailNextPopular = true
+    }
+}
+
+private actor SearchPaginationRepositoryStub: GuestContentRepository {
+    let first: GuestFixtures
+    let second: GuestFixtures
+    let failFirstSecondPage: Bool
+    private(set) var searchCallCount = 0
+    private var secondPageAttempts = 0
+
+    init(
+        first: GuestFixtures,
+        second: GuestFixtures,
+        failFirstSecondPage: Bool = false
+    ) {
+        self.first = first
+        self.second = second
+        self.failFirstSecondPage = failFirstSecondPage
+    }
+
+    func popular(page: Int, pageSize: Int) async throws -> PopularPage {
+        PopularPage(videos: [], pageNumber: page, pageSize: pageSize)
+    }
+
+    func searchVideos(keyword: String, page: Int) async throws -> SearchPage {
+        searchCallCount += 1
+        switch page {
+        case 1:
+            return SearchPage(
+                videos: [first.searchVideo, first.searchVideo],
+                pageNumber: 1,
+                pageSize: 20,
+                totalResults: 2,
+                totalPages: 2
+            )
+        case 2:
+            secondPageAttempts += 1
+            if failFirstSecondPage, secondPageAttempts == 1 {
+                throw GuestApplicationError.transportFailure
+            }
+            return SearchPage(
+                videos: [first.searchVideo, second.searchVideo],
+                pageNumber: 2,
+                pageSize: 20,
+                totalResults: 2,
+                totalPages: 2
+            )
+        default:
+            throw GuestApplicationError.invalidRequest
+        }
+    }
+
+    func videoDetail(for bvid: String) async throws -> VideoDetail { first.detail }
+    func pages(for bvid: String) async throws -> [VideoPage] { [first.page] }
+    func playback(for bvid: String, cid: Int64) async throws -> VideoPlayback {
+        first.playback
+    }
+}
+
+private actor BlockingSearchAppendRepositoryStub: GuestContentRepository {
+    let old: GuestFixtures
+    let fresh: GuestFixtures
+    private let oldAppendEvents = TestEventCounter()
+    private var oldAppendReleased = false
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(old: GuestFixtures, fresh: GuestFixtures) {
+        self.old = old
+        self.fresh = fresh
+    }
+
+    func popular(page: Int, pageSize: Int) async throws -> PopularPage {
+        PopularPage(videos: [], pageNumber: page, pageSize: pageSize)
+    }
+
+    func searchVideos(keyword: String, page: Int) async throws -> SearchPage {
+        if keyword == "旧查询", page == 2 {
+            await oldAppendEvents.signal()
+            await withCheckedContinuation { continuation in
+                if oldAppendReleased {
+                    continuation.resume()
+                } else {
+                    releaseWaiters.append(continuation)
+                }
+            }
+            return SearchPage(
+                videos: [old.searchVideo],
+                pageNumber: 2,
+                pageSize: 20,
+                totalResults: 2,
+                totalPages: 2
+            )
+        }
+        let fixture = keyword == "旧查询" ? old : fresh
+        return SearchPage(
+            videos: [fixture.searchVideo],
+            pageNumber: 1,
+            pageSize: 20,
+            totalResults: keyword == "旧查询" ? 2 : 1,
+            totalPages: keyword == "旧查询" ? 2 : 1
+        )
+    }
+
+    func videoDetail(for bvid: String) async throws -> VideoDetail { fresh.detail }
+    func pages(for bvid: String) async throws -> [VideoPage] { [fresh.page] }
+    func playback(for bvid: String, cid: Int64) async throws -> VideoPlayback {
+        fresh.playback
+    }
+
+    func waitForOldAppendStart() async throws {
+        try await oldAppendEvents.wait(until: 1)
+    }
+
+    func releaseOldAppend() {
+        oldAppendReleased = true
+        let pending = releaseWaiters
+        releaseWaiters.removeAll(keepingCapacity: false)
+        for waiter in pending {
+            waiter.resume()
+        }
     }
 }
 


### PR DESCRIPTION
## 变化

- 由 Search Feature 持有 query、页码、generation、取消、追加去重、结束判断及加载更多错误重试
- 使用窄 App 层 `SearchNativeGridView` 将搜索卡片映射到既有 AppKit `NativeVideoGridView`
- 复用现有原生卡片、匿名图片 pipeline、缓存、复用 token、离屏取消和 teardown
- 保留初始 loading、empty、failure、刷新、播放导航与返回行为
- 增加分页竞态、错误保留、去重、tail backpressure 和 presentation mapping 测试

## 原因

Search 原来只有第一页 SwiftUI `LazyVGrid`，未利用既有原生视频网格，也没有真实 near-end 分页状态机。接口已经提供稳定的 page、pageSize、numResults 和 numPages 语义，因此可以在不扩展认证或跨层架构的前提下闭合分页。

## 用户影响

搜索结果可以在接近尾部时顺序加载下一页；追加失败会保留已有卡片并允许重试。切换 query 会取消旧请求并拒绝迟到结果，append 不会跳回顶部。

## 验证

- `GuestBrowseAndVideoViewModelTests`：28/28 通过
- Search 原生 presentation mapping 与既有 NativeVideoGrid 契约测试通过
- `sh Scripts/run-quality-gates.sh app` 通过
  - Package：395 tests / 46 suites
  - App build-for-testing 与 App tests 通过
  - `CODE_SIGNING_ALLOWED=NO`，签名 Keychain smoke 按 Gate 设计跳过
- 匿名真实 Search runtime smoke：成功显示 9 张原生卡片
- 三路独立代码审核未发现生命周期、竞态或架构阻断问题

## 未覆盖边界

未覆盖真人 VoiceOver/FKA、签名/Keychain runtime、长时间快速 query churn 与性能 Instruments。Popular 无限分页不在本 PR 范围内。