### PR TITLE
feat(playback): 进入详情后自动开始播放

### DIFF
--- a/BiliKitMacTests/VideoDetailLifecycleTests.swift
+++ b/BiliKitMacTests/VideoDetailLifecycleTests.swift
@@ -543,6 +543,11 @@ private final class ControlledFailingPlayback: PlaybackControlling {
         }
     }
 
+    func beginPlayback(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent
+    ) -> Bool { true }
+
     func pause() {}
 
     func stop() {}
@@ -565,6 +570,7 @@ private func finishedPlaybackFailureEvents() -> AsyncStream<PlaybackFailureEvent
 @MainActor
 private final class RecordingLifecyclePlayback: PlaybackControlling {
     private(set) var loadedIdentities: [PlaybackItemIdentity] = []
+    private(set) var startedIdentities: [PlaybackItemIdentity] = []
     private(set) var stopCallCount = 0
 
     func playbackFailureEvents() -> AsyncStream<PlaybackFailureEvent> {
@@ -577,6 +583,14 @@ private final class RecordingLifecyclePlayback: PlaybackControlling {
         intent: PlaybackLoadIntent
     ) async throws {
         loadedIdentities.append(identity)
+    }
+
+    func beginPlayback(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent
+    ) -> Bool {
+        startedIdentities.append(identity)
+        return true
     }
 
     func pause() {}

--- a/Packages/BiliKitCore/Sources/BiliApplication/Playback/PlaybackTimeline.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Playback/PlaybackTimeline.swift
@@ -106,6 +106,12 @@ public protocol PlaybackControlling: AnyObject {
         identity: PlaybackItemIdentity,
         intent: PlaybackLoadIntent
     ) async throws
+    /// 只为仍匹配本次 load intent、且尚未播放或 seek 的 item 开始播放。
+    @discardableResult
+    func beginPlayback(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent
+    ) -> Bool
     func pause()
     func stop()
 }
@@ -171,13 +177,17 @@ package final class PlaybackTimelineStore {
         durationSeconds: Double?
     ) {
         guard token == currentToken else { return }
+        let state =
+            currentSnapshot.state == .loading
+            ? PlaybackTimelineState.ready
+            : currentSnapshot.state
         publish(
             PlaybackTimelineSnapshot(
                 identity: currentSnapshot.identity,
-                positionSeconds: 0,
+                positionSeconds: currentSnapshot.positionSeconds,
                 durationSeconds: durationSeconds,
-                rate: 0,
-                state: .ready,
+                rate: currentSnapshot.rate,
+                state: state,
                 discontinuityGeneration:
                     currentSnapshot.discontinuityGeneration
             )

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoViewModel.swift
@@ -281,6 +281,7 @@ public final class GuestVideoViewModel {
             )
             try Task.checkCancellation()
             guard generation == currentGeneration else { return }
+            playback.beginPlayback(identity: identity, intent: intent)
             presentedPlaybackIdentity = requestedPlaybackIdentity
             state = .ready(context)
         } catch is CancellationError {
@@ -331,6 +332,7 @@ public final class GuestVideoViewModel {
             )
             try Task.checkCancellation()
             guard generation == currentGeneration else { return }
+            playback.beginPlayback(identity: identity, intent: intent)
             presentedPlaybackIdentity = identity
             state = .ready(replacement)
         } catch is CancellationError {

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
@@ -273,6 +273,26 @@ public final class AVPlayerEngine:
         emit(.stateChanged(.idle))
     }
 
+    /// 只提交当前 load intent 的首次自动播放；旧请求、重复回调和已播放/seek 的 item 均拒绝。
+    @discardableResult
+    public func beginPlayback(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent
+    ) -> Bool {
+        guard loadIntent == intent,
+            timeline.currentSnapshot.identity == identity,
+            !timeline.hasObservedPlaybackInteraction,
+            player.currentTime().seconds.isFinite,
+            player.currentTime().seconds >= 0,
+            player.currentTime().seconds <= 0.25,
+            timeline.currentSnapshot.state == .ready
+                || timeline.currentSnapshot.state == .paused,
+            player.currentItem != nil
+        else { return false }
+        play()
+        return true
+    }
+
     public func play() {
         guard player.currentItem != nil else { return }
         timeline.play()

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerTimelineAdapter.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerTimelineAdapter.swift
@@ -1,6 +1,7 @@
 @preconcurrency import AVFoundation
 import BiliApplication
 import Foundation
+import Synchronization
 import os
 
 enum MomentaryRateRestorationAction: Equatable {
@@ -31,6 +32,18 @@ enum MomentaryRateRestorationPolicy {
     }
 }
 
+private final class PlaybackInteractionTracker: Sendable {
+    private let wasObserved = Mutex(false)
+
+    var hasObservedInteraction: Bool {
+        wasObserved.withLock { $0 }
+    }
+
+    func markObserved() {
+        wasObserved.withLock { $0 = true }
+    }
+}
+
 @MainActor
 /// 把 AVPlayer/KVO/notification 事件投影为平台无关、identity-safe 的播放时间线。
 ///
@@ -50,6 +63,10 @@ final class AVPlayerTimelineAdapter {
         store.currentSnapshot
     }
 
+    var hasObservedPlaybackInteraction: Bool {
+        interactionTracker.hasObservedInteraction
+    }
+
     private let player: AVPlayer
     private let store = PlaybackTimelineStore()
     private let observers = PlayerTimelineObserverBag()
@@ -57,6 +74,7 @@ final class AVPlayerTimelineAdapter {
     private var failedToken: PlaybackTimelineItemToken?
     private var momentaryRateSession: MomentaryRateSession?
     private var pendingExplicitSeekPosition: Double?
+    private var interactionTracker = PlaybackInteractionTracker()
 
     init(player: AVPlayer) {
         self.player = player
@@ -72,6 +90,7 @@ final class AVPlayerTimelineAdapter {
         momentaryRateSession = nil
         observers.reset()
         pendingExplicitSeekPosition = nil
+        interactionTracker = PlaybackInteractionTracker()
         token = store.beginItem(identity: identity)
         failedToken = nil
     }
@@ -80,6 +99,7 @@ final class AVPlayerTimelineAdapter {
     func installObservers(for item: AVPlayerItem) {
         observers.reset()
         guard let token else { return }
+        let interactionTracker = interactionTracker
 
         let periodicTimeObserver = player.addPeriodicTimeObserver(
             forInterval: CMTime(value: 1, timescale: 30),
@@ -109,22 +129,28 @@ final class AVPlayerTimelineAdapter {
 
         let timeControlObservation = player.observe(
             \.timeControlStatus,
-            options: [.initial, .new]
-        ) { [weak self, weak item] player, _ in
+            options: [.new]
+        ) { [weak self, weak item] player, change in
+            let observedStatus = change.newValue ?? player.timeControlStatus
+            if observedStatus != .paused {
+                interactionTracker.markObserved()
+            }
             Task { @MainActor in
                 guard let self, let item, self.player.currentItem === item else {
                     return
                 }
                 let currentState = self.store.currentSnapshot.state
                 guard currentState != .failed else { return }
-                switch player.timeControlStatus {
+                switch observedStatus {
                 case .paused:
-                    guard currentState != .loading, currentState != .ended else {
+                    guard currentState != .ended,
+                        currentState != .loading
+                            || interactionTracker.hasObservedInteraction
+                    else {
                         return
                     }
                     self.store.update(token: token, rate: 0, state: .paused)
                 case .waitingToPlayAtSpecifiedRate:
-                    guard currentState != .loading else { return }
                     self.store.update(
                         token: token,
                         rate: Double(player.rate),
@@ -253,6 +279,7 @@ final class AVPlayerTimelineAdapter {
 
     func pause() {
         guard let token else { return }
+        interactionTracker.markObserved()
         momentaryRateSession = nil
         player.pause()
         store.update(token: token, rate: 0, state: .paused)
@@ -326,6 +353,7 @@ final class AVPlayerTimelineAdapter {
     }
 
     func prepareExplicitSeek(to positionSeconds: Double) {
+        interactionTracker.markObserved()
         pendingExplicitSeekPosition = positionSeconds
     }
 

--- a/Packages/BiliKitCore/Tests/BiliApplicationTests/PlaybackTimelineStoreTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliApplicationTests/PlaybackTimelineStoreTests.swift
@@ -51,6 +51,29 @@ struct PlaybackTimelineStoreTests {
     }
 
     @Test
+    func readyTransitionDoesNotOverwriteAnExistingUserState() {
+        let store = PlaybackTimelineStore()
+        let identity = PlaybackItemIdentity(
+            bvid: "BV1UserIntentFixture",
+            cid: 900_001
+        )
+        let token = store.beginItem(identity: identity)
+
+        store.update(
+            token: token,
+            positionSeconds: 3,
+            rate: 0,
+            state: .paused
+        )
+        store.markReady(token: token, durationSeconds: 120)
+
+        #expect(store.currentSnapshot.positionSeconds == 3)
+        #expect(store.currentSnapshot.durationSeconds == 120)
+        #expect(store.currentSnapshot.rate == 0)
+        #expect(store.currentSnapshot.state == .paused)
+    }
+
+    @Test
     func replacementRejectsOldItemUpdatesAndClear() {
         let store = PlaybackTimelineStore()
         let oldIdentity = PlaybackItemIdentity(

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
@@ -547,6 +547,8 @@ struct GuestBrowseAndVideoViewModelTests {
                 )
             ]
         )
+        #expect(player.startedIdentities == player.loadedIdentities)
+        #expect(player.startedIntents.count == 1)
     }
 
     @Test
@@ -661,6 +663,8 @@ struct GuestBrowseAndVideoViewModelTests {
         #expect(context.detail.bvid == fast.detail.bvid)
         #expect(model.presentedContext?.detail.bvid == fast.detail.bvid)
         #expect(player.loadedPlaybacks.count == 1)
+        #expect(player.startedIdentities.count == 1)
+        #expect(player.startedIdentities.first?.bvid == fast.detail.bvid)
         #expect(player.stopCallCount == 1)
         #expect(
             player.loadedPlaybacks.first?.mediaHeaders["Referer"]?.contains(
@@ -700,10 +704,12 @@ struct GuestBrowseAndVideoViewModelTests {
         #expect(model.presentedContext?.selectedPage.cid == 900_002)
         #expect(model.presentedPlaybackIdentity == secondIdentity)
         #expect(player.loadedIdentities == [firstIdentity, secondIdentity])
+        #expect(player.startedIdentities == [firstIdentity, secondIdentity])
         #expect(player.stopCallCount == 1)
 
         model.selectPage(cid: 900_002)
         #expect(player.loadedIdentities == [firstIdentity, secondIdentity])
+        #expect(player.startedIdentities == [firstIdentity, secondIdentity])
         model.reset()
         #expect(model.presentedContext == nil)
         #expect(model.requestedPlaybackIdentity == nil)
@@ -857,6 +863,8 @@ struct GuestBrowseAndVideoViewModelTests {
         #expect(model.presentedPlaybackIdentity == firstIdentity)
         #expect(player.loadedIdentities.map(\.cid) == [900_001, 900_002, 900_001])
         #expect(player.loadedIntents[0] != player.loadedIntents[2])
+        #expect(player.startedIdentities.map(\.cid) == [900_001, 900_002, 900_001])
+        #expect(player.startedIntents == player.loadedIntents)
     }
 
     @Test(.timeLimit(.minutes(1)))
@@ -2247,6 +2255,8 @@ private actor TestEventCounter {
 private final class RecordingPlayerEngine: PlaybackControlling {
     private(set) var loadedPlaybacks: [VideoPlayback] = []
     private(set) var loadedIdentities: [PlaybackItemIdentity] = []
+    private(set) var startedIdentities: [PlaybackItemIdentity] = []
+    private(set) var startedIntents: [PlaybackLoadIntent] = []
     private(set) var pauseCallCount = 0
     private(set) var stopCallCount = 0
 
@@ -2261,6 +2271,15 @@ private final class RecordingPlayerEngine: PlaybackControlling {
     ) async throws {
         loadedPlaybacks.append(playback)
         loadedIdentities.append(identity)
+    }
+
+    func beginPlayback(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent
+    ) -> Bool {
+        startedIdentities.append(identity)
+        startedIntents.append(intent)
+        return true
     }
 
     func pause() {
@@ -2293,6 +2312,11 @@ private final class SelectiveFailingPlayerEngine: PlaybackControlling {
             throw SelectivePlaybackFailure()
         }
     }
+
+    func beginPlayback(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent
+    ) -> Bool { true }
 
     func pause() {}
 
@@ -2335,6 +2359,11 @@ private final class PostReadyFailurePlayer: PlaybackControlling {
         loadedIdentities.append(identity)
         loadedIntents[identity] = intent
     }
+
+    func beginPlayback(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent
+    ) -> Bool { true }
 
     func pause() {}
 
@@ -2410,6 +2439,11 @@ private final class FailureBeforeLoadReturnsPlayer: PlaybackControlling {
         }
     }
 
+    func beginPlayback(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent
+    ) -> Bool { true }
+
     func pause() {}
 
     func stop() {
@@ -2427,6 +2461,8 @@ private final class DelayedABAPlayback: PlaybackControlling {
     private var thirdLoadWaiters: [CheckedContinuation<Void, Never>] = []
     private(set) var loadedIdentities: [PlaybackItemIdentity] = []
     private(set) var loadedIntents: [PlaybackLoadIntent] = []
+    private(set) var startedIdentities: [PlaybackItemIdentity] = []
+    private(set) var startedIntents: [PlaybackLoadIntent] = []
     private(set) var stopCallCount = 0
 
     init() {
@@ -2457,6 +2493,15 @@ private final class DelayedABAPlayback: PlaybackControlling {
         await withCheckedContinuation { continuation in
             thirdLoadContinuation = continuation
         }
+    }
+
+    func beginPlayback(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent
+    ) -> Bool {
+        startedIdentities.append(identity)
+        startedIntents.append(intent)
+        return true
     }
 
     func pause() {}

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
@@ -2376,17 +2376,19 @@ struct LoopbackPlaybackServerTests {
         #expect(engine.player.currentItem == nil)
         #expect(engine.currentTimelineSnapshot == .idle)
 
+        let request = PlaybackRequest(
+            manifest: PlaybackManifest(
+                videoRepresentations: [highVideo, lowVideo],
+                originalAudioRepresentations: [audio, alternateAudio]
+            )
+        )
+        let loadIntent = PlaybackLoadIntent()
         try await engine.load(
-            PlaybackRequest(
-                manifest: PlaybackManifest(
-                    videoRepresentations: [highVideo, lowVideo],
-                    originalAudioRepresentations: [audio, alternateAudio]
-                )
-            ),
-            identity: identity
+            request,
+            identity: identity,
+            intent: loadIntent
         )
         let item = try #require(engine.player.currentItem)
-        let itemIdentity = ObjectIdentifier(item)
         let asset = try #require(item.asset as? AVURLAsset)
         let variants = try await asset.load(.variants)
         let audibleGroup = try #require(
@@ -2451,11 +2453,58 @@ struct LoopbackPlaybackServerTests {
             }
         )
 
-        engine.play()
+        #expect(
+            !engine.beginPlayback(
+                identity: identity,
+                intent: PlaybackLoadIntent()
+            )
+        )
+        #expect(
+            !engine.beginPlayback(
+                identity: PlaybackItemIdentity(
+                    bvid: "BV1StalePlayback",
+                    cid: identity.cid
+                ),
+                intent: loadIntent
+            )
+        )
+        engine.pause()
+        #expect(
+            !engine.beginPlayback(identity: identity, intent: loadIntent)
+        )
+
+        engine.stop()
+        let restartedIntent = PlaybackLoadIntent()
+        try await engine.load(
+            request,
+            identity: identity,
+            intent: restartedIntent
+        )
+        try await engine.seek(to: .milliseconds(100))
+        #expect(
+            !engine.beginPlayback(identity: identity, intent: restartedIntent)
+        )
+
+        engine.stop()
+        let playableIntent = PlaybackLoadIntent()
+        try await engine.load(
+            request,
+            identity: identity,
+            intent: playableIntent
+        )
+        let playableItemIdentity = engine.player.currentItem.map(
+            ObjectIdentifier.init
+        )
+        #expect(
+            engine.beginPlayback(identity: identity, intent: playableIntent)
+        )
+        #expect(
+            !engine.beginPlayback(identity: identity, intent: playableIntent)
+        )
         try await waitUntilPlaybackTime(engine.player, reaches: 0.15)
         #expect(
             engine.player.currentItem.map(ObjectIdentifier.init)
-                == itemIdentity
+                == playableItemIdentity
         )
         engine.stop()
     }


### PR DESCRIPTION
## 变化

- 在视频详情和分 P 准备完成后，通过独立的 `beginPlayback` 命令自动开始当前播放项目。
- 用 BVID、CID、不可复用的 load intent 和当前 item 状态共同拒绝旧请求、ABA 返回与重复开始。
- 为每个播放 item 维护单调的用户交互标记；显式播放、暂停和 seek 会阻止迟到的自动开始覆盖用户意图。
- 保持媒体加载与开始播放分离，继续复用单一 `AVPlayer`、时间线和 player host，为后续自动播放开关及首次断点 seek 保留边界。

## 原因

当前详情页已经完成 manifest 准备、`AVPlayerItem` 替换和 `readyToPlay`，但 Application 播放命令边界没有开始播放能力，因此用户仍需手动点击系统播放按钮。

## 用户影响

- 从热门、搜索、历史或相关推荐进入详情后，当前视频准备完成会直接开始播放。
- 换 P 后只会开始新 CID；快速 A→B→A、Back、关窗或账户边界变化不会启动旧 item。
- 用户在准备期间主动播放、暂停或 seek 后，自动播放不会覆盖该操作。
- 本次不加入设置项、断点续播、heartbeat 或第二播放器。

## 验证

- 独立 reviewer 两轮审查：旧请求、用户 pause/seek、重复触发、换 P、ABA、单播放器边界均无剩余阻断项。
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer BILIKIT_COMPACT_LOGS=1 sh Scripts/run-quality-gates.sh app`
  - 架构、安全、秘密模式与 Swift 格式检查通过
  - Swift Package：403 tests / 46 suites 通过
  - fresh macOS App `build-for-testing` 通过
  - App 单元与生命周期测试通过；签名关闭，Signed Keychain smoke 按 Gate 配置跳过
- 精简 fresh Debug App 构建并成功启动；未执行真实视频播放路径。

## 未覆盖

- 尚未用真实视频观察进入详情后的首帧、声音与 player surface 挂载顺序。
- 未验证 VoiceOver、Full Keyboard Access、长期稳定性或性能。
- 未涉及服务器历史进度读取、heartbeat 写入或 Cookie transport 改造。
