### PR TITLE
feat(video): 增加合集分P按需加载状态

### DIFF
--- a/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestVideoUseCase.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestVideoUseCase.swift
@@ -20,7 +20,7 @@ public struct GuestVideoContext: Sendable, Equatable {
     }
 }
 
-/// 并行取得详情与分 P，再为排序后的首分 P 取得播放清单。
+/// 优先使用详情响应自带的分 P；旧响应缺失时才回退到独立分 P endpoint。
 ///
 /// 用例不拥有播放器，也不保留可变状态；任何一个阶段取消都会阻止后续播放请求或结果返回。
 public struct GuestVideoUseCase: Sendable {
@@ -31,11 +31,14 @@ public struct GuestVideoUseCase: Sendable {
     }
 
     public func prepareVideo(bvid: String) async throws -> GuestVideoContext {
-        async let detail = repository.videoDetail(for: bvid)
-        async let pages = repository.pages(for: bvid)
-        let (resolvedDetail, resolvedPages) = try await (detail, pages)
+        let resolvedDetail = try await repository.videoDetail(for: bvid)
         try Task.checkCancellation()
 
+        let resolvedPages =
+            resolvedDetail.pages.isEmpty
+            ? try await repository.pages(for: bvid)
+            : resolvedDetail.pages
+        try Task.checkCancellation()
         let sortedPages = resolvedPages.sorted(by: { $0.index < $1.index })
         guard let selectedPage = sortedPages.first else {
             throw GuestApplicationError.invalidResponse
@@ -52,6 +55,21 @@ public struct GuestVideoUseCase: Sendable {
             selectedPage: selectedPage,
             playback: playback
         )
+    }
+
+    /// 取得合集 episode 的分 P；详情已含 pages 时不重复请求独立 pagelist。
+    public func pagesForCollectionEpisode(bvid: String) async throws -> [VideoPage] {
+        let detail = try await repository.videoDetail(for: bvid)
+        try Task.checkCancellation()
+        guard detail.bvid == bvid else {
+            throw GuestApplicationError.invalidResponse
+        }
+        let resolvedPages =
+            detail.pages.isEmpty
+            ? try await repository.pages(for: bvid)
+            : detail.pages
+        try Task.checkCancellation()
+        return resolvedPages.sorted(by: { $0.index < $1.index })
     }
 
     /// 复用同一视频已经取得的详情与分 P，只为指定 CID 重新取得播放清单。

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoViewModel.swift
@@ -29,6 +29,13 @@ public enum RelatedVideoState: Sendable, Equatable {
     case failed(bvid: String, error: GuestApplicationError)
 }
 
+public enum CollectionEpisodePagesState: Sendable, Equatable {
+    case idle
+    case loading
+    case loaded(bvid: String)
+    case failed(GuestApplicationError)
+}
+
 @MainActor
 @Observable
 /// 拥有单个视频准备意图，并把内容准备与播放器安装串成同一 generation。
@@ -50,6 +57,9 @@ public final class GuestVideoViewModel {
     public private(set) var presentedPlaybackIdentity: PlaybackItemIdentity?
     /// 仅在确认凭据失效时递增，由 App 层协调账户重校验；其他播放失败不能触发登出。
     public private(set) var authenticationRevalidationGeneration = 0
+    public private(set) var expandedCollectionEpisodes: Set<VideoCollectionEpisodeIdentity> = []
+    public private(set) var collectionEpisodePageStates:
+        [VideoCollectionEpisodeIdentity: CollectionEpisodePagesState] = [:]
 
     @ObservationIgnored private let useCase: GuestVideoUseCase
     @ObservationIgnored private let playback: any PlaybackControlling
@@ -60,6 +70,15 @@ public final class GuestVideoViewModel {
     @ObservationIgnored private var uploaderSignatureTask: Task<Void, Never>?
     @ObservationIgnored private var playbackFailureTask: Task<Void, Never>?
     @ObservationIgnored private var playbackIntent: PlaybackLoadIntent?
+    @ObservationIgnored private var collectionEpisodeTask: Task<Void, Never>?
+    @ObservationIgnored private var activeCollectionEpisodeRequest: CollectionEpisodePageRequest?
+    @ObservationIgnored private var collectionEpisodeWaitersByBVID:
+        [String: Set<VideoCollectionEpisodeIdentity>] = [:]
+    @ObservationIgnored private var pendingCollectionEpisodeBVIDs: [String] = []
+    @ObservationIgnored private var collectionEpisodeCache: [String: [VideoPage]] = [:]
+    @ObservationIgnored private var collectionEpisodeCacheOrder: [String] = []
+    @ObservationIgnored private var collectionSeasonID: Int64?
+    @ObservationIgnored private var collectionEpisodeRequestGeneration = 0
     @ObservationIgnored private var generation = 0
     @ObservationIgnored private var relatedVideoGeneration = 0
     @ObservationIgnored private var uploaderSignatureGeneration = 0
@@ -87,6 +106,7 @@ public final class GuestVideoViewModel {
         relatedVideoTask?.cancel()
         uploaderSignatureTask?.cancel()
         playbackFailureTask?.cancel()
+        collectionEpisodeTask?.cancel()
     }
 
     /// 取代当前播放意图；已有非 idle 会话会先停止，避免两个 bridge/server 并存。
@@ -94,6 +114,7 @@ public final class GuestVideoViewModel {
         generation += 1
         let currentGeneration = generation
         loadTask?.cancel()
+        cancelCollectionEpisodeRequest(markWaitersIdle: true)
         cancelUploaderSignature()
         if state != .idle {
             playback.stop()
@@ -109,6 +130,41 @@ public final class GuestVideoViewModel {
                 generation: currentGeneration
             )
         }
+    }
+
+    /// 合集 episode 的展开由 Feature 持有；远端未内嵌 pages 时才按 BVID 请求详情。
+    public func setCollectionEpisodeExpanded(
+        _ episode: VideoCollectionEpisode,
+        expanded: Bool
+    ) {
+        guard collectionContains(episode) else { return }
+        if !expanded {
+            expandedCollectionEpisodes.remove(episode.id)
+            removeCollectionEpisodeWaiter(episode)
+            return
+        }
+
+        expandedCollectionEpisodes.insert(episode.id)
+        resolveOrEnqueueCollectionEpisode(episode)
+    }
+
+    public func retryCollectionEpisodePages(
+        _ episode: VideoCollectionEpisode
+    ) {
+        guard expandedCollectionEpisodes.contains(episode.id),
+            collectionContains(episode),
+            episode.isIdentityConsistent,
+            let bvid = episode.bvid
+        else { return }
+        enqueueCollectionEpisode(episode, bvid: bvid)
+    }
+
+    public func collectionEpisodePages(
+        for identity: VideoCollectionEpisodeIdentity
+    ) -> [VideoPage]? {
+        guard case .loaded(let bvid) = collectionEpisodePageStates[identity]
+        else { return nil }
+        return collectionEpisodeCache[bvid]
     }
 
     /// 在同一 BVID 的现有 pages 内替换 CID，不创建新的导航目的地或播放器 owner。
@@ -174,6 +230,7 @@ public final class GuestVideoViewModel {
         relatedVideoTask = nil
         relatedVideoState = .idle
         cancelUploaderSignature()
+        clearCollectionEpisodeState()
         presentedContext = nil
         requestedPlaybackIdentity = nil
         presentedPlaybackIdentity = nil
@@ -184,6 +241,14 @@ public final class GuestVideoViewModel {
 
     public func waitForCurrentTask() async {
         await loadTask?.value
+    }
+
+    public func waitForCurrentCollectionEpisodeTask() async {
+        await collectionEpisodeTask?.value
+    }
+
+    func collectionEpisodeTaskSnapshotForTesting() -> Task<Void, Never>? {
+        collectionEpisodeTask
     }
 
     func taskSnapshotForTesting() -> Task<Void, Never>? {
@@ -265,6 +330,7 @@ public final class GuestVideoViewModel {
             guard generation == currentGeneration else { return }
 
             presentedContext = context
+            reconcileCollectionContext(context.detail.collection)
             loadUploaderSignature(for: context.detail.owner.id)
             let identity = PlaybackItemIdentity(
                 bvid: context.detail.bvid,
@@ -286,6 +352,7 @@ public final class GuestVideoViewModel {
             state = .ready(context)
         } catch is CancellationError {
             guard generation == currentGeneration else { return }
+            clearCollectionEpisodeState()
             presentedContext = nil
             requestedPlaybackIdentity = nil
             presentedPlaybackIdentity = nil
@@ -337,6 +404,7 @@ public final class GuestVideoViewModel {
             state = .ready(replacement)
         } catch is CancellationError {
             guard generation == currentGeneration else { return }
+            clearCollectionEpisodeState()
             requestedPlaybackIdentity = nil
             presentedPlaybackIdentity = nil
             playbackIntent = nil
@@ -438,4 +506,293 @@ public final class GuestVideoViewModel {
         uploaderSignatureTask = nil
         uploaderSignatureState = .loaded(nil)
     }
+
+    private func resolveOrEnqueueCollectionEpisode(
+        _ episode: VideoCollectionEpisode
+    ) {
+        guard episode.isIdentityConsistent, let bvid = episode.bvid else {
+            collectionEpisodePageStates[episode.id] = .failed(.invalidResponse)
+            return
+        }
+        if let knownPages = episode.knownPages {
+            cacheAndMarkCollectionPages(knownPages, bvid: bvid, requested: episode.id)
+            return
+        }
+        if presentedContext?.detail.bvid == bvid,
+            let pages = presentedContext?.pages,
+            !pages.isEmpty
+        {
+            cacheAndMarkCollectionPages(pages, bvid: bvid, requested: episode.id)
+            return
+        }
+        if collectionEpisodeCache[bvid] != nil {
+            touchCollectionEpisodeCache(bvid)
+            collectionEpisodePageStates[episode.id] = .loaded(bvid: bvid)
+            return
+        }
+        enqueueCollectionEpisode(episode, bvid: bvid)
+    }
+
+    private func enqueueCollectionEpisode(
+        _ episode: VideoCollectionEpisode,
+        bvid: String
+    ) {
+        collectionEpisodeWaitersByBVID[bvid, default: []].insert(episode.id)
+        collectionEpisodePageStates[episode.id] = .loading
+        if activeCollectionEpisodeRequest?.bvid != bvid,
+            !pendingCollectionEpisodeBVIDs.contains(bvid)
+        {
+            pendingCollectionEpisodeBVIDs.append(bvid)
+        }
+        startNextCollectionEpisodeRequestIfNeeded()
+    }
+
+    private func startNextCollectionEpisodeRequestIfNeeded() {
+        guard activeCollectionEpisodeRequest == nil else { return }
+        while !pendingCollectionEpisodeBVIDs.isEmpty {
+            let bvid = pendingCollectionEpisodeBVIDs.removeFirst()
+            guard let waiters = collectionEpisodeWaitersByBVID[bvid],
+                !waiters.isEmpty,
+                let seasonID = collectionSeasonID
+            else { continue }
+            collectionEpisodeRequestGeneration += 1
+            let request = CollectionEpisodePageRequest(
+                seasonID: seasonID,
+                bvid: bvid,
+                generation: collectionEpisodeRequestGeneration
+            )
+            activeCollectionEpisodeRequest = request
+            let useCase = useCase
+            collectionEpisodeTask = Task { [weak self, useCase] in
+                let result: CollectionEpisodePageResult
+                do {
+                    let pages = try await useCase.pagesForCollectionEpisode(
+                        bvid: request.bvid
+                    )
+                    try Task.checkCancellation()
+                    result = .success(pages)
+                } catch is CancellationError {
+                    result = .cancelled
+                } catch let error as GuestApplicationError {
+                    result = Task.isCancelled ? .cancelled : .failure(error)
+                } catch {
+                    result = Task.isCancelled ? .cancelled : .failure(.unavailable)
+                }
+                self?.completeCollectionEpisodeRequest(request, result: result)
+            }
+            return
+        }
+    }
+
+    private func completeCollectionEpisodeRequest(
+        _ request: CollectionEpisodePageRequest,
+        result: CollectionEpisodePageResult
+    ) {
+        guard activeCollectionEpisodeRequest == request,
+            collectionSeasonID == request.seasonID
+        else { return }
+        let waiters = matchingCollectionEpisodeWaiters(for: request.bvid)
+        switch result {
+        case .success(let pages):
+            do {
+                let resolved = try validatedCollectionPages(pages)
+                storeCollectionEpisodeCache(resolved, for: request.bvid)
+                for identity in waiters {
+                    collectionEpisodePageStates[identity] = .loaded(bvid: request.bvid)
+                }
+            } catch let error as GuestApplicationError {
+                for identity in waiters {
+                    collectionEpisodePageStates[identity] = .failed(error)
+                }
+            } catch {
+                for identity in waiters {
+                    collectionEpisodePageStates[identity] = .failed(.invalidResponse)
+                }
+            }
+        case .failure(let error):
+            recordAuthenticationInvalidationIfNeeded(error)
+            for identity in waiters {
+                collectionEpisodePageStates[identity] = .failed(error)
+            }
+        case .cancelled:
+            for identity in waiters
+            where collectionEpisodePageStates[identity] == .loading {
+                collectionEpisodePageStates[identity] = .idle
+            }
+        }
+        collectionEpisodeWaitersByBVID.removeValue(forKey: request.bvid)
+        activeCollectionEpisodeRequest = nil
+        collectionEpisodeTask = nil
+        startNextCollectionEpisodeRequestIfNeeded()
+    }
+
+    private func cacheAndMarkCollectionPages(
+        _ pages: [VideoPage],
+        bvid: String,
+        requested identity: VideoCollectionEpisodeIdentity
+    ) {
+        do {
+            let resolved = try validatedCollectionPages(pages)
+            storeCollectionEpisodeCache(resolved, for: bvid)
+            let matchingExpanded = expandedCollectionEpisodes.filter {
+                collectionEpisode(identity: $0)?.bvid == bvid
+            }
+            for matchingIdentity in matchingExpanded {
+                collectionEpisodePageStates[matchingIdentity] = .loaded(bvid: bvid)
+            }
+            collectionEpisodePageStates[identity] = .loaded(bvid: bvid)
+        } catch let error as GuestApplicationError {
+            collectionEpisodePageStates[identity] = .failed(error)
+        } catch {
+            collectionEpisodePageStates[identity] = .failed(.invalidResponse)
+        }
+    }
+
+    private func validatedCollectionPages(
+        _ pages: [VideoPage]
+    ) throws
+        -> [VideoPage]
+    {
+        guard !pages.isEmpty,
+            Set(pages.map(\.cid)).count == pages.count,
+            Set(pages.map(\.index)).count == pages.count
+        else {
+            throw GuestApplicationError.invalidResponse
+        }
+        return pages.sorted(by: { $0.index < $1.index })
+    }
+
+    private func matchingCollectionEpisodeWaiters(
+        for bvid: String
+    )
+        -> Set<VideoCollectionEpisodeIdentity>
+    {
+        Set(
+            (collectionEpisodeWaitersByBVID[bvid] ?? []).filter { identity in
+                expandedCollectionEpisodes.contains(identity)
+                    && collectionEpisode(identity: identity)?.bvid == bvid
+            }
+        )
+    }
+
+    private func cancelCollectionEpisodeRequest(markWaitersIdle: Bool) {
+        collectionEpisodeRequestGeneration += 1
+        collectionEpisodeTask?.cancel()
+        collectionEpisodeTask = nil
+        if markWaitersIdle {
+            for waiters in collectionEpisodeWaitersByBVID.values {
+                for identity in waiters
+                where collectionEpisodePageStates[identity] == .loading {
+                    collectionEpisodePageStates[identity] = .idle
+                }
+            }
+        }
+        activeCollectionEpisodeRequest = nil
+        collectionEpisodeWaitersByBVID.removeAll()
+        pendingCollectionEpisodeBVIDs.removeAll()
+    }
+
+    private func removeCollectionEpisodeWaiter(
+        _ episode: VideoCollectionEpisode
+    ) {
+        collectionEpisodePageStates[episode.id] = .idle
+        guard let bvid = episode.bvid else { return }
+        collectionEpisodeWaitersByBVID[bvid]?.remove(episode.id)
+        guard collectionEpisodeWaitersByBVID[bvid]?.isEmpty == true else { return }
+        collectionEpisodeWaitersByBVID.removeValue(forKey: bvid)
+        pendingCollectionEpisodeBVIDs.removeAll(where: { $0 == bvid })
+        if activeCollectionEpisodeRequest?.bvid == bvid {
+            collectionEpisodeRequestGeneration += 1
+            activeCollectionEpisodeRequest = nil
+            let cancelledTask = collectionEpisodeTask
+            collectionEpisodeTask = nil
+            cancelledTask?.cancel()
+            startNextCollectionEpisodeRequestIfNeeded()
+        }
+    }
+
+    private func reconcileCollectionContext(_ collection: VideoCollection?) {
+        guard let collection else {
+            clearCollectionEpisodeState()
+            return
+        }
+        if collectionSeasonID != collection.id {
+            clearCollectionEpisodeState()
+            collectionSeasonID = collection.id
+            return
+        }
+        let validIdentities = Set(
+            collection.sections.flatMap(\.episodes).map(\.id)
+        )
+        expandedCollectionEpisodes.formIntersection(validIdentities)
+        collectionEpisodePageStates = collectionEpisodePageStates.filter {
+            validIdentities.contains($0.key)
+        }
+        resumeExpandedCollectionEpisodeLoads()
+    }
+
+    private func resumeExpandedCollectionEpisodeLoads() {
+        let identities = expandedCollectionEpisodes
+        for identity in identities {
+            guard let episode = collectionEpisode(identity: identity) else { continue }
+            resolveOrEnqueueCollectionEpisode(episode)
+        }
+    }
+
+    private func clearCollectionEpisodeState() {
+        cancelCollectionEpisodeRequest(markWaitersIdle: false)
+        expandedCollectionEpisodes.removeAll()
+        collectionEpisodePageStates.removeAll()
+        collectionEpisodeCache.removeAll()
+        collectionEpisodeCacheOrder.removeAll()
+        collectionSeasonID = nil
+    }
+
+    private func collectionContains(_ episode: VideoCollectionEpisode) -> Bool {
+        collectionEpisode(identity: episode.id) == episode
+    }
+
+    private func collectionEpisode(
+        identity: VideoCollectionEpisodeIdentity
+    ) -> VideoCollectionEpisode? {
+        presentedContext?.detail.collection?.sections
+            .flatMap(\.episodes)
+            .first(where: { $0.id == identity })
+    }
+
+    private func storeCollectionEpisodeCache(
+        _ pages: [VideoPage],
+        for bvid: String
+    ) {
+        collectionEpisodeCache[bvid] = pages
+        touchCollectionEpisodeCache(bvid)
+        while collectionEpisodeCacheOrder.count > 12 {
+            let evicted = collectionEpisodeCacheOrder.removeFirst()
+            collectionEpisodeCache.removeValue(forKey: evicted)
+            let evictedIdentities = collectionEpisodePageStates.compactMap { identity, state in
+                state == .loaded(bvid: evicted) ? identity : nil
+            }
+            for identity in evictedIdentities {
+                collectionEpisodePageStates[identity] = .idle
+                expandedCollectionEpisodes.remove(identity)
+            }
+        }
+    }
+
+    private func touchCollectionEpisodeCache(_ bvid: String) {
+        collectionEpisodeCacheOrder.removeAll(where: { $0 == bvid })
+        collectionEpisodeCacheOrder.append(bvid)
+    }
+}
+
+private struct CollectionEpisodePageRequest: Sendable, Equatable {
+    let seasonID: Int64
+    let bvid: String
+    let generation: Int
+}
+
+private enum CollectionEpisodePageResult: Sendable {
+    case success([VideoPage])
+    case failure(GuestApplicationError)
+    case cancelled
 }

--- a/Packages/BiliKitCore/Tests/BiliApplicationTests/GuestVideoUseCaseTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliApplicationTests/GuestVideoUseCaseTests.swift
@@ -19,6 +19,30 @@ struct GuestVideoUseCaseTests {
     }
 
     @Test
+    func usesPagesEmbeddedInDetailWithoutPagelistRequest() async throws {
+        let repository = GuestRepositoryStub(detailHasPages: true)
+        let useCase = GuestVideoUseCase(repository: repository)
+
+        let context = try await useCase.prepareVideo(bvid: "BV1FixtureA1")
+
+        #expect(context.pages.map(\.cid) == [900_001, 900_002])
+        #expect(await repository.pageRequestCount() == 0)
+    }
+
+    @Test
+    func collectionEpisodePagesUseDetailBeforePagelistFallback() async throws {
+        let repository = GuestRepositoryStub(detailHasPages: true)
+        let useCase = GuestVideoUseCase(repository: repository)
+
+        let pages = try await useCase.pagesForCollectionEpisode(
+            bvid: "BV1FixtureA1"
+        )
+
+        #expect(pages.map(\.cid) == [900_001, 900_002])
+        #expect(await repository.pageRequestCount() == 0)
+    }
+
+    @Test
     func rejectsVideoWithoutPagesBeforeRequestingPlayback() async {
         let repository = GuestRepositoryStub(hasPages: false)
         let useCase = GuestVideoUseCase(repository: repository)
@@ -57,14 +81,112 @@ struct GuestVideoUseCaseTests {
         }
         #expect(await repository.playbackCIDs() == [900_001])
     }
+
+    @Test
+    func cancellationDuringPagelistFallbackPreventsPlayback() async throws {
+        let repository = FallbackCancellationRepository()
+        let useCase = GuestVideoUseCase(repository: repository)
+        let task = Task {
+            try await useCase.prepareVideo(bvid: "BV1FixtureA1")
+        }
+
+        await repository.waitForPagesRequest()
+        task.cancel()
+        await repository.releasePages()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(await repository.playbackRequestCount() == 0)
+    }
+}
+
+private actor FallbackCancellationRepository: GuestContentRepository {
+    private var pagesStarted = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+    private var playbackRequests = 0
+
+    func popular(page: Int, pageSize: Int) async throws -> PopularPage {
+        PopularPage(videos: [], pageNumber: page, pageSize: pageSize)
+    }
+
+    func searchVideos(keyword: String, page: Int) async throws -> SearchPage {
+        SearchPage(
+            videos: [],
+            pageNumber: page,
+            pageSize: 20,
+            totalResults: 0,
+            totalPages: 0
+        )
+    }
+
+    func videoDetail(for bvid: String) async throws -> VideoDetail {
+        VideoDetail(
+            bvid: bvid,
+            title: "详情",
+            summary: "说明",
+            coverURL: nil,
+            owner: VideoOwner(id: 1, name: "作者"),
+            statistics: VideoStatistics(viewCount: 1, danmakuCount: 1, likeCount: 1),
+            durationSeconds: 10,
+            publishedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+
+    func pages(for bvid: String) async throws -> [VideoPage] {
+        pagesStarted = true
+        let waiters = startWaiters
+        startWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+        await withCheckedContinuation { continuation in
+            releaseWaiters.append(continuation)
+        }
+        return [VideoPage(cid: 900_001, index: 1, title: "P1", durationSeconds: 10)]
+    }
+
+    func playback(for bvid: String, cid: Int64) async throws -> VideoPlayback {
+        playbackRequests += 1
+        return VideoPlayback(
+            manifest: PlaybackManifest(
+                videoRepresentations: [],
+                originalAudioRepresentations: []
+            ),
+            mediaHeaders: [:]
+        )
+    }
+
+    func waitForPagesRequest() async {
+        guard !pagesStarted else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func releasePages() {
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    func playbackRequestCount() -> Int {
+        playbackRequests
+    }
 }
 
 private actor GuestRepositoryStub: GuestContentRepository {
     private let hasPages: Bool
+    private let detailHasPages: Bool
     private var observedPlaybackCIDs: [Int64] = []
+    private var observedPageRequestCount = 0
 
-    init(hasPages: Bool = true) {
+    init(hasPages: Bool = true, detailHasPages: Bool = false) {
         self.hasPages = hasPages
+        self.detailHasPages = detailHasPages
     }
 
     func popular(page: Int, pageSize: Int) async throws -> PopularPage {
@@ -86,8 +208,17 @@ private actor GuestRepositoryStub: GuestContentRepository {
     }
 
     func pages(for bvid: String) async throws -> [VideoPage] {
+        observedPageRequestCount += 1
         guard hasPages else { return [] }
-        return [
+        return fixturePages
+    }
+
+    func pageRequestCount() -> Int {
+        observedPageRequestCount
+    }
+
+    private var fixturePages: [VideoPage] {
+        [
             VideoPage(
                 cid: 900_002,
                 index: 2,
@@ -128,7 +259,8 @@ private actor GuestRepositoryStub: GuestContentRepository {
                 likeCount: 20
             ),
             durationSeconds: 360,
-            publishedAt: Date(timeIntervalSince1970: 1_720_000_000)
+            publishedAt: Date(timeIntervalSince1970: 1_720_000_000),
+            pages: detailHasPages ? fixturePages : []
         )
     }
 

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
@@ -712,7 +712,8 @@ struct GuestBrowseAndVideoViewModelTests {
         )
 
         model.loadVideo(slow.detail.bvid)
-        try await repository.waitForSlowRequestCount(2)
+        // `/view` 先返回后才决定是否需要 pagelist，因此旧请求此时只有 detail 在飞行。
+        try await repository.waitForSlowRequestCount(1)
         let supersededTask = try #require(model.taskSnapshotForTesting())
         model.loadVideo(fast.detail.bvid)
         await model.waitForCurrentTask()
@@ -1225,6 +1226,664 @@ struct GuestBrowseAndVideoViewModelTests {
         #expect(model.state == .idle)
         #expect(model.presentedContext == nil)
         #expect(model.uploaderSignatureState == .loaded(nil))
+    }
+
+    @Test
+    @MainActor
+    func embeddedCollectionPagesLoadWithoutAnotherDetailRequest() async throws {
+        let fixtures = CollectionFixtures()
+        let repository = CollectionEpisodeRepositoryStub(fixtures: fixtures)
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: RecordingPlayerEngine()
+        )
+
+        model.loadVideo(fixtures.rootBVID)
+        await model.waitForCurrentTask()
+        model.setCollectionEpisodeExpanded(
+            fixtures.embeddedEpisode,
+            expanded: true
+        )
+
+        #expect(
+            model.collectionEpisodePageStates[fixtures.embeddedEpisode.id]
+                == .loaded(bvid: fixtures.rootBVID)
+        )
+        #expect(
+            model.collectionEpisodePages(for: fixtures.embeddedEpisode.id) == fixtures.rootPages
+        )
+        #expect(await repository.episodeDetailRequestCount() == 0)
+    }
+
+    @Test
+    @MainActor
+    func duplicateBVIDEpisodeExpansionsShareOneDetailRequest() async throws {
+        let fixtures = CollectionFixtures()
+        let repository = CollectionEpisodeRepositoryStub(
+            fixtures: fixtures,
+            blocksEpisodeDetail: true
+        )
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: RecordingPlayerEngine()
+        )
+
+        model.loadVideo(fixtures.rootBVID)
+        await model.waitForCurrentTask()
+        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        model.setCollectionEpisodeExpanded(
+            fixtures.duplicateLazyEpisode,
+            expanded: true
+        )
+        await repository.waitForEpisodeDetailRequest()
+        await repository.releaseEpisodeDetail()
+        await model.waitForCurrentCollectionEpisodeTask()
+
+        #expect(await repository.episodeDetailRequestCount() == 1)
+        #expect(
+            model.collectionEpisodePageStates[fixtures.lazyEpisode.id]
+                == .loaded(bvid: fixtures.episodeBVID)
+        )
+        #expect(
+            model.collectionEpisodePageStates[fixtures.duplicateLazyEpisode.id]
+                == .loaded(bvid: fixtures.episodeBVID)
+        )
+    }
+
+    @Test
+    @MainActor
+    func collapsingOneDuplicateWaiterKeepsTheSharedRequestAlive() async throws {
+        let fixtures = CollectionFixtures()
+        let repository = CollectionEpisodeRepositoryStub(
+            fixtures: fixtures,
+            blocksEpisodeDetail: true
+        )
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: RecordingPlayerEngine()
+        )
+
+        model.loadVideo(fixtures.rootBVID)
+        await model.waitForCurrentTask()
+        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        model.setCollectionEpisodeExpanded(
+            fixtures.duplicateLazyEpisode,
+            expanded: true
+        )
+        await repository.waitForEpisodeDetailRequest()
+        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: false)
+        await repository.releaseEpisodeDetail()
+        await model.waitForCurrentCollectionEpisodeTask()
+
+        #expect(await repository.episodeDetailRequestCount() == 1)
+        #expect(
+            model.collectionEpisodePageStates[fixtures.lazyEpisode.id]
+                == .idle
+        )
+        #expect(
+            model.collectionEpisodePageStates[fixtures.duplicateLazyEpisode.id]
+                == .loaded(bvid: fixtures.episodeBVID)
+        )
+    }
+
+    @Test
+    @MainActor
+    func collapsingAndImmediatelyReexpandingStartsANewGeneration() async throws {
+        let fixtures = CollectionFixtures()
+        let repository = CollectionEpisodeRepositoryStub(
+            fixtures: fixtures,
+            blocksEpisodeDetail: true
+        )
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: RecordingPlayerEngine()
+        )
+
+        model.loadVideo(fixtures.rootBVID)
+        await model.waitForCurrentTask()
+        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        await repository.waitForEpisodeDetailRequest(count: 1)
+        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: false)
+        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        await repository.waitForEpisodeDetailRequest(count: 2)
+        await repository.releaseEpisodeDetail()
+        await model.waitForCurrentCollectionEpisodeTask()
+
+        #expect(await repository.episodeDetailRequestCount() == 2)
+        #expect(model.expandedCollectionEpisodes.contains(fixtures.lazyEpisode.id))
+        #expect(
+            model.collectionEpisodePageStates[fixtures.lazyEpisode.id]
+                == .loaded(bvid: fixtures.episodeBVID)
+        )
+    }
+
+    @Test
+    @MainActor
+    func cancelledEpisodeFailureDoesNotRevalidateAuthentication() async throws {
+        let fixtures = CollectionFixtures()
+        let repository = CollectionEpisodeRepositoryStub(
+            fixtures: fixtures,
+            blocksEpisodeDetail: true,
+            episodeFailureAfterRelease: .authenticationInvalid
+        )
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: RecordingPlayerEngine()
+        )
+
+        model.loadVideo(fixtures.rootBVID)
+        await model.waitForCurrentTask()
+        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        await repository.waitForEpisodeDetailRequest()
+        let cancelledTask = try #require(
+            model.collectionEpisodeTaskSnapshotForTesting()
+        )
+        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: false)
+        await repository.releaseEpisodeDetail()
+        await cancelledTask.value
+
+        #expect(model.authenticationRevalidationGeneration == 0)
+        #expect(model.collectionEpisodePageStates[fixtures.lazyEpisode.id] == .idle)
+    }
+
+    @Test
+    @MainActor
+    func episodeFailureIsLocalAndRetryCanRecover() async throws {
+        let fixtures = CollectionFixtures()
+        let repository = CollectionEpisodeRepositoryStub(
+            fixtures: fixtures,
+            failsFirstEpisodeDetail: true
+        )
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: RecordingPlayerEngine()
+        )
+
+        model.loadVideo(fixtures.rootBVID)
+        await model.waitForCurrentTask()
+        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        await model.waitForCurrentCollectionEpisodeTask()
+
+        #expect(
+            model.collectionEpisodePageStates[fixtures.lazyEpisode.id]
+                == .failed(.transportFailure)
+        )
+        #expect(model.presentedContext?.detail.bvid == fixtures.rootBVID)
+
+        model.retryCollectionEpisodePages(fixtures.lazyEpisode)
+        await model.waitForCurrentCollectionEpisodeTask()
+
+        #expect(
+            model.collectionEpisodePageStates[fixtures.lazyEpisode.id]
+                == .loaded(bvid: fixtures.episodeBVID)
+        )
+        #expect(await repository.episodeDetailRequestCount() == 2)
+    }
+
+    @Test
+    @MainActor
+    func resetRejectsLateCollectionEpisodePages() async throws {
+        let fixtures = CollectionFixtures()
+        let repository = CollectionEpisodeRepositoryStub(
+            fixtures: fixtures,
+            blocksEpisodeDetail: true
+        )
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: RecordingPlayerEngine()
+        )
+
+        model.loadVideo(fixtures.rootBVID)
+        await model.waitForCurrentTask()
+        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        await repository.waitForEpisodeDetailRequest()
+        let lateTask = try #require(
+            model.collectionEpisodeTaskSnapshotForTesting()
+        )
+
+        model.reset()
+        await repository.releaseEpisodeDetail()
+        await lateTask.value
+
+        #expect(model.expandedCollectionEpisodes.isEmpty)
+        #expect(model.collectionEpisodePageStates.isEmpty)
+        #expect(model.presentedContext == nil)
+    }
+
+    @Test
+    @MainActor
+    func differentBVIDExpansionsRunSeriallyWithoutLeavingIdleExpandedItem() async throws {
+        let fixtures = CollectionFixtures()
+        let repository = CollectionEpisodeRepositoryStub(
+            fixtures: fixtures,
+            blocksEpisodeDetail: true
+        )
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: RecordingPlayerEngine()
+        )
+
+        model.loadVideo(fixtures.rootBVID)
+        await model.waitForCurrentTask()
+        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        await repository.waitForEpisodeDetailRequest(count: 1)
+        model.setCollectionEpisodeExpanded(fixtures.thirdLazyEpisode, expanded: true)
+
+        #expect(await repository.episodeDetailRequestCount() == 1)
+        #expect(model.collectionEpisodePageStates[fixtures.lazyEpisode.id] == .loading)
+        #expect(model.collectionEpisodePageStates[fixtures.thirdLazyEpisode.id] == .loading)
+
+        await repository.releaseEpisodeDetail()
+        await repository.waitForEpisodeDetailRequest(count: 2)
+        await repository.releaseEpisodeDetail()
+        await model.waitForCurrentCollectionEpisodeTask()
+
+        #expect(await repository.episodeDetailRequestCount() == 2)
+        #expect(
+            model.collectionEpisodePageStates[fixtures.lazyEpisode.id]
+                == .loaded(bvid: fixtures.episodeBVID)
+        )
+        #expect(
+            model.collectionEpisodePageStates[fixtures.thirdLazyEpisode.id]
+                == .loaded(bvid: fixtures.thirdBVID)
+        )
+    }
+
+    @Test
+    @MainActor
+    func currentAndEmbeddedPagesPopulateBVIDCacheWithoutRemoteDetail() async {
+        let fixtures = CollectionFixtures()
+        let repository = CollectionEpisodeRepositoryStub(fixtures: fixtures)
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: RecordingPlayerEngine()
+        )
+
+        model.loadVideo(fixtures.rootBVID)
+        await model.waitForCurrentTask()
+        model.setCollectionEpisodeExpanded(fixtures.rootSummaryEpisode, expanded: true)
+        model.setCollectionEpisodeExpanded(fixtures.embeddedRemoteEpisode, expanded: true)
+        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+
+        #expect(await repository.episodeDetailRequestCount() == 0)
+        #expect(
+            model.collectionEpisodePages(for: fixtures.rootSummaryEpisode.id)
+                == fixtures.rootPages
+        )
+        #expect(
+            model.collectionEpisodePages(for: fixtures.lazyEpisode.id)
+                == fixtures.episodePages
+        )
+    }
+
+    @Test
+    @MainActor
+    func episodePageCacheEvictsAndReleasesTheThirteenthBVID() async {
+        let fixtures = BoundedCollectionCacheFixtures()
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(
+                repository: StaticCollectionRepositoryStub(fixtures: fixtures)
+            ),
+            playback: RecordingPlayerEngine()
+        )
+
+        model.loadVideo(fixtures.rootBVID)
+        await model.waitForCurrentTask()
+        for episode in fixtures.episodes {
+            model.setCollectionEpisodeExpanded(episode, expanded: true)
+        }
+
+        let first = fixtures.episodes[0]
+        let last = fixtures.episodes[12]
+        #expect(!model.expandedCollectionEpisodes.contains(first.id))
+        #expect(model.collectionEpisodePageStates[first.id] == .idle)
+        #expect(model.collectionEpisodePages(for: first.id) == nil)
+        #expect(model.collectionEpisodePageStates[last.id] == .loaded(bvid: last.bvid!))
+        #expect(model.collectionEpisodePages(for: last.id) == last.knownPages)
+    }
+}
+
+private struct BoundedCollectionCacheFixtures: Sendable {
+    let rootBVID = "BV1CacheRoot"
+
+    var episodes: [VideoCollectionEpisode] {
+        (1...13).map { value in
+            let bvid = String(format: "BV1Cache%04d", value)
+            let page = VideoPage(
+                cid: Int64(930_000 + value),
+                index: 1,
+                title: "P1",
+                durationSeconds: 10
+            )
+            return VideoCollectionEpisode(
+                id: VideoCollectionEpisodeIdentity(
+                    seasonID: 801,
+                    sectionID: 802,
+                    episodeID: Int64(8_100 + value)
+                ),
+                ordinal: value - 1,
+                aid: Int64(9_100 + value),
+                bvid: bvid,
+                title: "缓存视频 \(value)",
+                coverURL: nil,
+                durationSeconds: 10,
+                defaultCID: page.cid,
+                knownPages: [page]
+            )
+        }
+    }
+
+    var detail: VideoDetail {
+        let rootPage = VideoPage(
+            cid: 939_999,
+            index: 1,
+            title: "当前 P1",
+            durationSeconds: 10
+        )
+        return VideoDetail(
+            bvid: rootBVID,
+            title: "缓存边界",
+            summary: "脱敏详情",
+            coverURL: nil,
+            owner: VideoOwner(id: 10_001, name: "测试 UP 主"),
+            statistics: VideoStatistics(viewCount: 1, danmakuCount: 1, likeCount: 1),
+            durationSeconds: 10,
+            publishedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            pages: [rootPage],
+            collection: VideoCollection(
+                id: 801,
+                title: "缓存合集",
+                reportedEpisodeCount: 13,
+                sections: [
+                    VideoCollectionSection(
+                        id: VideoCollectionSectionIdentity(
+                            seasonID: 801,
+                            sectionID: 802
+                        ),
+                        ordinal: 0,
+                        title: "分部",
+                        episodes: episodes
+                    )
+                ]
+            )
+        )
+    }
+
+    var playback: VideoPlayback {
+        VideoPlayback(
+            manifest: PlaybackManifest(
+                videoRepresentations: [],
+                originalAudioRepresentations: []
+            ),
+            mediaHeaders: [:]
+        )
+    }
+}
+
+private actor StaticCollectionRepositoryStub: GuestContentRepository {
+    let fixtures: BoundedCollectionCacheFixtures
+
+    init(fixtures: BoundedCollectionCacheFixtures) {
+        self.fixtures = fixtures
+    }
+
+    func popular(page: Int, pageSize: Int) async throws -> PopularPage {
+        PopularPage(videos: [], pageNumber: page, pageSize: pageSize)
+    }
+
+    func searchVideos(keyword: String, page: Int) async throws -> SearchPage {
+        SearchPage(
+            videos: [],
+            pageNumber: page,
+            pageSize: 20,
+            totalResults: 0,
+            totalPages: 0
+        )
+    }
+
+    func videoDetail(for bvid: String) async throws -> VideoDetail {
+        fixtures.detail
+    }
+
+    func pages(for bvid: String) async throws -> [VideoPage] {
+        fixtures.detail.pages
+    }
+
+    func playback(for bvid: String, cid: Int64) async throws -> VideoPlayback {
+        fixtures.playback
+    }
+}
+
+private struct CollectionFixtures: Sendable {
+    let rootBVID = "BV1FixtureA1"
+    let episodeBVID = "BV1FixtureB2"
+    let thirdBVID = "BV1FixtureC3"
+    let rootPages = [
+        VideoPage(cid: 900_001, index: 1, title: "当前 P1", durationSeconds: 120),
+        VideoPage(cid: 900_002, index: 2, title: "当前 P2", durationSeconds: 180),
+    ]
+    let episodePages = [
+        VideoPage(cid: 910_001, index: 1, title: "下一 P1", durationSeconds: 90),
+        VideoPage(cid: 910_002, index: 2, title: "下一 P2", durationSeconds: 110),
+    ]
+    let thirdPages = [
+        VideoPage(cid: 920_001, index: 1, title: "第三 P1", durationSeconds: 80)
+    ]
+
+    var embeddedEpisode: VideoCollectionEpisode {
+        episode(
+            episodeID: 701,
+            ordinal: 0,
+            bvid: rootBVID,
+            pages: rootPages
+        )
+    }
+
+    var lazyEpisode: VideoCollectionEpisode {
+        episode(
+            episodeID: 702,
+            ordinal: 1,
+            bvid: episodeBVID,
+            pages: nil
+        )
+    }
+
+    var duplicateLazyEpisode: VideoCollectionEpisode {
+        episode(
+            episodeID: 703,
+            ordinal: 2,
+            bvid: episodeBVID,
+            pages: nil
+        )
+    }
+
+    var thirdLazyEpisode: VideoCollectionEpisode {
+        episode(episodeID: 704, ordinal: 3, bvid: thirdBVID, pages: nil)
+    }
+
+    var rootSummaryEpisode: VideoCollectionEpisode {
+        episode(episodeID: 705, ordinal: 4, bvid: rootBVID, pages: nil)
+    }
+
+    var embeddedRemoteEpisode: VideoCollectionEpisode {
+        episode(episodeID: 706, ordinal: 5, bvid: episodeBVID, pages: episodePages)
+    }
+
+    var rootDetail: VideoDetail {
+        detail(
+            bvid: rootBVID,
+            pages: rootPages,
+            collection: VideoCollection(
+                id: 501,
+                title: "测试合集",
+                reportedEpisodeCount: 6,
+                sections: [
+                    VideoCollectionSection(
+                        id: VideoCollectionSectionIdentity(
+                            seasonID: 501,
+                            sectionID: 601
+                        ),
+                        ordinal: 0,
+                        title: "第一章",
+                        episodes: [
+                            embeddedEpisode,
+                            lazyEpisode,
+                            duplicateLazyEpisode,
+                            thirdLazyEpisode,
+                            rootSummaryEpisode,
+                            embeddedRemoteEpisode,
+                        ]
+                    )
+                ]
+            )
+        )
+    }
+
+    var episodeDetail: VideoDetail {
+        detail(bvid: episodeBVID, pages: episodePages, collection: nil)
+    }
+
+    var thirdDetail: VideoDetail {
+        detail(bvid: thirdBVID, pages: thirdPages, collection: nil)
+    }
+
+    var playback: VideoPlayback {
+        VideoPlayback(
+            manifest: PlaybackManifest(
+                videoRepresentations: [],
+                originalAudioRepresentations: []
+            ),
+            mediaHeaders: [:]
+        )
+    }
+
+    private func episode(
+        episodeID: Int64,
+        ordinal: Int,
+        bvid: String,
+        pages: [VideoPage]?
+    ) -> VideoCollectionEpisode {
+        VideoCollectionEpisode(
+            id: VideoCollectionEpisodeIdentity(
+                seasonID: 501,
+                sectionID: 601,
+                episodeID: episodeID
+            ),
+            ordinal: ordinal,
+            aid: episodeID + 6_000,
+            bvid: bvid,
+            title: "合集视频 \(ordinal + 1)",
+            coverURL: nil,
+            durationSeconds: pages?.reduce(0) { $0 + $1.durationSeconds },
+            defaultCID: pages?.first?.cid,
+            knownPages: pages
+        )
+    }
+
+    private func detail(
+        bvid: String,
+        pages: [VideoPage],
+        collection: VideoCollection?
+    ) -> VideoDetail {
+        VideoDetail(
+            bvid: bvid,
+            title: "详情 \(bvid)",
+            summary: "脱敏详情",
+            coverURL: nil,
+            owner: VideoOwner(id: 10_001, name: "测试 UP 主"),
+            statistics: VideoStatistics(
+                viewCount: 10,
+                danmakuCount: 2,
+                likeCount: 3
+            ),
+            durationSeconds: pages.reduce(0) { $0 + $1.durationSeconds },
+            publishedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            pages: pages,
+            collection: collection
+        )
+    }
+}
+
+private actor CollectionEpisodeRepositoryStub: GuestContentRepository {
+    let fixtures: CollectionFixtures
+    let blocksEpisodeDetail: Bool
+    let episodeFailureAfterRelease: GuestApplicationError?
+    var failsFirstEpisodeDetail: Bool
+    private var episodeRequests = 0
+    private let episodeRequestEvents = TestEventCounter()
+    private var episodeReleaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(
+        fixtures: CollectionFixtures,
+        blocksEpisodeDetail: Bool = false,
+        failsFirstEpisodeDetail: Bool = false,
+        episodeFailureAfterRelease: GuestApplicationError? = nil
+    ) {
+        self.fixtures = fixtures
+        self.blocksEpisodeDetail = blocksEpisodeDetail
+        self.failsFirstEpisodeDetail = failsFirstEpisodeDetail
+        self.episodeFailureAfterRelease = episodeFailureAfterRelease
+    }
+
+    func popular(page: Int, pageSize: Int) async throws -> PopularPage {
+        PopularPage(videos: [], pageNumber: page, pageSize: pageSize)
+    }
+
+    func searchVideos(keyword: String, page: Int) async throws -> SearchPage {
+        SearchPage(
+            videos: [],
+            pageNumber: page,
+            pageSize: 20,
+            totalResults: 0,
+            totalPages: 0
+        )
+    }
+
+    func videoDetail(for bvid: String) async throws -> VideoDetail {
+        guard bvid != fixtures.rootBVID else {
+            return fixtures.rootDetail
+        }
+        episodeRequests += 1
+        await episodeRequestEvents.signal()
+        if failsFirstEpisodeDetail {
+            failsFirstEpisodeDetail = false
+            throw GuestApplicationError.transportFailure
+        }
+        if blocksEpisodeDetail {
+            await withCheckedContinuation { continuation in
+                episodeReleaseWaiters.append(continuation)
+            }
+        }
+        if let episodeFailureAfterRelease {
+            throw episodeFailureAfterRelease
+        }
+        return bvid == fixtures.episodeBVID
+            ? fixtures.episodeDetail
+            : fixtures.thirdDetail
+    }
+
+    func pages(for bvid: String) async throws -> [VideoPage] {
+        bvid == fixtures.rootBVID ? fixtures.rootPages : fixtures.episodePages
+    }
+
+    func playback(for bvid: String, cid: Int64) async throws -> VideoPlayback {
+        fixtures.playback
+    }
+
+    func episodeDetailRequestCount() -> Int {
+        episodeRequests
+    }
+
+    func waitForEpisodeDetailRequest(count: Int = 1) async {
+        try? await episodeRequestEvents.wait(until: count)
+    }
+
+    func releaseEpisodeDetail() {
+        let waiters = episodeReleaseWaiters
+        episodeReleaseWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 }
 


### PR DESCRIPTION
## 依赖

这是堆叠 PR，base 为 `codex/ugc-collection-domain`（PR #67）。PR #67 合并后，本 PR 应改回 `main`。

## 变化

- 当前详情优先使用 `/view` 内嵌 pages，缺失时才回退 pagelist
- 为合集 episode 提供按 BVID lazy pages 加载
- Feature/ViewModel 持有展开、loading/error/retry、waiter、generation 与取消状态
- 不同 BVID 串行 one-in-flight；相同 BVID occurrence 合并请求
- 复用当前视频和内嵌 episode pages，避免重复详情请求
- 使用 12 项内存 LRU，淘汰时释放 pages 并同步修正展开状态
- 拒绝迟到结果、重复 CID/page、BVID mismatch 和已取消认证错误

## 原因与用户影响

为后续合集 UI 展开 episode 分 P 提供明确异步 owner。单个 episode 加载失败不会清空当前视频或其他合集项，快速展开、折叠、Back 和 reset 也不会让旧结果覆盖新状态。

## 验证

- 三路 agent 修复后重审：无 P0–P2
- 覆盖 same/different BVID、one-in-flight、dedup、retry、cancel、stale、LRU、fallback 与慢 pagelist cancellation
- 完整 App Gate：436 tests / 46 suites、app build-for-testing、app tests 通过
- `git diff --check` 通过

## 未包含

- 不包含具体 Disclosure/List UI
- UI 不直接调用播放器；后续仍交给现有 navigation/playback owner
- 不实现自动下一集、磁盘持久化或无界预取
