### PR TITLE
feat(api): 保真映射 UGC 合集与分P

### DIFF
--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
@@ -249,7 +249,7 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
                 mapsAuthenticationInvalidation: true
             )
         )
-        return try payload.map { try $0.model() }
+        return try validatedPageModels(payload)
     }
 
     /// 取得 AVC/AAC DASH 清单；仅 playurl 可按本地凭据状态选择精确授权或匿名请求。

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/VideoEndpointPayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/VideoEndpointPayloads.swift
@@ -138,6 +138,7 @@ struct StatisticsPayload: Decodable, Sendable {
 }
 
 struct VideoDetailPayload: Decodable, Sendable {
+    let aid: Int64?
     let bvid: String
     let title: String
     let desc: String
@@ -147,11 +148,24 @@ struct VideoDetailPayload: Decodable, Sendable {
     let duration: Int
     let pubdate: Int64
     let dimension: DimensionPayload?
+    let pages: [PagePayload]?
+    let ugcSeason: UGCSeasonPayload?
+
+    private enum CodingKeys: String, CodingKey {
+        case aid, bvid, title, desc, pic, owner, stat, duration, pubdate, dimension, pages
+        case ugcSeason = "ugc_season"
+    }
 
     func model() throws -> VideoDetail {
-        guard bvid.hasPrefix("BV"), !title.isEmpty, duration >= 0, pubdate >= 0 else {
+        guard aid.map({ $0 > 0 }) ?? true,
+            bvid.hasPrefix("BV"),
+            !title.isEmpty,
+            duration >= 0,
+            pubdate >= 0
+        else {
             throw BiliAPIError.decodingFailed
         }
+        let resolvedPages = try validatedPageModels(pages ?? [])
         return VideoDetail(
             bvid: bvid,
             title: title,
@@ -161,7 +175,10 @@ struct VideoDetailPayload: Decodable, Sendable {
             statistics: stat.model(),
             durationSeconds: duration,
             publishedAt: Date(timeIntervalSince1970: TimeInterval(pubdate)),
-            dimension: dimension?.model()
+            dimension: dimension?.model(),
+            aid: aid,
+            pages: resolvedPages,
+            collection: ugcSeason?.model()
         )
     }
 }
@@ -185,6 +202,246 @@ struct PagePayload: Decodable, Sendable {
             dimension: dimension?.model()
         )
     }
+}
+
+struct UGCSeasonPayload: Decodable, Sendable {
+    let id: Int64?
+    let title: String?
+    let epCount: Int?
+    let sections: [UGCSeasonSectionPayload]?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, sections
+        case epCount = "ep_count"
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try? container.decodeIfPresent(Int64.self, forKey: .id)
+        title = try? container.decodeIfPresent(String.self, forKey: .title)
+        epCount = try? container.decodeIfPresent(Int.self, forKey: .epCount)
+        sections = try? container.decodeIfPresent([UGCSeasonSectionPayload].self, forKey: .sections)
+    }
+
+    func model() -> VideoCollection? {
+        guard let id,
+            id > 0,
+            let title,
+            !title.isEmpty,
+            epCount.map({ $0 >= 0 }) ?? true
+        else {
+            return nil
+        }
+        let resolvedSections = sections ?? []
+        let sectionIDCounts = Dictionary(grouping: resolvedSections, by: \.resolvedID)
+            .mapValues(\.count)
+        return VideoCollection(
+            id: id,
+            title: title,
+            reportedEpisodeCount: epCount,
+            sections: resolvedSections.enumerated().map { ordinal, section in
+                section.model(
+                    seasonID: id,
+                    ordinal: ordinal,
+                    needsOccurrenceIdentity: sectionIDCounts[section.resolvedID, default: 0] > 1
+                )
+            }
+        )
+    }
+}
+
+struct UGCSeasonSectionPayload: Decodable, Sendable {
+    let id: Int64?
+    let sectionIDAlias: Int64?
+    let seasonID: Int64?
+    let title: String?
+    let episodes: [UGCSeasonEpisodePayload]?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, episodes
+        case sectionIDAlias = "section_id"
+        case seasonID = "season_id"
+    }
+
+    var resolvedID: Int64? { id ?? sectionIDAlias }
+
+    init(from decoder: any Decoder) throws {
+        guard let container = try? decoder.container(keyedBy: CodingKeys.self) else {
+            id = nil
+            seasonID = nil
+            sectionIDAlias = nil
+            title = nil
+            episodes = nil
+            return
+        }
+        id = try? container.decodeIfPresent(Int64.self, forKey: .id)
+        seasonID = try? container.decodeIfPresent(Int64.self, forKey: .seasonID)
+        sectionIDAlias = try? container.decodeIfPresent(Int64.self, forKey: .sectionIDAlias)
+        title = try? container.decodeIfPresent(String.self, forKey: .title)
+        episodes = try? container.decodeIfPresent([UGCSeasonEpisodePayload].self, forKey: .episodes)
+    }
+
+    func model(
+        seasonID expectedSeasonID: Int64,
+        ordinal: Int,
+        needsOccurrenceIdentity: Bool
+    ) -> VideoCollectionSection {
+        let sectionIDFieldsAreConsistent =
+            id == nil || sectionIDAlias == nil || id == sectionIDAlias
+        let resolvedID = resolvedID ?? 0
+        let identityIsConsistent =
+            resolvedID > 0
+            && sectionIDFieldsAreConsistent
+            && (seasonID.map { $0 == expectedSeasonID } ?? true)
+        let resolvedEpisodes = episodes ?? []
+        let episodeIDCounts = Dictionary(
+            grouping: resolvedEpisodes.compactMap(\.id),
+            by: { $0 }
+        ).mapValues(\.count)
+        return VideoCollectionSection(
+            id: VideoCollectionSectionIdentity(
+                seasonID: expectedSeasonID,
+                sectionID: resolvedID,
+                occurrenceOrdinal: needsOccurrenceIdentity ? ordinal : nil
+            ),
+            ordinal: ordinal,
+            title: title ?? "",
+            episodes: resolvedEpisodes.enumerated().map { episodeOrdinal, episode in
+                episode.model(
+                    seasonID: expectedSeasonID,
+                    sectionID: resolvedID,
+                    sectionOccurrenceOrdinal: needsOccurrenceIdentity ? ordinal : nil,
+                    ordinal: episodeOrdinal,
+                    parentIdentityIsConsistent: identityIsConsistent,
+                    needsOccurrenceIdentity: episode.id == nil
+                        || episodeIDCounts[episode.id ?? 0, default: 0] > 1
+                )
+            },
+            isIdentityConsistent: identityIsConsistent
+        )
+    }
+}
+
+struct UGCSeasonEpisodePayload: Decodable, Sendable {
+    let id: Int64?
+    let seasonID: Int64?
+    let sectionID: Int64?
+    let aid: Int64?
+    let bvid: String?
+    let cid: Int64?
+    let title: String?
+    let arc: UGCSeasonEpisodeArcPayload?
+    let page: PagePayload?
+    let pages: [PagePayload]?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, aid, bvid, cid, title, arc, page, pages
+        case seasonID = "season_id"
+        case sectionID = "section_id"
+    }
+
+    init(from decoder: any Decoder) throws {
+        guard let container = try? decoder.container(keyedBy: CodingKeys.self) else {
+            id = nil
+            seasonID = nil
+            sectionID = nil
+            aid = nil
+            bvid = nil
+            cid = nil
+            title = nil
+            arc = nil
+            page = nil
+            pages = nil
+            return
+        }
+        id = try? container.decodeIfPresent(Int64.self, forKey: .id)
+        seasonID = try? container.decodeIfPresent(Int64.self, forKey: .seasonID)
+        sectionID = try? container.decodeIfPresent(Int64.self, forKey: .sectionID)
+        aid = try? container.decodeIfPresent(Int64.self, forKey: .aid)
+        bvid = try? container.decodeIfPresent(String.self, forKey: .bvid)
+        cid = try? container.decodeIfPresent(Int64.self, forKey: .cid)
+        title = try? container.decodeIfPresent(String.self, forKey: .title)
+        arc = try? container.decodeIfPresent(UGCSeasonEpisodeArcPayload.self, forKey: .arc)
+        page = try? container.decodeIfPresent(PagePayload.self, forKey: .page)
+        pages = try? container.decodeIfPresent([PagePayload].self, forKey: .pages)
+    }
+
+    func model(
+        seasonID expectedSeasonID: Int64,
+        sectionID expectedSectionID: Int64,
+        sectionOccurrenceOrdinal: Int?,
+        ordinal: Int,
+        parentIdentityIsConsistent: Bool,
+        needsOccurrenceIdentity: Bool
+    ) -> VideoCollectionEpisode {
+        let aidIsConsistent = aid == nil || arc?.aid == nil || aid == arc?.aid
+        let bvidIsConsistent = bvid == nil || arc?.bvid == nil || bvid == arc?.bvid
+        let resolvedAID = aidIsConsistent ? (aid ?? arc?.aid) : nil
+        let resolvedBVID = bvidIsConsistent ? (bvid ?? arc?.bvid) : nil
+        let resolvedTitle = title ?? arc?.title ?? ""
+        let resolvedPage = page.flatMap { try? $0.model() }
+        let knownPages = pages.flatMap { try? validatedPageModels($0) }
+        let pageDataIsValid = page == nil || resolvedPage != nil
+        let pagesDataIsValid = pages == nil || knownPages != nil
+        let candidateCID = cid ?? resolvedPage?.cid ?? knownPages?.first?.cid
+        let cidIsConsistent =
+            (cid == nil || resolvedPage?.cid == nil || cid == resolvedPage?.cid)
+            && (knownPages.map { pages in
+                guard let candidateCID else { return true }
+                return pages.contains(where: { $0.cid == candidateCID })
+            } ?? true)
+        let identityIsConsistent =
+            parentIdentityIsConsistent
+            && (id.map { $0 > 0 } ?? true)
+            && (seasonID.map { $0 == expectedSeasonID } ?? true)
+            && (sectionID.map { $0 == expectedSectionID } ?? true)
+            && aidIsConsistent
+            && bvidIsConsistent
+            && (resolvedAID.map { $0 > 0 } ?? true)
+            && (resolvedBVID.map { $0.hasPrefix("BV") && $0.count == 12 } ?? true)
+            && !resolvedTitle.isEmpty
+            && (cid.map { $0 > 0 } ?? true)
+            && pageDataIsValid
+            && pagesDataIsValid
+            && cidIsConsistent
+            && (arc?.duration.map { $0 >= 0 } ?? true)
+        return VideoCollectionEpisode(
+            id: VideoCollectionEpisodeIdentity(
+                seasonID: expectedSeasonID,
+                sectionID: expectedSectionID,
+                sectionOccurrenceOrdinal: sectionOccurrenceOrdinal,
+                episodeID: id,
+                occurrenceOrdinal: needsOccurrenceIdentity ? ordinal : nil
+            ),
+            ordinal: ordinal,
+            aid: resolvedAID,
+            bvid: resolvedBVID,
+            title: resolvedTitle,
+            coverURL: arc?.pic.flatMap(WebImageURL.parse),
+            durationSeconds: arc?.duration,
+            defaultCID: cidIsConsistent ? candidateCID : nil,
+            knownPages: knownPages,
+            isIdentityConsistent: identityIsConsistent
+        )
+    }
+}
+
+struct UGCSeasonEpisodeArcPayload: Decodable, Sendable {
+    let aid: Int64?
+    let bvid: String?
+    let title: String?
+    let pic: String?
+    let duration: Int?
+}
+
+func validatedPageModels(_ payloads: [PagePayload]) throws -> [VideoPage] {
+    let pages = try payloads.map { try $0.model() }
+    guard Set(pages.map(\.cid)).count == pages.count,
+        Set(pages.map(\.index)).count == pages.count
+    else {
+        throw BiliAPIError.decodingFailed
+    }
+    return pages.sorted(by: { $0.index < $1.index })
 }
 
 struct DimensionPayload: Decodable, Sendable {

--- a/Packages/BiliKitCore/Sources/BiliModels/Video/VideoModels.swift
+++ b/Packages/BiliKitCore/Sources/BiliModels/Video/VideoModels.swift
@@ -113,6 +113,7 @@ public struct RelatedVideo: Identifiable, Sendable, Equatable {
 public struct VideoDetail: Identifiable, Sendable, Equatable {
     public var id: String { bvid }
 
+    public let aid: Int64?
     public let bvid: String
     public let title: String
     public let summary: String
@@ -122,6 +123,9 @@ public struct VideoDetail: Identifiable, Sendable, Equatable {
     public let durationSeconds: Int
     public let publishedAt: Date
     public let dimension: VideoDimension?
+    /// 当前 BVID 自身的分 P；与所属合集同时存在，不表达合集 episode。
+    public let pages: [VideoPage]
+    public let collection: VideoCollection?
 
     public init(
         bvid: String,
@@ -132,8 +136,12 @@ public struct VideoDetail: Identifiable, Sendable, Equatable {
         statistics: VideoStatistics,
         durationSeconds: Int,
         publishedAt: Date,
-        dimension: VideoDimension? = nil
+        dimension: VideoDimension? = nil,
+        aid: Int64? = nil,
+        pages: [VideoPage] = [],
+        collection: VideoCollection? = nil
     ) {
+        self.aid = aid
         self.bvid = bvid
         self.title = title
         self.summary = summary
@@ -143,6 +151,8 @@ public struct VideoDetail: Identifiable, Sendable, Equatable {
         self.durationSeconds = durationSeconds
         self.publishedAt = publishedAt
         self.dimension = dimension
+        self.pages = pages
+        self.collection = collection
     }
 }
 
@@ -179,6 +189,138 @@ public struct VideoPage: Identifiable, Sendable, Equatable {
         self.title = title
         self.durationSeconds = durationSeconds
         self.dimension = dimension
+    }
+}
+
+/// 仅表示 `/x/web-interface/view` 的 `ugc_season`；不表示 series、投稿列表或 PGC season。
+public struct VideoCollection: Identifiable, Sendable, Equatable {
+    public let id: Int64
+    public let title: String
+    public let reportedEpisodeCount: Int?
+    public let sections: [VideoCollectionSection]
+
+    public var embeddedEpisodeCount: Int {
+        sections.reduce(into: 0) { $0 += $1.episodes.count }
+    }
+
+    /// 只表达计数是否相等；非公开接口没有承诺相等即代表 section 树完整。
+    public var embeddedCountMatchesReportedCount: Bool? {
+        guard let reportedEpisodeCount else { return nil }
+        return reportedEpisodeCount == embeddedEpisodeCount
+    }
+
+    public init(
+        id: Int64,
+        title: String,
+        reportedEpisodeCount: Int?,
+        sections: [VideoCollectionSection]
+    ) {
+        self.id = id
+        self.title = title
+        self.reportedEpisodeCount = reportedEpisodeCount
+        self.sections = sections
+    }
+}
+
+public struct VideoCollectionSectionIdentity: Sendable, Hashable {
+    public let seasonID: Int64
+    public let sectionID: Int64
+    /// 仅在远端 section ID 重复时区分同一响应中的 occurrence。
+    public let occurrenceOrdinal: Int?
+
+    public init(
+        seasonID: Int64,
+        sectionID: Int64,
+        occurrenceOrdinal: Int? = nil
+    ) {
+        self.seasonID = seasonID
+        self.sectionID = sectionID
+        self.occurrenceOrdinal = occurrenceOrdinal
+    }
+}
+
+public struct VideoCollectionSection: Identifiable, Sendable, Equatable {
+    public let id: VideoCollectionSectionIdentity
+    public let ordinal: Int
+    public let title: String
+    public let episodes: [VideoCollectionEpisode]
+    public let isIdentityConsistent: Bool
+
+    public init(
+        id: VideoCollectionSectionIdentity,
+        ordinal: Int,
+        title: String,
+        episodes: [VideoCollectionEpisode],
+        isIdentityConsistent: Bool = true
+    ) {
+        self.id = id
+        self.ordinal = ordinal
+        self.title = title
+        self.episodes = episodes
+        self.isIdentityConsistent = isIdentityConsistent
+    }
+}
+
+public struct VideoCollectionEpisodeIdentity: Sendable, Hashable {
+    public let seasonID: Int64
+    public let sectionID: Int64
+    /// 父 section ID 重复时继承其 occurrence，避免跨 section 的 episode identity 碰撞。
+    public let sectionOccurrenceOrdinal: Int?
+    public let episodeID: Int64?
+    /// 远端 ID 缺失或重复时才用于区分当前响应中的 occurrence。
+    public let occurrenceOrdinal: Int?
+
+    public init(
+        seasonID: Int64,
+        sectionID: Int64,
+        sectionOccurrenceOrdinal: Int? = nil,
+        episodeID: Int64?,
+        occurrenceOrdinal: Int? = nil
+    ) {
+        self.seasonID = seasonID
+        self.sectionID = sectionID
+        self.sectionOccurrenceOrdinal = sectionOccurrenceOrdinal
+        self.episodeID = episodeID
+        self.occurrenceOrdinal = occurrenceOrdinal
+    }
+}
+
+public struct VideoCollectionEpisode: Identifiable, Sendable, Equatable {
+    public let id: VideoCollectionEpisodeIdentity
+    public let ordinal: Int
+    public let aid: Int64?
+    public let bvid: String?
+    public let title: String
+    public let coverURL: URL?
+    public let durationSeconds: Int?
+    public let defaultCID: Int64?
+    /// `nil` 表示详情摘要没有给出分 P；空数组表示远端明确给出空列表。
+    public let knownPages: [VideoPage]?
+    /// 重复身份字段冲突或缺少标题时为 false；仍保留 occurrence 供 UI 解释不可用状态。
+    public let isIdentityConsistent: Bool
+
+    public init(
+        id: VideoCollectionEpisodeIdentity,
+        ordinal: Int,
+        aid: Int64?,
+        bvid: String?,
+        title: String,
+        coverURL: URL?,
+        durationSeconds: Int?,
+        defaultCID: Int64?,
+        knownPages: [VideoPage]?,
+        isIdentityConsistent: Bool = true
+    ) {
+        self.id = id
+        self.ordinal = ordinal
+        self.aid = aid
+        self.bvid = bvid
+        self.title = title
+        self.coverURL = coverURL
+        self.durationSeconds = durationSeconds
+        self.defaultCID = defaultCID
+        self.knownPages = knownPages
+        self.isIdentityConsistent = isIdentityConsistent
     }
 }
 

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
@@ -60,10 +60,212 @@ struct BiliAPIClientTests {
         #expect(detail.owner.id == 10_001)
         #expect(detail.statistics.likeCount == 3_456)
         #expect(detail.dimension == VideoDimension(width: 1920, height: 1080, rotation: 0))
+        #expect(detail.pages.map(\.cid) == [900_001])
 
         let request = try #require(await transport.capturedRequests().first)
         #expect(request.url.path == "/x/web-interface/view")
         #expect(request.headers["Referer"] == "https://www.bilibili.com/video/BV1FixtureA1/")
+    }
+
+    @Test
+    func videoDetailPreservesCurrentPagesAndNestedUGCCollection() async throws {
+        let response = jsonResponse(
+            #"""
+            {"code":0,"data":{"aid":7001,"bvid":"BV1FixtureA1","title":"当前视频","desc":"说明","pic":"https://images.example.invalid/current.jpg","owner":{"mid":10001,"name":"作者"},"stat":{"view":1,"danmaku":2,"like":3},"duration":300,"pubdate":1720000000,"pages":[{"cid":900001,"page":1,"part":"当前 P1","duration":120},{"cid":900002,"page":2,"part":"当前 P2","duration":180}],"ugc_season":{"id":501,"title":"测试合集","ep_count":3,"sections":[{"season_id":501,"id":601,"title":"第一章","episodes":[{"season_id":501,"section_id":601,"id":701,"aid":7001,"bvid":"BV1FixtureA1","cid":900001,"title":"当前视频","arc":{"aid":7001,"bvid":"BV1FixtureA1","title":"当前视频","pic":"https://images.example.invalid/current.jpg","duration":300},"pages":[{"cid":900001,"page":1,"part":"当前 P1","duration":120},{"cid":900002,"page":2,"part":"当前 P2","duration":180}]},{"season_id":501,"section_id":601,"id":702,"aid":7002,"bvid":"BV1FixtureB2","cid":910001,"title":"下一视频","arc":{"duration":200},"page":{"cid":910001,"page":1,"part":"默认 P","duration":200}}]},{"season_id":501,"id":602,"title":"第二章","episodes":[{"season_id":501,"section_id":602,"id":703,"aid":7003,"bvid":"BV1FixtureC3","cid":920001,"title":"第三视频","arc":{"duration":100}}]}]}}}
+            """#
+        )
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [response])
+        )
+
+        let detail = try await client.videoDetail(for: "BV1FixtureA1")
+
+        #expect(detail.aid == 7_001)
+        #expect(detail.pages.map(\.cid) == [900_001, 900_002])
+        let collection = try #require(detail.collection)
+        #expect(collection.id == 501)
+        #expect(collection.sections.count == 2)
+        #expect(collection.embeddedEpisodeCount == 3)
+        #expect(collection.embeddedCountMatchesReportedCount == true)
+        #expect(collection.sections[0].ordinal == 0)
+        #expect(collection.sections[1].ordinal == 1)
+        #expect(collection.sections[0].episodes[0].knownPages?.map(\.cid) == [900_001, 900_002])
+        #expect(collection.sections[0].episodes[1].knownPages == nil)
+        #expect(collection.sections[0].episodes[1].defaultCID == 910_001)
+    }
+
+    @Test
+    func videoDetailPreservesIncompleteCollectionSummary() async throws {
+        let response = jsonResponse(
+            #"{"code":0,"data":{"bvid":"BV1FixtureA1","title":"当前视频","desc":"说明","pic":"","owner":{"mid":10001,"name":"作者"},"stat":{"view":1,"danmaku":2,"like":3},"duration":120,"pubdate":1720000000,"pages":[{"cid":900001,"page":1,"part":"P1","duration":120}],"ugc_season":{"id":501,"title":"摘要合集","ep_count":20}}}"#
+        )
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [response])
+        )
+
+        let collection = try #require(
+            try await client.videoDetail(for: "BV1FixtureA1").collection
+        )
+
+        #expect(collection.sections.isEmpty)
+        #expect(collection.reportedEpisodeCount == 20)
+        #expect(collection.embeddedCountMatchesReportedCount == false)
+    }
+
+    @Test
+    func videoDetailRejectsDuplicatePageIdentity() async {
+        let response = jsonResponse(
+            #"{"code":0,"data":{"bvid":"BV1FixtureA1","title":"当前视频","desc":"说明","pic":"","owner":{"mid":10001,"name":"作者"},"stat":{"view":1,"danmaku":2,"like":3},"duration":120,"pubdate":1720000000,"pages":[{"cid":900001,"page":1,"part":"P1","duration":60},{"cid":900001,"page":2,"part":"P2","duration":60}]}}"#
+        )
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [response])
+        )
+
+        await #expect(throws: BiliAPIError.decodingFailed) {
+            try await client.videoDetail(for: "BV1FixtureA1")
+        }
+    }
+
+    @Test
+    func malformedCollectionEpisodeDoesNotBlockCurrentVideo() async throws {
+        let response = jsonResponse(
+            #"{"code":0,"data":{"bvid":"BV1FixtureA1","title":"当前视频","desc":"说明","pic":"","owner":{"mid":10001,"name":"作者"},"stat":{"view":1,"danmaku":2,"like":3},"duration":120,"pubdate":1720000000,"pages":[{"cid":900001,"page":1,"part":"P1","duration":120}],"ugc_season":{"id":501,"title":"合集","ep_count":1,"sections":[{"season_id":501,"id":601,"title":"分部","episodes":[{"season_id":999,"section_id":601,"id":701,"aid":7001,"bvid":"BV1FixtureB2","cid":910001,"title":"","arc":{"aid":7002,"bvid":"BV1FixtureC3","duration":100},"page":{"cid":910002,"page":1,"part":"P1","duration":100}}]}]}}}"#
+        )
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [response])
+        )
+
+        let detail = try await client.videoDetail(for: "BV1FixtureA1")
+
+        #expect(detail.pages.map(\.cid) == [900_001])
+        let episode = try #require(detail.collection?.sections.first?.episodes.first)
+        #expect(!episode.isIdentityConsistent)
+        #expect(episode.bvid == nil)
+        #expect(episode.defaultCID == nil)
+    }
+
+    @Test
+    func malformedCollectionElementsPreserveValidOccurrences() async throws {
+        let response = jsonResponse(
+            #"{"code":0,"data":{"bvid":"BV1FixtureA1","title":"当前视频","desc":"说明","pic":"","owner":{"mid":10001,"name":"作者"},"stat":{"view":1,"danmaku":2,"like":3},"duration":120,"pubdate":1720000000,"pages":[{"cid":900001,"page":1,"part":"P1","duration":120}],"ugc_season":{"id":501,"title":"合集","sections":[{"season_id":501,"id":601,"title":"分部","episodes":[{"season_id":501,"section_id":601,"id":701,"bvid":"BV1FixtureB2","title":"一"},null,{"season_id":501,"section_id":601,"id":702,"bvid":"BV1FixtureC3","title":"二"}]},null]}}}"#
+        )
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [response])
+        )
+
+        let collection = try #require(
+            try await client.videoDetail(for: "BV1FixtureA1").collection
+        )
+
+        #expect(collection.sections.count == 2)
+        #expect(collection.sections[0].episodes.count == 3)
+        #expect(collection.sections[0].episodes[0].isIdentityConsistent)
+        #expect(!collection.sections[0].episodes[1].isIdentityConsistent)
+        #expect(collection.sections[0].episodes[2].isIdentityConsistent)
+        #expect(!collection.sections[1].isIdentityConsistent)
+    }
+
+    @Test
+    func duplicateSectionOccurrencesKeepEpisodeIdentitiesDistinct() async throws {
+        let response = jsonResponse(
+            #"{"code":0,"data":{"bvid":"BV1FixtureA1","title":"当前视频","desc":"说明","pic":"","owner":{"mid":10001,"name":"作者"},"stat":{"view":1,"danmaku":2,"like":3},"duration":120,"pubdate":1720000000,"pages":[{"cid":900001,"page":1,"part":"P1","duration":120}],"ugc_season":{"id":501,"title":"合集","sections":[{"season_id":501,"section_id":601,"episodes":[{"season_id":501,"section_id":601,"id":701,"bvid":"BV1FixtureB2","title":"一"}]},{"season_id":501,"id":601,"episodes":[{"season_id":501,"section_id":601,"id":701,"bvid":"BV1FixtureC3","title":"二"}]}]}}}"#
+        )
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [response])
+        )
+
+        let sections = try #require(
+            try await client.videoDetail(for: "BV1FixtureA1").collection?.sections
+        )
+        let first = try #require(sections[0].episodes.first)
+        let second = try #require(sections[1].episodes.first)
+
+        #expect(sections[0].id.occurrenceOrdinal == 0)
+        #expect(sections[1].id.occurrenceOrdinal == 1)
+        #expect(first.id != second.id)
+        #expect(first.id.sectionOccurrenceOrdinal == 0)
+        #expect(second.id.sectionOccurrenceOrdinal == 1)
+    }
+
+    @Test
+    func conflictingSectionIDAliasesAreRetainedAsInvalid() async throws {
+        let response = jsonResponse(
+            #"{"code":0,"data":{"bvid":"BV1FixtureA1","title":"当前视频","desc":"说明","pic":"","owner":{"mid":10001,"name":"作者"},"stat":{"view":1,"danmaku":2,"like":3},"duration":120,"pubdate":1720000000,"pages":[{"cid":900001,"page":1,"part":"P1","duration":120}],"ugc_season":{"id":501,"title":"合集","sections":[{"season_id":501,"id":601,"section_id":602,"episodes":[]}]}}}"#
+        )
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [response])
+        )
+
+        let section = try #require(
+            try await client.videoDetail(for: "BV1FixtureA1")
+                .collection?.sections.first
+        )
+
+        #expect(!section.isIdentityConsistent)
+    }
+
+    @Test
+    func collectionIdentityRemainsStableWhenOrderChanges() async throws {
+        func response(order: String) -> HTTPResponse {
+            jsonResponse(
+                #"{"code":0,"data":{"bvid":"BV1FixtureA1","title":"当前视频","desc":"说明","pic":"","owner":{"mid":10001,"name":"作者"},"stat":{"view":1,"danmaku":2,"like":3},"duration":120,"pubdate":1720000000,"pages":[{"cid":900001,"page":1,"part":"P1","duration":120}],"ugc_season":{"id":501,"title":"合集","ep_count":2,"sections":[{"season_id":501,"id":601,"title":"分部","episodes":ORDER}]}}}"#
+                    .replacingOccurrences(
+                        of: "ORDER",
+                        with: order
+                    )
+            )
+        }
+        let firstEpisode =
+            #"{"season_id":501,"section_id":601,"id":701,"aid":7001,"bvid":"BV1FixtureB2","cid":910001,"title":"一"}"#
+        let secondEpisode =
+            #"{"season_id":501,"section_id":601,"id":702,"aid":7002,"bvid":"BV1FixtureC3","cid":920001,"title":"二"}"#
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [
+                response(order: "[\(firstEpisode),\(secondEpisode)]"),
+                response(order: "[\(secondEpisode),\(firstEpisode)]"),
+            ])
+        )
+
+        let first = try await client.videoDetail(for: "BV1FixtureA1")
+        let second = try await client.videoDetail(for: "BV1FixtureA1")
+        let firstIDs = try #require(first.collection?.sections.first?.episodes.map(\.id))
+        let secondIDs = try #require(second.collection?.sections.first?.episodes.map(\.id))
+
+        #expect(firstIDs == secondIDs.reversed())
+        #expect(firstIDs[0].occurrenceOrdinal == nil)
+    }
+
+    @Test
+    func episodePagesAreSortedAndDefaultCIDMustBelongToThem() async throws {
+        let response = jsonResponse(
+            #"{"code":0,"data":{"bvid":"BV1FixtureA1","title":"当前视频","desc":"说明","pic":"","owner":{"mid":10001,"name":"作者"},"stat":{"view":1,"danmaku":2,"like":3},"duration":120,"pubdate":1720000000,"pages":[{"cid":900001,"page":1,"part":"P1","duration":120}],"ugc_season":{"id":501,"title":"合集","sections":[{"season_id":501,"id":601,"title":"分部","episodes":[{"season_id":501,"section_id":601,"id":701,"aid":7001,"bvid":"BV1FixtureB2","cid":999999,"title":"视频","pages":[{"cid":910002,"page":2,"part":"P2","duration":50},{"cid":910001,"page":1,"part":"P1","duration":50}]}]}]}}}"#
+        )
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [response])
+        )
+
+        let episode = try #require(
+            try await client.videoDetail(for: "BV1FixtureA1")
+                .collection?.sections.first?.episodes.first
+        )
+
+        #expect(episode.knownPages?.map(\.index) == [1, 2])
+        #expect(episode.defaultCID == nil)
+        #expect(!episode.isIdentityConsistent)
+    }
+
+    @Test
+    func pagelistRejectsDuplicateIdentity() async {
+        let response = jsonResponse(
+            #"{"code":0,"data":[{"cid":900001,"page":1,"part":"P1","duration":60},{"cid":900001,"page":2,"part":"P2","duration":60}]}"#
+        )
+        let client = BiliAPIClient(
+            transport: RecordingTransport(responses: [response])
+        )
+
+        await #expect(throws: BiliAPIError.decodingFailed) {
+            try await client.pages(for: "BV1FixtureA1")
+        }
     }
 
     @Test


### PR DESCRIPTION
## 变化

- 保留 `/x/web-interface/view` 返回的当前视频 `aid`、`pages` 与 `ugc_season`
- 建模 season、section、episode 与 episode 已知/未知 pages
- 校验 BVID、AID、CID、page/pages 和父子 season/section identity
- 对坏 section/episode 局部降级，避免合集补充信息阻断当前视频详情
- pagelist 与内嵌 pages 共用排序和重复身份校验

## 原因与用户影响

为后续同时展示“当前视频分 P”和“所属 UGC 合集”建立无 UI 依赖的数据契约。合集 episode 不再被等同为 CID，重复 section occurrence 也不会导致 episode identity 碰撞。

## 验证

- 三路 agent 修复后重审：无 P0–P2
- 定向 API、UseCase、ViewModel 测试通过
- 完整 App Gate：436 tests / 46 suites、app build-for-testing、app tests 通过
- `git diff --check` 通过

## 未包含

- 不包含具体 UI
- 不包含自动下一集、PGC、相关推荐顺序或播放 owner 改造
- episode pages 的按需加载由后续堆叠 PR 接入
