### PR TITLE
feat(playback): 支持详情自动开播与断点续播

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
           - macos-26
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
 
     steps:
       - name: Check out repository

--- a/BiliKitMac/App/AppSourceRootViews.swift
+++ b/BiliKitMac/App/AppSourceRootViews.swift
@@ -89,11 +89,7 @@ struct SearchTabRoot: View {
     }
 
     private var searchFieldPlacement: SearchFieldPlacement {
-        #if compiler(>=6.2)
-            .toolbarPrincipal
-        #else
-            .toolbar
-        #endif
+        .toolbarPrincipal
     }
 }
 

--- a/BiliKitMac/App/AppWindowOwner.swift
+++ b/BiliKitMac/App/AppWindowOwner.swift
@@ -42,7 +42,7 @@ final class AppWindowOwner {
             danmakuModel: danmakuModel,
             authenticationModel: environment.makeAuthenticationViewModel(),
             historyModel: environment.makeWatchHistoryViewModel(),
-            playerContent: environment.makePlayerView(),
+            playerContent: environment.makePlayerView(videoModel: videoModel),
             playbackPreferencesController: environment.playbackPreferencesController,
             openEnvironment: environment.open,
             closeEnvironment: environment.close

--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -161,12 +161,13 @@ struct AppEnvironment {
         )
     }
 
-    func makePlayerView() -> AnyView {
+    func makePlayerView(videoModel: GuestVideoViewModel) -> AnyView {
         AnyView(
             PlayerHostView(
                 player: playerEngine.player,
                 danmakuRenderer: danmakuRenderer,
                 danmakuController: danmakuController,
+                videoModel: videoModel,
                 beginMomentaryPlaybackRate: { [playerEngine] rate in
                     try? playerEngine.beginMomentaryPlaybackRate(Double(rate))
                 },

--- a/BiliKitMac/Platform/PlayerHostView.swift
+++ b/BiliKitMac/Platform/PlayerHostView.swift
@@ -1,5 +1,8 @@
 import AVKit
+import BiliApplication
+import BiliBrowseFeature
 import BiliDanmaku
+import BiliUI
 import SwiftUI
 
 /// 把唯一 `AVPlayer` 宿主与弹幕 overlay 组合为稳定的播放 surface。
@@ -10,6 +13,7 @@ struct PlayerHostView: View {
     let player: AVPlayer
     let danmakuRenderer: CoreAnimationDanmakuRenderer
     let danmakuController: DanmakuPresentationController
+    let videoModel: GuestVideoViewModel?
     let beginMomentaryPlaybackRate: ((Float) -> UUID?)?
     let endMomentaryPlaybackRate: ((UUID) -> Void)?
 
@@ -17,12 +21,14 @@ struct PlayerHostView: View {
         player: AVPlayer,
         danmakuRenderer: CoreAnimationDanmakuRenderer,
         danmakuController: DanmakuPresentationController,
+        videoModel: GuestVideoViewModel? = nil,
         beginMomentaryPlaybackRate: ((Float) -> UUID?)? = nil,
         endMomentaryPlaybackRate: ((UUID) -> Void)? = nil
     ) {
         self.player = player
         self.danmakuRenderer = danmakuRenderer
         self.danmakuController = danmakuController
+        self.videoModel = videoModel
         self.beginMomentaryPlaybackRate = beginMomentaryPlaybackRate
         self.endMomentaryPlaybackRate = endMomentaryPlaybackRate
     }
@@ -32,9 +38,22 @@ struct PlayerHostView: View {
             player: player,
             renderer: danmakuRenderer,
             controller: danmakuController,
+            blocksNativePlaybackInteraction: blocksNativePlaybackInteraction,
+            resumeNotice: videoModel?.resumeNotice,
+            restartFromBeginning: { videoModel?.restartFromBeginning() },
             beginMomentaryPlaybackRate: beginMomentaryPlaybackRate,
             endMomentaryPlaybackRate: endMomentaryPlaybackRate
         )
+    }
+
+    private var blocksNativePlaybackInteraction: Bool {
+        guard let videoModel else { return false }
+        return switch videoModel.state {
+        case .loading, .loadingPage, .preparingPlayback:
+            true
+        case .idle, .ready, .failed, .failedPage:
+            false
+        }
     }
 }
 
@@ -42,6 +61,9 @@ private struct AVPlayerContainerView: NSViewRepresentable {
     let player: AVPlayer
     let renderer: CoreAnimationDanmakuRenderer
     let controller: DanmakuPresentationController
+    let blocksNativePlaybackInteraction: Bool
+    let resumeNotice: PlaybackResumeNotice?
+    let restartFromBeginning: () -> Void
     let beginMomentaryPlaybackRate: ((Float) -> UUID?)?
     let endMomentaryPlaybackRate: ((UUID) -> Void)?
 
@@ -54,17 +76,26 @@ private struct AVPlayerContainerView: NSViewRepresentable {
         )
         view.player = player
         view.startObservingPlayerItemChanges()
-        view.controlsStyle = .default
+        view.setPlaybackPreparationBlocked(blocksNativePlaybackInteraction)
         view.showsFullScreenToggleButton = true
         view.allowsPictureInPicturePlayback = true
         view.installWindowScrollWheelShield()
+        view.setResumeNotice(
+            resumeNotice,
+            restartFromBeginning: restartFromBeginning
+        )
         return view
     }
 
     func updateNSView(_ view: DanmakuPlayerView, context: Context) {
         view.installWindowScrollWheelShield()
+        view.setPlaybackPreparationBlocked(blocksNativePlaybackInteraction)
         view.requestMomentaryPlaybackRate = beginMomentaryPlaybackRate
         view.finishMomentaryPlaybackRate = endMomentaryPlaybackRate
+        view.setResumeNotice(
+            resumeNotice,
+            restartFromBeginning: restartFromBeginning
+        )
         if view.player !== player {
             view.cancelMomentaryPlaybackRate()
             view.player = player
@@ -77,6 +108,7 @@ private struct AVPlayerContainerView: NSViewRepresentable {
         _ view: DanmakuPlayerView,
         coordinator: ()
     ) {
+        view.setResumeNotice(nil, restartFromBeginning: {})
         view.danmakuOverlay.detachSurface()
         view.stopObservingFocusLoss()
         view.stopObservingPlayerItemChanges()
@@ -132,13 +164,13 @@ private struct PlayerMomentaryRateBadge: View {
         .font(.title3.weight(.semibold))
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
-        .modifier(PlayerMomentaryRateBadgeBackground())
+        .modifier(PlayerGlassCapsuleBackground())
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(rate.accessibilityLabel)
     }
 }
 
-private struct PlayerMomentaryRateBadgeBackground: ViewModifier {
+private struct PlayerGlassCapsuleBackground: ViewModifier {
     @ViewBuilder
     func body(content: Content) -> some View {
         #if compiler(>=6.2)
@@ -162,6 +194,76 @@ private struct PlayerMomentaryRateBadgeBackground: ViewModifier {
     }
 }
 
+struct PlayerResumeNoticeLayout {
+    static let leadingInset: CGFloat = 20
+    static let bottomInset: CGFloat = 64
+}
+
+enum PlayerResumeNoticePresentation {
+    static let title = "从头播放"
+}
+
+enum PlayerResumeNoticeDismissalPolicy {
+    static let delay: Duration = .seconds(5)
+    static let fadeDurationSeconds: TimeInterval = 0.2
+
+    static func shouldDismiss(
+        displayedToken: PlaybackResumeToken?,
+        scheduledToken: PlaybackResumeToken
+    ) -> Bool {
+        displayedToken == scheduledToken
+    }
+}
+
+enum PlayerPlaybackPreparationPolicy {
+    static func controlsStyle(
+        blocksNativePlaybackInteraction: Bool
+    ) -> AVPlayerViewControlsStyle {
+        blocksNativePlaybackInteraction ? .none : .default
+    }
+}
+
+private struct PlayerResumeButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Label(
+                PlayerResumeNoticePresentation.title,
+                systemImage: "arrow.uturn.backward"
+            )
+            .fontWeight(.semibold)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+        }
+        .modifier(PlayerResumeButtonStyle())
+        .accessibilityLabel(PlayerResumeNoticePresentation.title)
+        .accessibilityHint("将当前视频定位到开头并继续播放")
+    }
+}
+
+private struct PlayerResumeButtonStyle: ViewModifier {
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        #if compiler(>=6.2)
+            if #available(macOS 26.0, *) {
+                content.buttonStyle(.glass)
+            } else {
+                fallback(content)
+            }
+        #else
+            fallback(content)
+        #endif
+    }
+
+    private func fallback(_ content: Content) -> some View {
+        content
+            .buttonStyle(.plain)
+            .foregroundStyle(.white)
+            .modifier(PlayerGlassCapsuleBackground())
+    }
+}
+
 @MainActor
 private final class PlayerMomentaryRateBadgeHostingView:
     NSHostingView<PlayerMomentaryRateBadge>
@@ -172,7 +274,7 @@ private final class PlayerMomentaryRateBadgeHostingView:
 }
 
 @MainActor
-private final class DanmakuPlayerView: AVPlayerView {
+final class DanmakuPlayerView: AVPlayerView {
     let danmakuOverlay: DanmakuOverlayView
     private let scrollWheelCaptureView = PlayerScrollWheelCaptureView()
     private let windowScrollWheelShieldView = PlayerScrollWheelShieldView()
@@ -183,6 +285,13 @@ private final class DanmakuPlayerView: AVPlayerView {
     private weak var observedPlayer: AVPlayer?
     private var playerItemObservation: NSKeyValueObservation?
     private var playerTimeControlObservation: NSKeyValueObservation?
+    private var playerItemTimeJumpObserver: NSObjectProtocol?
+    private var resumeButtonHostingView: NSHostingView<PlayerResumeButton>?
+    private var displayedResumeNotice: PlaybackResumeNotice?
+    private var dismissedResumeToken: PlaybackResumeToken?
+    private var resumeRestartAction: (() -> Void)?
+    private var resumeNoticeDismissTask: Task<Void, Never>?
+    private var blocksNativePlaybackInteraction = false
     private var appResignObserver: NSObjectProtocol?
     private var windowResignObserver: NSObjectProtocol?
     var requestMomentaryPlaybackRate: ((Float) -> UUID?)?
@@ -213,6 +322,57 @@ private final class DanmakuPlayerView: AVPlayerView {
         installDanmakuOverlayIfNeeded()
     }
 
+    override var acceptsFirstResponder: Bool {
+        !blocksNativePlaybackInteraction && super.acceptsFirstResponder
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard !blocksNativePlaybackInteraction else { return nil }
+        return super.hitTest(point)
+    }
+
+    func setPlaybackPreparationBlocked(_ blocked: Bool) {
+        guard blocksNativePlaybackInteraction != blocked else { return }
+        blocksNativePlaybackInteraction = blocked
+        controlsStyle = PlayerPlaybackPreparationPolicy.controlsStyle(
+            blocksNativePlaybackInteraction: blocked
+        )
+        setAccessibilityHidden(blocked)
+        guard blocked,
+            let window,
+            let responderView = window.firstResponder as? NSView,
+            responderView === self || responderView.isDescendant(of: self)
+        else { return }
+        window.makeFirstResponder(nil)
+    }
+
+    func setResumeNotice(
+        _ notice: PlaybackResumeNotice?,
+        restartFromBeginning: @escaping () -> Void
+    ) {
+        resumeRestartAction = restartFromBeginning
+        guard let notice else {
+            clearResumeNotice(markDismissed: false)
+            dismissedResumeToken = nil
+            return
+        }
+        guard dismissedResumeToken != notice.token else { return }
+        if displayedResumeNotice?.token == notice.token,
+            let resumeButtonHostingView
+        {
+            resumeButtonHostingView.rootView = makeResumeButton(
+                restartFromBeginning: restartFromBeginning
+            )
+            return
+        }
+        clearResumeNotice(markDismissed: false)
+        displayedResumeNotice = notice
+        installResumeButtonIfPossible(
+            notice: notice,
+            restartFromBeginning: restartFromBeginning
+        )
+    }
+
     override func viewWillMove(toWindow newWindow: NSWindow?) {
         if window !== newWindow {
             stopObservingFocusLoss()
@@ -226,6 +386,15 @@ private final class DanmakuPlayerView: AVPlayerView {
         installDanmakuOverlayIfNeeded()
         installWindowScrollWheelShield()
         startObservingFocusLoss()
+        if let displayedResumeNotice,
+            resumeButtonHostingView == nil,
+            let resumeRestartAction
+        {
+            installResumeButtonIfPossible(
+                notice: displayedResumeNotice,
+                restartFromBeginning: resumeRestartAction
+            )
+        }
     }
 
     override func layout() {
@@ -302,6 +471,8 @@ private final class DanmakuPlayerView: AVPlayerView {
             [weak self] _, _ in
             Task { @MainActor in
                 self?.cancelMomentaryPlaybackRateIfItemChanged()
+                self?.clearResumeNotice(markDismissed: true)
+                self?.startObservingCurrentItemTimeJumps()
             }
         }
         playerTimeControlObservation = player.observe(
@@ -323,6 +494,33 @@ private final class DanmakuPlayerView: AVPlayerView {
                 self.cancelMomentaryPlaybackRate()
             }
         }
+        startObservingCurrentItemTimeJumps()
+    }
+
+    private func startObservingCurrentItemTimeJumps() {
+        if let playerItemTimeJumpObserver {
+            NotificationCenter.default.removeObserver(playerItemTimeJumpObserver)
+            self.playerItemTimeJumpObserver = nil
+        }
+        guard let item = player?.currentItem else { return }
+        playerItemTimeJumpObserver = NotificationCenter.default.addObserver(
+            forName: AVPlayerItem.timeJumpedNotification,
+            object: item,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self,
+                    self.player?.currentItem != nil,
+                    let notice = self.displayedResumeNotice
+                else { return }
+                let currentSeconds = self.player?.currentTime().seconds ?? .nan
+                guard
+                    !currentSeconds.isFinite
+                        || abs(currentSeconds - notice.positionSeconds) > 0.5
+                else { return }
+                self.clearResumeNotice(markDismissed: true)
+            }
+        }
     }
 
     func stopObservingPlayerItemChanges() {
@@ -330,6 +528,10 @@ private final class DanmakuPlayerView: AVPlayerView {
         playerItemObservation = nil
         playerTimeControlObservation?.invalidate()
         playerTimeControlObservation = nil
+        if let playerItemTimeJumpObserver {
+            NotificationCenter.default.removeObserver(playerItemTimeJumpObserver)
+            self.playerItemTimeJumpObserver = nil
+        }
         observedPlayer = nil
     }
 
@@ -374,6 +576,96 @@ private final class DanmakuPlayerView: AVPlayerView {
                 equalTo: contentOverlayView.bottomAnchor
             ),
         ])
+    }
+
+    private func installResumeButtonIfPossible(
+        notice: PlaybackResumeNotice,
+        restartFromBeginning: @escaping () -> Void
+    ) {
+        guard let contentOverlayView else { return }
+        let hostingView = NSHostingView(
+            rootView: makeResumeButton(
+                restartFromBeginning: restartFromBeginning
+            )
+        )
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        contentOverlayView.addSubview(
+            hostingView,
+            positioned: .above,
+            relativeTo: nil
+        )
+        NSLayoutConstraint.activate([
+            hostingView.leadingAnchor.constraint(
+                equalTo: contentOverlayView.leadingAnchor,
+                constant: PlayerResumeNoticeLayout.leadingInset
+            ),
+            hostingView.bottomAnchor.constraint(
+                equalTo: contentOverlayView.bottomAnchor,
+                constant: -PlayerResumeNoticeLayout.bottomInset
+            ),
+        ])
+        resumeButtonHostingView = hostingView
+        scheduleResumeNoticeDismissal(for: notice.token)
+    }
+
+    private func makeResumeButton(
+        restartFromBeginning: @escaping () -> Void
+    ) -> PlayerResumeButton {
+        PlayerResumeButton {
+            restartFromBeginning()
+        }
+    }
+
+    private func scheduleResumeNoticeDismissal(
+        for token: PlaybackResumeToken
+    ) {
+        resumeNoticeDismissTask?.cancel()
+        resumeNoticeDismissTask = Task { [weak self] in
+            do {
+                try await Task.sleep(
+                    for: PlayerResumeNoticeDismissalPolicy.delay
+                )
+            } catch {
+                return
+            }
+            guard let self,
+                PlayerResumeNoticeDismissalPolicy.shouldDismiss(
+                    displayedToken: self.displayedResumeNotice?.token,
+                    scheduledToken: token
+                )
+            else { return }
+            guard let hostingView = self.resumeButtonHostingView else {
+                self.resumeNoticeDismissTask = nil
+                self.clearResumeNotice(markDismissed: true)
+                return
+            }
+            await NSAnimationContext.runAnimationGroup { context in
+                context.duration =
+                    PlayerResumeNoticeDismissalPolicy.fadeDurationSeconds
+                hostingView.animator().alphaValue = 0
+            }
+            guard
+                !Task.isCancelled,
+                PlayerResumeNoticeDismissalPolicy.shouldDismiss(
+                    displayedToken: self.displayedResumeNotice?.token,
+                    scheduledToken: token
+                ),
+                self.resumeButtonHostingView === hostingView
+            else { return }
+            self.resumeNoticeDismissTask = nil
+            self.clearResumeNotice(markDismissed: true)
+        }
+    }
+
+    private func clearResumeNotice(markDismissed: Bool) {
+        resumeNoticeDismissTask?.cancel()
+        resumeNoticeDismissTask = nil
+        if markDismissed {
+            dismissedResumeToken = displayedResumeNotice?.token
+        }
+        displayedResumeNotice = nil
+        resumeButtonHostingView?.removeFromSuperview()
+        resumeButtonHostingView = nil
     }
 
     private var canBeginMomentaryPlaybackRate: Bool {

--- a/BiliKitMac/Platform/PlayerHostView.swift
+++ b/BiliKitMac/Platform/PlayerHostView.swift
@@ -173,15 +173,11 @@ private struct PlayerMomentaryRateBadge: View {
 private struct PlayerGlassCapsuleBackground: ViewModifier {
     @ViewBuilder
     func body(content: Content) -> some View {
-        #if compiler(>=6.2)
-            if #available(macOS 26.0, *) {
-                content.glassEffect(.regular, in: Capsule())
-            } else {
-                fallbackBackground(content)
-            }
-        #else
+        if #available(macOS 26.0, *) {
+            content.glassEffect(.regular, in: Capsule())
+        } else {
             fallbackBackground(content)
-        #endif
+        }
     }
 
     private func fallbackBackground(_ content: Content) -> some View {
@@ -245,15 +241,11 @@ private struct PlayerResumeButton: View {
 private struct PlayerResumeButtonStyle: ViewModifier {
     @ViewBuilder
     func body(content: Content) -> some View {
-        #if compiler(>=6.2)
-            if #available(macOS 26.0, *) {
-                content.buttonStyle(.glass)
-            } else {
-                fallback(content)
-            }
-        #else
+        if #available(macOS 26.0, *) {
+            content.buttonStyle(.glass)
+        } else {
             fallback(content)
-        #endif
+        }
     }
 
     private func fallback(_ content: Content) -> some View {

--- a/BiliKitMacTests/PlayerHostViewIdentityTests.swift
+++ b/BiliKitMacTests/PlayerHostViewIdentityTests.swift
@@ -12,6 +12,54 @@ import Testing
 @Suite(.serialized)
 struct PlayerHostViewIdentityTests {
     @Test
+    func resumeNoticeUsesCompactCopyAndTokenScopedFiveSecondDismissal() {
+        let scheduledToken = PlaybackResumeToken()
+        let replacementToken = PlaybackResumeToken()
+
+        #expect(PlayerResumeNoticePresentation.title == "从头播放")
+        #expect(PlayerResumeNoticeDismissalPolicy.delay == .seconds(5))
+        #expect(PlayerResumeNoticeDismissalPolicy.fadeDurationSeconds == 0.2)
+        #expect(
+            PlayerResumeNoticeDismissalPolicy.shouldDismiss(
+                displayedToken: scheduledToken,
+                scheduledToken: scheduledToken
+            )
+        )
+        #expect(
+            !PlayerResumeNoticeDismissalPolicy.shouldDismiss(
+                displayedToken: replacementToken,
+                scheduledToken: scheduledToken
+            )
+        )
+    }
+
+    @Test
+    @MainActor
+    func playbackPreparationBlocksNativePlayerInputAndAccessibility() {
+        let renderer = CoreAnimationDanmakuRenderer()
+        let controller = DanmakuPresentationController(
+            backend: renderer,
+            configuration: Self.emptyDanmakuConfiguration
+        )
+        let view = DanmakuPlayerView(
+            renderer: renderer,
+            controller: controller,
+            beginMomentaryPlaybackRate: nil,
+            endMomentaryPlaybackRate: nil
+        )
+
+        view.setPlaybackPreparationBlocked(true)
+        #expect(view.controlsStyle == .none)
+        #expect(!view.acceptsFirstResponder)
+        #expect(view.hitTest(.zero) == nil)
+        #expect(view.isAccessibilityHidden())
+
+        view.setPlaybackPreparationBlocked(false)
+        #expect(view.controlsStyle == .default)
+        #expect(!view.isAccessibilityHidden())
+    }
+
+    @Test
     @MainActor
     func danmakuSurfaceSurvivesTemporaryWindowReparenting() throws {
         let renderer = CoreAnimationDanmakuRenderer()

--- a/BiliKitMacTests/PopularNativeGridTests.swift
+++ b/BiliKitMacTests/PopularNativeGridTests.swift
@@ -520,7 +520,7 @@ struct PopularNativeGridTests {
     @Test
     func releasingImageOwnerSynchronouslyInvalidatesRetainedPipeline() async {
         var owner: NativeVideoImagePipelineOwner? = NativeVideoImagePipelineOwner()
-        weak var weakOwner = owner
+        weak let weakOwner = owner
         let pipeline = owner!.pipeline
 
         owner = nil

--- a/BiliKitMacTests/VideoDetailLifecycleTests.swift
+++ b/BiliKitMacTests/VideoDetailLifecycleTests.swift
@@ -545,8 +545,15 @@ private final class ControlledFailingPlayback: PlaybackControlling {
 
     func beginPlayback(
         identity: PlaybackItemIdentity,
-        intent: PlaybackLoadIntent
-    ) -> Bool { true }
+        intent: PlaybackLoadIntent,
+        initialPositionSeconds: Double?
+    ) async -> PlaybackStartOutcome { .startedAtBeginning }
+
+    func restartFromBeginning(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent,
+        resumeToken: PlaybackResumeToken
+    ) async -> Bool { false }
 
     func pause() {}
 
@@ -587,11 +594,18 @@ private final class RecordingLifecyclePlayback: PlaybackControlling {
 
     func beginPlayback(
         identity: PlaybackItemIdentity,
-        intent: PlaybackLoadIntent
-    ) -> Bool {
+        intent: PlaybackLoadIntent,
+        initialPositionSeconds: Double?
+    ) async -> PlaybackStartOutcome {
         startedIdentities.append(identity)
-        return true
+        return .startedAtBeginning
     }
+
+    func restartFromBeginning(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent,
+        resumeToken: PlaybackResumeToken
+    ) async -> Bool { false }
 
     func pause() {}
 

--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
@@ -332,7 +332,10 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
             mediaHeaders: [
                 "Referer": referer,
                 "User-Agent": userAgent,
-            ]
+            ],
+            resumeMetadata:
+                resolved.authorizationProvenance == .authenticated
+                ? payload.resumeMetadata : nil
         )
     }
 

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/PlaybackEndpointPayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/PlaybackEndpointPayloads.swift
@@ -7,12 +7,16 @@ struct PlayURLPayload: Decodable, Sendable {
     let currentLanguage: String?
     let currentProductionType: Int?
     let languageCatalog: AudioLanguageCatalogPayload?
+    let lastPlayTime: Int64?
+    let lastPlayCID: Int64?
 
     private enum CodingKeys: String, CodingKey {
         case dash
         case currentLanguage = "cur_language"
         case currentProductionType = "cur_production_type"
         case languageCatalog = "language"
+        case lastPlayTime = "last_play_time"
+        case lastPlayCID = "last_play_cid"
     }
 
     init(from decoder: any Decoder) throws {
@@ -29,6 +33,16 @@ struct PlayURLPayload: Decodable, Sendable {
         languageCatalog = try? container.decode(
             AudioLanguageCatalogPayload.self,
             forKey: .languageCatalog
+        )
+        lastPlayTime = try? container.decode(Int64.self, forKey: .lastPlayTime)
+        lastPlayCID = try? container.decode(Int64.self, forKey: .lastPlayCID)
+    }
+
+    var resumeMetadata: PlaybackResumeMetadata? {
+        guard let lastPlayCID, let lastPlayTime else { return nil }
+        return PlaybackResumeMetadata(
+            lastPlayedCID: lastPlayCID,
+            positionMilliseconds: lastPlayTime
         )
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestVideoUseCase.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestVideoUseCase.swift
@@ -6,17 +6,20 @@ public struct GuestVideoContext: Sendable, Equatable {
     public let pages: [VideoPage]
     public let selectedPage: VideoPage
     public let playback: VideoPlayback
+    public let resumePositionSeconds: Double?
 
     public init(
         detail: VideoDetail,
         pages: [VideoPage],
         selectedPage: VideoPage,
-        playback: VideoPlayback
+        playback: VideoPlayback,
+        resumePositionSeconds: Double? = nil
     ) {
         self.detail = detail
         self.pages = pages
         self.selectedPage = selectedPage
         self.playback = playback
+        self.resumePositionSeconds = resumePositionSeconds
     }
 }
 
@@ -40,20 +43,39 @@ public struct GuestVideoUseCase: Sendable {
             : resolvedDetail.pages
         try Task.checkCancellation()
         let sortedPages = resolvedPages.sorted(by: { $0.index < $1.index })
-        guard let selectedPage = sortedPages.first else {
+        guard let provisionalPage = sortedPages.first else {
             throw GuestApplicationError.invalidResponse
         }
-        let playback = try await repository.playback(
+        let provisionalPlayback = try await repository.playback(
             for: bvid,
-            cid: selectedPage.cid
+            cid: provisionalPage.cid
         )
         try Task.checkCancellation()
+
+        let selectedPage =
+            provisionalPlayback.resumeMetadata.flatMap { metadata in
+                sortedPages.first(where: { $0.cid == metadata.lastPlayedCID })
+            } ?? provisionalPage
+        let playback: VideoPlayback
+        if selectedPage.cid == provisionalPage.cid {
+            playback = provisionalPlayback
+        } else {
+            playback = try await repository.playback(
+                for: bvid,
+                cid: selectedPage.cid
+            )
+            try Task.checkCancellation()
+        }
 
         return GuestVideoContext(
             detail: resolvedDetail,
             pages: sortedPages,
             selectedPage: selectedPage,
-            playback: playback
+            playback: playback,
+            resumePositionSeconds: Self.resumePosition(
+                metadata: provisionalPlayback.resumeMetadata,
+                page: selectedPage
+            )
         )
     }
 
@@ -93,5 +115,21 @@ public struct GuestVideoUseCase: Sendable {
             selectedPage: selectedPage,
             playback: playback
         )
+    }
+
+    static func resumePosition(
+        metadata: PlaybackResumeMetadata?,
+        page: VideoPage
+    ) -> Double? {
+        guard let metadata,
+            metadata.lastPlayedCID == page.cid,
+            page.durationSeconds > 0
+        else { return nil }
+        let seconds = Double(metadata.positionMilliseconds) / 1_000
+        let latestUsefulPosition =
+            Double(page.durationSeconds)
+            - PlaybackResumePolicy.completedThresholdSeconds
+        guard seconds > 0, seconds < latestUsefulPosition else { return nil }
+        return seconds
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliApplication/Playback/PlaybackTimeline.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Playback/PlaybackTimeline.swift
@@ -26,6 +26,31 @@ public struct PlaybackLoadIntent: Sendable, Hashable {
     }
 }
 
+/// 一次成功断点定位的不可复用能力；旧浮层不能控制后来加载的 item。
+public struct PlaybackResumeToken: Sendable, Hashable {
+    private let value: UUID
+
+    public init() {
+        value = UUID()
+    }
+}
+
+public enum PlaybackStartOutcome: Sendable, Equatable {
+    case rejected
+    case preparationFailed
+    case startedAtBeginning
+    case resumed(
+        positionSeconds: Double,
+        token: PlaybackResumeToken,
+        discontinuityGeneration: UInt64
+    )
+}
+
+public enum PlaybackResumePolicy {
+    /// 接近片尾的服务器位置按已看完处理，避免恢复到结束画面。
+    public static let completedThresholdSeconds = 5.0
+}
+
 public struct PlaybackFailureEvent: Sendable, Equatable {
     public let identity: PlaybackItemIdentity
     public let intent: PlaybackLoadIntent
@@ -106,12 +131,18 @@ public protocol PlaybackControlling: AnyObject {
         identity: PlaybackItemIdentity,
         intent: PlaybackLoadIntent
     ) async throws
-    /// 只为仍匹配本次 load intent、且尚未播放或 seek 的 item 开始播放。
-    @discardableResult
+    /// 为当前 load intent 原子完成可选首次定位与开播；用户意图可在任一 await 后否决提交。
     func beginPlayback(
         identity: PlaybackItemIdentity,
-        intent: PlaybackLoadIntent
-    ) -> Bool
+        intent: PlaybackLoadIntent,
+        initialPositionSeconds: Double?
+    ) async -> PlaybackStartOutcome
+    /// 仅允许当前断点浮层把仍匹配的 item 定位到 0 秒并继续播放。
+    func restartFromBeginning(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent,
+        resumeToken: PlaybackResumeToken
+    ) async -> Bool
     func pause()
     func stop()
 }

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoDetailView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoDetailView.swift
@@ -91,12 +91,25 @@ struct GuestVideoDetailView<PlayerContent: View>: View {
                 ZStack {
                     Rectangle()
                         .fill(.black)
-                    ProgressView("正在准备播放…")
-                        .controlSize(.large)
-                        .font(.title3)
-                        .foregroundStyle(.white)
+                    VStack(spacing: 12) {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .controlSize(.large)
+                            .tint(.white)
+                        Text("正在准备播放…")
+                            .font(.title3)
+                            .foregroundStyle(.white)
+                    }
+                    .environment(\.colorScheme, .dark)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("正在准备播放")
                 }
-                .transition(.opacity)
+                .transition(
+                    .asymmetric(
+                        insertion: .identity,
+                        removal: .opacity
+                    )
+                )
             }
         }
         .animation(

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoDetailView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoDetailView.swift
@@ -90,7 +90,7 @@ struct GuestVideoDetailView<PlayerContent: View>: View {
             if isPreparingPlayback {
                 ZStack {
                     Rectangle()
-                        .fill(.black.opacity(0.45))
+                        .fill(.black)
                     ProgressView("正在准备播放…")
                         .controlSize(.large)
                         .font(.title3)

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoViewModel.swift
@@ -36,6 +36,18 @@ public enum CollectionEpisodePagesState: Sendable, Equatable {
     case failed(GuestApplicationError)
 }
 
+public struct PlaybackResumeNotice: Sendable, Equatable {
+    public let positionSeconds: Double
+    public let token: PlaybackResumeToken
+
+    public init(positionSeconds: Double, token: PlaybackResumeToken) {
+        self.positionSeconds = positionSeconds
+        self.token = token
+    }
+}
+
+private struct PlaybackStartPreparationFailure: Error {}
+
 @MainActor
 @Observable
 /// 拥有单个视频准备意图，并把内容准备与播放器安装串成同一 generation。
@@ -60,6 +72,8 @@ public final class GuestVideoViewModel {
     public private(set) var expandedCollectionEpisodes: Set<VideoCollectionEpisodeIdentity> = []
     public private(set) var collectionEpisodePageStates:
         [VideoCollectionEpisodeIdentity: CollectionEpisodePagesState] = [:]
+    /// 只在当前 item 已完成首次定位并开始播放后出现。
+    public private(set) var resumeNotice: PlaybackResumeNotice?
 
     @ObservationIgnored private let useCase: GuestVideoUseCase
     @ObservationIgnored private let playback: any PlaybackControlling
@@ -69,6 +83,7 @@ public final class GuestVideoViewModel {
     @ObservationIgnored private var relatedVideoTask: Task<Void, Never>?
     @ObservationIgnored private var uploaderSignatureTask: Task<Void, Never>?
     @ObservationIgnored private var playbackFailureTask: Task<Void, Never>?
+    @ObservationIgnored private var resumeActionTask: Task<Void, Never>?
     @ObservationIgnored private var playbackIntent: PlaybackLoadIntent?
     @ObservationIgnored private var collectionEpisodeTask: Task<Void, Never>?
     @ObservationIgnored private var activeCollectionEpisodeRequest: CollectionEpisodePageRequest?
@@ -107,6 +122,7 @@ public final class GuestVideoViewModel {
         uploaderSignatureTask?.cancel()
         playbackFailureTask?.cancel()
         collectionEpisodeTask?.cancel()
+        resumeActionTask?.cancel()
     }
 
     /// 取代当前播放意图；已有非 idle 会话会先停止，避免两个 bridge/server 并存。
@@ -122,6 +138,7 @@ public final class GuestVideoViewModel {
         requestedPlaybackIdentity = nil
         presentedPlaybackIdentity = nil
         playbackIntent = nil
+        clearResumeNotice()
         state = .loading(bvid: bvid)
         loadRelatedVideos(for: bvid)
         loadTask = Task { [weak self] in
@@ -187,6 +204,7 @@ public final class GuestVideoViewModel {
         let currentGeneration = generation
         loadTask?.cancel()
         playback.stop()
+        clearResumeNotice()
         requestedPlaybackIdentity = targetIdentity
         presentedPlaybackIdentity = nil
         let intent = PlaybackLoadIntent()
@@ -235,8 +253,39 @@ public final class GuestVideoViewModel {
         requestedPlaybackIdentity = nil
         presentedPlaybackIdentity = nil
         playbackIntent = nil
+        clearResumeNotice()
         state = .idle
         playback.stop()
+    }
+
+    /// 当前浮层的 token、identity 与 load intent 都匹配时才允许回到 0 秒。
+    public func restartFromBeginning() {
+        guard let resumeNotice,
+            let identity = presentedPlaybackIdentity,
+            let intent = playbackIntent
+        else { return }
+        let currentGeneration = generation
+        resumeActionTask?.cancel()
+        resumeActionTask = Task { [weak self, playback] in
+            let restarted = await playback.restartFromBeginning(
+                identity: identity,
+                intent: intent,
+                resumeToken: resumeNotice.token
+            )
+            guard let self else { return }
+            guard generation == currentGeneration,
+                self.resumeNotice?.token == resumeNotice.token
+            else {
+                if generation == currentGeneration {
+                    self.resumeActionTask = nil
+                }
+                return
+            }
+            if restarted {
+                self.resumeNotice = nil
+            }
+            self.resumeActionTask = nil
+        }
     }
 
     public func waitForCurrentTask() async {
@@ -253,6 +302,10 @@ public final class GuestVideoViewModel {
 
     func taskSnapshotForTesting() -> Task<Void, Never>? {
         loadTask
+    }
+
+    func waitForResumeActionForTesting() async {
+        await resumeActionTask?.value
     }
 
     public func waitForCurrentRelatedVideoTask() async {
@@ -347,12 +400,23 @@ public final class GuestVideoViewModel {
             )
             try Task.checkCancellation()
             guard generation == currentGeneration else { return }
-            playback.beginPlayback(identity: identity, intent: intent)
+            let startOutcome = await playback.beginPlayback(
+                identity: identity,
+                intent: intent,
+                initialPositionSeconds: context.resumePositionSeconds
+            )
+            try Task.checkCancellation()
+            guard generation == currentGeneration else { return }
+            if startOutcome == .preparationFailed {
+                throw PlaybackStartPreparationFailure()
+            }
+            applyResumeNotice(from: startOutcome)
             presentedPlaybackIdentity = requestedPlaybackIdentity
             state = .ready(context)
         } catch is CancellationError {
             guard generation == currentGeneration else { return }
             clearCollectionEpisodeState()
+            clearResumeNotice()
             presentedContext = nil
             requestedPlaybackIdentity = nil
             presentedPlaybackIdentity = nil
@@ -360,10 +424,12 @@ public final class GuestVideoViewModel {
             state = .idle
         } catch let error as GuestApplicationError {
             guard generation == currentGeneration else { return }
+            clearResumeNotice()
             recordAuthenticationInvalidationIfNeeded(error)
             state = .failed(bvid: bvid, failure: .content(error))
         } catch {
             guard generation == currentGeneration else { return }
+            clearResumeNotice()
             state = .failed(bvid: bvid, failure: .playback)
         }
 
@@ -399,12 +465,23 @@ public final class GuestVideoViewModel {
             )
             try Task.checkCancellation()
             guard generation == currentGeneration else { return }
-            playback.beginPlayback(identity: identity, intent: intent)
+            let startOutcome = await playback.beginPlayback(
+                identity: identity,
+                intent: intent,
+                initialPositionSeconds: replacement.resumePositionSeconds
+            )
+            try Task.checkCancellation()
+            guard generation == currentGeneration else { return }
+            if startOutcome == .preparationFailed {
+                throw PlaybackStartPreparationFailure()
+            }
+            applyResumeNotice(from: startOutcome)
             presentedPlaybackIdentity = identity
             state = .ready(replacement)
         } catch is CancellationError {
             guard generation == currentGeneration else { return }
             clearCollectionEpisodeState()
+            clearResumeNotice()
             requestedPlaybackIdentity = nil
             presentedPlaybackIdentity = nil
             playbackIntent = nil
@@ -412,6 +489,7 @@ public final class GuestVideoViewModel {
             presentedContext = nil
         } catch let error as GuestApplicationError {
             guard generation == currentGeneration else { return }
+            clearResumeNotice()
             recordAuthenticationInvalidationIfNeeded(error)
             state = .failedPage(
                 context: context,
@@ -420,6 +498,7 @@ public final class GuestVideoViewModel {
             )
         } catch {
             guard generation == currentGeneration else { return }
+            clearResumeNotice()
             state = .failedPage(
                 context: context,
                 targetPage: targetPage,
@@ -454,6 +533,7 @@ public final class GuestVideoViewModel {
         loadTask?.cancel()
         loadTask = nil
         playback.stop()
+        clearResumeNotice()
         requestedPlaybackIdentity = event.identity
         presentedPlaybackIdentity = nil
         state = .failedPage(
@@ -468,6 +548,24 @@ public final class GuestVideoViewModel {
     ) {
         guard error == .authenticationInvalid else { return }
         authenticationRevalidationGeneration += 1
+    }
+
+    private func applyResumeNotice(from outcome: PlaybackStartOutcome) {
+        switch outcome {
+        case .resumed(let positionSeconds, let token, _):
+            resumeNotice = PlaybackResumeNotice(
+                positionSeconds: positionSeconds,
+                token: token
+            )
+        case .rejected, .preparationFailed, .startedAtBeginning:
+            resumeNotice = nil
+        }
+    }
+
+    private func clearResumeNotice() {
+        resumeActionTask?.cancel()
+        resumeActionTask = nil
+        resumeNotice = nil
     }
 
     private func loadUploaderSignature(for ownerID: Int64) {

--- a/Packages/BiliKitCore/Sources/BiliModels/Video/VideoModels.swift
+++ b/Packages/BiliKitCore/Sources/BiliModels/Video/VideoModels.swift
@@ -327,13 +327,32 @@ public struct VideoCollectionEpisode: Identifiable, Sendable, Equatable {
 public struct VideoPlayback: Sendable, Equatable {
     public let manifest: PlaybackManifest
     public let mediaHeaders: [String: String]
+    /// 已认证 playurl 返回的账户级断点；匿名响应与异常字段保持为 nil。
+    public let resumeMetadata: PlaybackResumeMetadata?
 
     public init(
         manifest: PlaybackManifest,
-        mediaHeaders: [String: String]
+        mediaHeaders: [String: String],
+        resumeMetadata: PlaybackResumeMetadata? = nil
     ) {
         self.manifest = manifest
         self.mediaHeaders = mediaHeaders
+        self.resumeMetadata = resumeMetadata
+    }
+}
+
+/// 账户对同一 BVID 最近播放分 P 的服务器记录；位置单位固定为毫秒。
+public struct PlaybackResumeMetadata: Sendable, Equatable {
+    public let lastPlayedCID: Int64
+    public let positionMilliseconds: Int64
+
+    public init?(
+        lastPlayedCID: Int64,
+        positionMilliseconds: Int64
+    ) {
+        guard lastPlayedCID > 0, positionMilliseconds >= 0 else { return nil }
+        self.lastPlayedCID = lastPlayedCID
+        self.positionMilliseconds = positionMilliseconds
     }
 }
 

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
@@ -43,6 +43,8 @@ public final class AVPlayerEngine:
     private var readinessTask: Task<Void, any Error>?
     private var loadGeneration = UUID()
     private var loadIntent: PlaybackLoadIntent?
+    private var activeResumeToken: PlaybackResumeToken?
+    private var restartOperation: UUID?
     private var preparedAsset: PreparedPlaybackAsset?
     private var subtitleIdentity: PlaybackItemIdentity?
     private var subtitleResetTask: Task<Void, Never>?
@@ -168,6 +170,8 @@ public final class AVPlayerEngine:
 
         loadGeneration = generation
         loadIntent = intent
+        activeResumeToken = nil
+        restartOperation = nil
         loadTask?.cancel()
         loadTask = nil
         readinessTask?.cancel()
@@ -261,6 +265,8 @@ public final class AVPlayerEngine:
         guard loadGeneration == generation else { return }
         loadGeneration = UUID()
         loadIntent = nil
+        activeResumeToken = nil
+        restartOperation = nil
         loadTask?.cancel()
         loadTask = nil
         readinessTask?.cancel()
@@ -273,12 +279,12 @@ public final class AVPlayerEngine:
         emit(.stateChanged(.idle))
     }
 
-    /// 只提交当前 load intent 的首次自动播放；旧请求、重复回调和已播放/seek 的 item 均拒绝。
-    @discardableResult
+    /// 当前 item 保持暂停，先完成受 intent 和交互 revision 保护的首次定位，再开始播放。
     public func beginPlayback(
         identity: PlaybackItemIdentity,
-        intent: PlaybackLoadIntent
-    ) -> Bool {
+        intent: PlaybackLoadIntent,
+        initialPositionSeconds: Double?
+    ) async -> PlaybackStartOutcome {
         guard loadIntent == intent,
             timeline.currentSnapshot.identity == identity,
             !timeline.hasObservedPlaybackInteraction,
@@ -287,9 +293,122 @@ public final class AVPlayerEngine:
             player.currentTime().seconds <= 0.25,
             timeline.currentSnapshot.state == .ready
                 || timeline.currentSnapshot.state == .paused,
-            player.currentItem != nil
+            let item = player.currentItem
+        else { return .rejected }
+
+        let currentGeneration = loadGeneration
+        let interactionRevision = timeline.playbackInteractionRevision
+        guard let initialPositionSeconds,
+            let durationSeconds = Self.validSeconds(item.duration),
+            initialPositionSeconds.isFinite,
+            initialPositionSeconds > 0,
+            initialPositionSeconds < durationSeconds - 0.05
+        else {
+            activeResumeToken = nil
+            play()
+            return .startedAtBeginning
+        }
+
+        timeline.prepareInitialSeek(to: initialPositionSeconds)
+        let tolerance = CMTime(seconds: 0.25, preferredTimescale: 600)
+        let didSeek = await player.seek(
+            to: CMTime(seconds: initialPositionSeconds, preferredTimescale: 600),
+            toleranceBefore: tolerance,
+            toleranceAfter: tolerance
+        )
+        guard didSeek else {
+            timeline.initialSeekFailed()
+            return .preparationFailed
+        }
+        guard loadGeneration == currentGeneration,
+            loadIntent == intent,
+            player.currentItem === item,
+            timeline.currentSnapshot.identity == identity,
+            timeline.playbackInteractionRevision == interactionRevision,
+            timeline.currentSnapshot.state == .ready
+                || timeline.currentSnapshot.state == .paused
+                || timeline.currentSnapshot.state == .buffering
+        else {
+            if player.currentItem === item {
+                timeline.initialSeekFailed()
+            }
+            return .rejected
+        }
+
+        guard
+            let resolvedPosition = Self.validatedResolvedInitialPosition(
+                player.currentTime(),
+                durationSeconds: durationSeconds
+            )
+        else {
+            timeline.initialSeekFailed()
+            return .preparationFailed
+        }
+        timeline.initialSeekCompleted(at: resolvedPosition)
+        let token = PlaybackResumeToken()
+        activeResumeToken = token
+        timeline.playAfterInternalSeek()
+        emit(.stateChanged(.playing))
+        return .resumed(
+            positionSeconds: resolvedPosition,
+            token: token,
+            discontinuityGeneration:
+                timeline.currentSnapshot.discontinuityGeneration
+        )
+    }
+
+    public func restartFromBeginning(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent,
+        resumeToken: PlaybackResumeToken
+    ) async -> Bool {
+        guard activeResumeToken == resumeToken,
+            restartOperation == nil,
+            loadIntent == intent,
+            timeline.currentSnapshot.identity == identity,
+            let item = player.currentItem
         else { return false }
-        play()
+        let operation = UUID()
+        restartOperation = operation
+        defer {
+            if restartOperation == operation {
+                restartOperation = nil
+            }
+        }
+        let currentGeneration = loadGeneration
+        timeline.prepareResumeRestart()
+        let interactionRevision = timeline.playbackInteractionRevision
+        let didSeek = await player.seek(
+            to: .zero,
+            toleranceBefore: .zero,
+            toleranceAfter: .zero
+        )
+        guard didSeek else {
+            timeline.resumeRestartFailed()
+            return false
+        }
+        guard activeResumeToken == resumeToken,
+            loadGeneration == currentGeneration,
+            loadIntent == intent,
+            player.currentItem === item,
+            timeline.currentSnapshot.identity == identity,
+            timeline.playbackInteractionRevision == interactionRevision
+        else {
+            if player.currentItem === item {
+                timeline.resumeRestartFailed()
+            }
+            return false
+        }
+        guard let resolvedPosition = Self.validSeconds(player.currentTime()),
+            resolvedPosition <= 0.5
+        else {
+            timeline.resumeRestartFailed()
+            return false
+        }
+        timeline.resumeRestartCompleted()
+        activeResumeToken = nil
+        timeline.playAfterInternalSeek()
+        emit(.stateChanged(.playing))
         return true
     }
 
@@ -345,6 +464,8 @@ public final class AVPlayerEngine:
     public func stop() {
         loadGeneration = UUID()
         loadIntent = nil
+        activeResumeToken = nil
+        restartOperation = nil
         loadTask?.cancel()
         loadTask = nil
         readinessTask?.cancel()
@@ -356,6 +477,24 @@ public final class AVPlayerEngine:
         timeline.clear()
         _ = enqueueSubtitleReset()
         emit(.stateChanged(.idle))
+    }
+
+    private static func validSeconds(_ time: CMTime) -> Double? {
+        let seconds = CMTimeGetSeconds(time)
+        guard seconds.isFinite, seconds >= 0 else { return nil }
+        return seconds
+    }
+
+    static func validatedResolvedInitialPosition(
+        _ time: CMTime,
+        durationSeconds: Double
+    ) -> Double? {
+        guard let positionSeconds = validSeconds(time),
+            durationSeconds.isFinite,
+            positionSeconds > 0.25,
+            positionSeconds < durationSeconds - 0.05
+        else { return nil }
+        return positionSeconds
     }
 
     private func selectedVideos(

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerTimelineAdapter.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerTimelineAdapter.swift
@@ -32,15 +32,141 @@ enum MomentaryRateRestorationPolicy {
     }
 }
 
-private final class PlaybackInteractionTracker: Sendable {
-    private let wasObserved = Mutex(false)
+final class PlaybackInteractionTracker: Sendable {
+    private struct State {
+        var revision: UInt64 = 0
+        var internalSeekTarget: Double?
+        var internalSeekInFlight = false
+        var internalPlayStartInFlight = false
+        var hasPlaybackStarted = false
+        var observedNonPausedDuringInitialSeek = false
+    }
+
+    private let state = Mutex(State())
 
     var hasObservedInteraction: Bool {
-        wasObserved.withLock { $0 }
+        revision > 0
+    }
+
+    var revision: UInt64 {
+        state.withLock { $0.revision }
     }
 
     func markObserved() {
-        wasObserved.withLock { $0 = true }
+        state.withLock {
+            $0.revision &+= 1
+            $0.internalSeekTarget = nil
+            $0.internalSeekInFlight = false
+            $0.internalPlayStartInFlight = false
+            $0.observedNonPausedDuringInitialSeek = false
+        }
+    }
+
+    func allowInternalSeek(to positionSeconds: Double) {
+        state.withLock {
+            $0.internalSeekTarget = positionSeconds
+            $0.internalSeekInFlight = true
+            $0.observedNonPausedDuringInitialSeek = false
+        }
+    }
+
+    func markObservedAllowingInternalSeek(to positionSeconds: Double) {
+        state.withLock {
+            $0.revision &+= 1
+            $0.internalSeekTarget = positionSeconds
+            $0.internalSeekInFlight = true
+            $0.observedNonPausedDuringInitialSeek = false
+        }
+    }
+
+    /// 新 item 的系统初始 paused 不算用户操作；会话已有交互后，paused 必须使在途提交失效。
+    func observeTimeControlStatus(
+        isPaused: Bool,
+        isPlaying: Bool,
+        playbackRate: Float
+    ) {
+        state.withLock {
+            if $0.internalPlayStartInFlight {
+                if isPaused {
+                    $0.revision &+= 1
+                    $0.internalPlayStartInFlight = false
+                } else if isPlaying {
+                    $0.hasPlaybackStarted = true
+                    $0.internalPlayStartInFlight = false
+                }
+                return
+            }
+            if $0.internalSeekInFlight, !isPaused {
+                if isPlaying || playbackRate > 0 {
+                    $0.observedNonPausedDuringInitialSeek = true
+                }
+                return
+            }
+            if $0.internalSeekInFlight,
+                isPaused,
+                $0.observedNonPausedDuringInitialSeek
+            {
+                $0.revision &+= 1
+                $0.internalSeekTarget = nil
+                $0.internalSeekInFlight = false
+                $0.observedNonPausedDuringInitialSeek = false
+                return
+            }
+            guard
+                !isPaused || $0.revision > 0 || $0.hasPlaybackStarted
+            else { return }
+            $0.revision &+= 1
+            if isPlaying {
+                $0.hasPlaybackStarted = true
+            }
+            $0.internalSeekTarget = nil
+            $0.internalSeekInFlight = false
+            $0.observedNonPausedDuringInitialSeek = false
+        }
+    }
+
+    func allowInternalPlayStart() {
+        state.withLock { $0.internalPlayStartInFlight = true }
+    }
+
+    func completeInternalSeek(at positionSeconds: Double) {
+        state.withLock {
+            $0.internalSeekTarget = positionSeconds
+            $0.internalSeekInFlight = false
+            $0.observedNonPausedDuringInitialSeek = false
+        }
+    }
+
+    func cancelInternalSeek() {
+        state.withLock {
+            $0.internalSeekTarget = nil
+            $0.internalSeekInFlight = false
+            $0.observedNonPausedDuringInitialSeek = false
+        }
+    }
+
+    /// 内部首次定位允许同一目标产生一个或多个系统 time-jump；其他跳变立即记为用户意图。
+    func observeTimeJump(at positionSeconds: Double) {
+        state.withLock {
+            if $0.internalSeekInFlight {
+                // 准备阶段由 player host 禁用原生控制；受控外部 seek 会在命令入口先
+                // 推进 revision，因此这里不能按 HLS 实际落点与目标的距离猜测来源。
+                return
+            }
+            if $0.revision == 0,
+                $0.internalSeekTarget == nil,
+                positionSeconds <= 0.25
+            {
+                return
+            }
+            if let target = $0.internalSeekTarget,
+                abs(target - positionSeconds) <= 0.5
+            {
+                return
+            }
+            $0.revision &+= 1
+            $0.internalSeekTarget = nil
+        }
     }
 }
 
@@ -65,6 +191,10 @@ final class AVPlayerTimelineAdapter {
 
     var hasObservedPlaybackInteraction: Bool {
         interactionTracker.hasObservedInteraction
+    }
+
+    var playbackInteractionRevision: UInt64 {
+        interactionTracker.revision
     }
 
     private let player: AVPlayer
@@ -132,9 +262,11 @@ final class AVPlayerTimelineAdapter {
             options: [.new]
         ) { [weak self, weak item] player, change in
             let observedStatus = change.newValue ?? player.timeControlStatus
-            if observedStatus != .paused {
-                interactionTracker.markObserved()
-            }
+            interactionTracker.observeTimeControlStatus(
+                isPaused: observedStatus == .paused,
+                isPlaying: observedStatus == .playing,
+                playbackRate: player.rate
+            )
             Task { @MainActor in
                 guard let self, let item, self.player.currentItem === item else {
                     return
@@ -217,6 +349,11 @@ final class AVPlayerTimelineAdapter {
             object: item,
             queue: .main
         ) { [weak self, weak item] _ in
+            if let item,
+                let position = Self.seconds(from: item.currentTime())
+            {
+                interactionTracker.observeTimeJump(at: position)
+            }
             Task { @MainActor in
                 guard let self, let item, self.player.currentItem === item,
                     self.store.currentSnapshot.state != .loading,
@@ -275,6 +412,11 @@ final class AVPlayerTimelineAdapter {
             rate: Double(preferredRate),
             state: .playing
         )
+    }
+
+    func playAfterInternalSeek() {
+        interactionTracker.allowInternalPlayStart()
+        play()
     }
 
     func pause() {
@@ -357,6 +499,41 @@ final class AVPlayerTimelineAdapter {
         pendingExplicitSeekPosition = positionSeconds
     }
 
+    func prepareInitialSeek(to positionSeconds: Double) {
+        interactionTracker.allowInternalSeek(to: positionSeconds)
+        pendingExplicitSeekPosition = positionSeconds
+    }
+
+    func prepareResumeRestart() {
+        interactionTracker.markObservedAllowingInternalSeek(to: 0)
+        pendingExplicitSeekPosition = 0
+    }
+
+    func resumeRestartFailed() {
+        pendingExplicitSeekPosition = nil
+        interactionTracker.cancelInternalSeek()
+    }
+
+    func resumeRestartCompleted() {
+        interactionTracker.completeInternalSeek(at: 0)
+        explicitSeekCompleted(at: 0)
+    }
+
+    func initialSeekFailed() {
+        pendingExplicitSeekPosition = nil
+        interactionTracker.cancelInternalSeek()
+    }
+
+    func initialSeekCompleted(at positionSeconds: Double) {
+        guard let token else { return }
+        pendingExplicitSeekPosition = nil
+        interactionTracker.completeInternalSeek(at: positionSeconds)
+        store.markDiscontinuity(
+            token: token,
+            positionSeconds: positionSeconds
+        )
+    }
+
     func explicitSeekFailed() {
         pendingExplicitSeekPosition = nil
     }
@@ -395,7 +572,7 @@ final class AVPlayerTimelineAdapter {
         onFailed?()
     }
 
-    private static func seconds(from time: CMTime) -> Double? {
+    private nonisolated static func seconds(from time: CMTime) -> Double? {
         let seconds = CMTimeGetSeconds(time)
         guard seconds.isFinite, seconds >= 0 else { return nil }
         return seconds

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
@@ -930,6 +930,45 @@ struct BiliAPIClientTests {
     }
 
     @Test
+    func authenticatedPlaybackMapsServerResumeMetadata() async throws {
+        let client = BiliAPIClient(
+            transport: RecordingTransport(
+                responses: [try resumePlayURLResponse()]
+            ),
+            requestAuthorizer: RecordingRequestAuthorizer()
+        )
+
+        let playback = try await client.playback(
+            for: "BV1FixtureA1",
+            cid: 900_001
+        )
+
+        #expect(
+            playback.resumeMetadata
+                == PlaybackResumeMetadata(
+                    lastPlayedCID: 900_002,
+                    positionMilliseconds: 42_500
+                )
+        )
+    }
+
+    @Test
+    func anonymousPlaybackDropsServerResumeMetadata() async throws {
+        let client = BiliAPIClient(
+            transport: RecordingTransport(
+                responses: [try resumePlayURLResponse()]
+            )
+        )
+
+        let playback = try await client.playback(
+            for: "BV1FixtureA1",
+            cid: 900_001
+        )
+
+        #expect(playback.resumeMetadata == nil)
+    }
+
+    @Test
     func playbackUsesAnonymousRequestOnlyForExplicitlyMissingCredential()
         async throws
     {
@@ -1622,6 +1661,26 @@ struct BiliAPIClientTests {
             statusCode: 200,
             headers: ["Content-Type": "application/json; charset=utf-8"],
             body: try Data(contentsOf: url)
+        )
+    }
+
+    private func resumePlayURLResponse() throws -> HTTPResponse {
+        let fixture = try fixtureResponse("playurl")
+        var object = try #require(
+            JSONSerialization.jsonObject(with: fixture.body)
+                as? [String: Any]
+        )
+        var data = try #require(object["data"] as? [String: Any])
+        data["last_play_cid"] = 900_002
+        data["last_play_time"] = 42_500
+        object["data"] = data
+        return HTTPResponse(
+            statusCode: fixture.statusCode,
+            headers: fixture.headers,
+            body: try JSONSerialization.data(
+                withJSONObject: object,
+                options: [.sortedKeys]
+            )
         )
     }
 

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
@@ -616,6 +616,125 @@ struct GuestBrowseAndVideoViewModelTests {
 
     @Test
     @MainActor
+    func authenticatedResumeSelectsRecordedPartBeforeStartingAndCanRestart()
+        async throws
+    {
+        let fixture = GuestFixtures()
+        let resumeToken = PlaybackResumeToken()
+        let repository = ResumeRepositoryStub(
+            fixtures: fixture,
+            metadata: try #require(
+                PlaybackResumeMetadata(
+                    lastPlayedCID: 900_002,
+                    positionMilliseconds: 42_500
+                )
+            )
+        )
+        let player = RecordingPlayerEngine(
+            startOutcome: .resumed(
+                positionSeconds: 42.5,
+                token: resumeToken,
+                discontinuityGeneration: 3
+            ),
+            restartSucceeds: true
+        )
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: player
+        )
+
+        model.loadVideo(fixture.bvid)
+        await model.waitForCurrentTask()
+
+        #expect(model.presentedContext?.selectedPage.cid == 900_002)
+        #expect(await repository.playbackCIDs == [900_001, 900_002])
+        #expect(player.startedInitialPositions == [42.5])
+        #expect(
+            model.resumeNotice
+                == PlaybackResumeNotice(
+                    positionSeconds: 42.5,
+                    token: resumeToken
+                )
+        )
+
+        model.restartFromBeginning()
+        await model.waitForResumeActionForTesting()
+
+        #expect(model.resumeNotice == nil)
+        #expect(player.restartTokens == [resumeToken])
+    }
+
+    @Test
+    @MainActor
+    func resumePreparationFailureUsesExistingPlaybackRetryState() async {
+        let fixture = GuestFixtures()
+        let player = RecordingPlayerEngine(
+            startOutcome: .preparationFailed
+        )
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(
+                repository: GuestRepositoryStub(fixtures: fixture)
+            ),
+            playback: player
+        )
+
+        model.loadVideo(fixture.bvid)
+        await model.waitForCurrentTask()
+
+        #expect(
+            model.state
+                == .failed(bvid: fixture.bvid, failure: .playback)
+        )
+        #expect(model.resumeNotice == nil)
+    }
+
+    @Test(arguments: [0, 115_000, 120_000, 900_000])
+    func zeroCompletedAndOutOfRangeResumePositionsStartAtBeginning(
+        positionMilliseconds: Int64
+    ) async throws {
+        let fixture = GuestFixtures()
+        let repository = ResumeRepositoryStub(
+            fixtures: fixture,
+            metadata: try #require(
+                PlaybackResumeMetadata(
+                    lastPlayedCID: 900_001,
+                    positionMilliseconds: positionMilliseconds
+                )
+            ),
+            includesSecondPage: false
+        )
+
+        let context = try await GuestVideoUseCase(
+            repository: repository
+        ).prepareVideo(bvid: fixture.bvid)
+
+        #expect(context.selectedPage.cid == 900_001)
+        #expect(context.resumePositionSeconds == nil)
+    }
+
+    @Test
+    func explicitPartSelectionDoesNotBounceToServerRecordedPart() async throws {
+        let fixture = GuestFixtures()
+        let repository = ResumeRepositoryStub(
+            fixtures: fixture,
+            metadata: try #require(
+                PlaybackResumeMetadata(
+                    lastPlayedCID: 900_002,
+                    positionMilliseconds: 42_500
+                )
+            )
+        )
+        let useCase = GuestVideoUseCase(repository: repository)
+        let initial = try await useCase.prepareVideo(bvid: fixture.bvid)
+
+        let selected = try await useCase.preparePage(in: initial, cid: 900_002)
+
+        #expect(selected.selectedPage.cid == 900_002)
+        #expect(selected.resumePositionSeconds == nil)
+    }
+
+    @Test
+    @MainActor
     func resettingVideoLoadClearsDetailAndStopsPlayer() async {
         let fixture = GuestFixtures()
         let player = RecordingPlayerEngine()
@@ -2558,6 +2677,63 @@ private actor GuestRepositoryStub: GuestContentRepository {
     }
 }
 
+private actor ResumeRepositoryStub: GuestContentRepository {
+    let fixtures: GuestFixtures
+    let metadata: PlaybackResumeMetadata
+    let includesSecondPage: Bool
+    private(set) var playbackCIDs: [Int64] = []
+
+    init(
+        fixtures: GuestFixtures,
+        metadata: PlaybackResumeMetadata,
+        includesSecondPage: Bool = true
+    ) {
+        self.fixtures = fixtures
+        self.metadata = metadata
+        self.includesSecondPage = includesSecondPage
+    }
+
+    func popular(page: Int, pageSize: Int) async throws -> PopularPage {
+        PopularPage(videos: [], pageNumber: page, pageSize: pageSize)
+    }
+
+    func searchVideos(keyword: String, page: Int) async throws -> SearchPage {
+        SearchPage(
+            videos: [],
+            pageNumber: page,
+            pageSize: 20,
+            totalResults: 0,
+            totalPages: 0
+        )
+    }
+
+    func videoDetail(for bvid: String) async throws -> VideoDetail {
+        fixtures.detail
+    }
+
+    func pages(for bvid: String) async throws -> [VideoPage] {
+        guard includesSecondPage else { return [fixtures.page] }
+        return [
+            fixtures.page,
+            VideoPage(
+                cid: 900_002,
+                index: 2,
+                title: "P2",
+                durationSeconds: 120
+            ),
+        ]
+    }
+
+    func playback(for bvid: String, cid: Int64) async throws -> VideoPlayback {
+        playbackCIDs.append(cid)
+        return VideoPlayback(
+            manifest: fixtures.playback.manifest,
+            mediaHeaders: fixtures.playback.mediaHeaders,
+            resumeMetadata: metadata
+        )
+    }
+}
+
 private actor PlaybackFailureRepositoryStub: GuestContentRepository {
     let fixtures: GuestFixtures
     let error: GuestApplicationError
@@ -3085,8 +3261,20 @@ private final class RecordingPlayerEngine: PlaybackControlling {
     private(set) var loadedIdentities: [PlaybackItemIdentity] = []
     private(set) var startedIdentities: [PlaybackItemIdentity] = []
     private(set) var startedIntents: [PlaybackLoadIntent] = []
+    private(set) var startedInitialPositions: [Double?] = []
+    private(set) var restartTokens: [PlaybackResumeToken] = []
     private(set) var pauseCallCount = 0
     private(set) var stopCallCount = 0
+    private let startOutcome: PlaybackStartOutcome
+    private let restartSucceeds: Bool
+
+    init(
+        startOutcome: PlaybackStartOutcome = .startedAtBeginning,
+        restartSucceeds: Bool = false
+    ) {
+        self.startOutcome = startOutcome
+        self.restartSucceeds = restartSucceeds
+    }
 
     func playbackFailureEvents() -> AsyncStream<PlaybackFailureEvent> {
         finishedPlaybackFailureEvents()
@@ -3103,11 +3291,22 @@ private final class RecordingPlayerEngine: PlaybackControlling {
 
     func beginPlayback(
         identity: PlaybackItemIdentity,
-        intent: PlaybackLoadIntent
-    ) -> Bool {
+        intent: PlaybackLoadIntent,
+        initialPositionSeconds: Double?
+    ) async -> PlaybackStartOutcome {
         startedIdentities.append(identity)
         startedIntents.append(intent)
-        return true
+        startedInitialPositions.append(initialPositionSeconds)
+        return startOutcome
+    }
+
+    func restartFromBeginning(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent,
+        resumeToken: PlaybackResumeToken
+    ) async -> Bool {
+        restartTokens.append(resumeToken)
+        return restartSucceeds
     }
 
     func pause() {
@@ -3143,8 +3342,15 @@ private final class SelectiveFailingPlayerEngine: PlaybackControlling {
 
     func beginPlayback(
         identity: PlaybackItemIdentity,
-        intent: PlaybackLoadIntent
-    ) -> Bool { true }
+        intent: PlaybackLoadIntent,
+        initialPositionSeconds: Double?
+    ) async -> PlaybackStartOutcome { .startedAtBeginning }
+
+    func restartFromBeginning(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent,
+        resumeToken: PlaybackResumeToken
+    ) async -> Bool { false }
 
     func pause() {}
 
@@ -3190,8 +3396,15 @@ private final class PostReadyFailurePlayer: PlaybackControlling {
 
     func beginPlayback(
         identity: PlaybackItemIdentity,
-        intent: PlaybackLoadIntent
-    ) -> Bool { true }
+        intent: PlaybackLoadIntent,
+        initialPositionSeconds: Double?
+    ) async -> PlaybackStartOutcome { .startedAtBeginning }
+
+    func restartFromBeginning(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent,
+        resumeToken: PlaybackResumeToken
+    ) async -> Bool { false }
 
     func pause() {}
 
@@ -3269,8 +3482,15 @@ private final class FailureBeforeLoadReturnsPlayer: PlaybackControlling {
 
     func beginPlayback(
         identity: PlaybackItemIdentity,
-        intent: PlaybackLoadIntent
-    ) -> Bool { true }
+        intent: PlaybackLoadIntent,
+        initialPositionSeconds: Double?
+    ) async -> PlaybackStartOutcome { .startedAtBeginning }
+
+    func restartFromBeginning(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent,
+        resumeToken: PlaybackResumeToken
+    ) async -> Bool { false }
 
     func pause() {}
 
@@ -3325,12 +3545,19 @@ private final class DelayedABAPlayback: PlaybackControlling {
 
     func beginPlayback(
         identity: PlaybackItemIdentity,
-        intent: PlaybackLoadIntent
-    ) -> Bool {
+        intent: PlaybackLoadIntent,
+        initialPositionSeconds: Double?
+    ) async -> PlaybackStartOutcome {
         startedIdentities.append(identity)
         startedIntents.append(intent)
-        return true
+        return .startedAtBeginning
     }
+
+    func restartFromBeginning(
+        identity: PlaybackItemIdentity,
+        intent: PlaybackLoadIntent,
+        resumeToken: PlaybackResumeToken
+    ) async -> Bool { false }
 
     func pause() {}
 

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/AVPlayerTimelineAdapterTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/AVPlayerTimelineAdapterTests.swift
@@ -7,6 +7,174 @@ import Testing
 struct AVPlayerTimelineAdapterTests {
     @Test
     @MainActor
+    func resolvedInitialPositionUsesMediaBoundsInsteadOfTargetDelta() {
+        #expect(
+            AVPlayerEngine.validatedResolvedInitialPosition(
+                CMTime(seconds: 37, preferredTimescale: 600),
+                durationSeconds: 300
+            ) == 37
+        )
+        #expect(
+            AVPlayerEngine.validatedResolvedInitialPosition(
+                CMTime(seconds: 0.25, preferredTimescale: 600),
+                durationSeconds: 300
+            ) == nil
+        )
+        #expect(
+            AVPlayerEngine.validatedResolvedInitialPosition(
+                CMTime(seconds: 299.96, preferredTimescale: 600),
+                durationSeconds: 300
+            ) == nil
+        )
+        #expect(
+            AVPlayerEngine.validatedResolvedInitialPosition(
+                .indefinite,
+                durationSeconds: 300
+            ) == nil
+        )
+    }
+
+    @Test
+    func interactionTrackerDoesNotInferIntentFromInFlightHLSSeekLanding() {
+        let tracker = PlaybackInteractionTracker()
+        tracker.allowInternalSeek(to: 42)
+
+        tracker.observeTimeJump(at: 42.25)
+        tracker.observeTimeJump(at: 10)
+        #expect(tracker.revision == 0)
+        tracker.completeInternalSeek(at: 37)
+
+        tracker.observeTimeJump(at: 10)
+        #expect(tracker.revision == 1)
+    }
+
+    @Test
+    func initialSystemZeroJumpDoesNotCountAsUserSeek() {
+        let tracker = PlaybackInteractionTracker()
+
+        tracker.observeTimeJump(at: 0)
+        tracker.observeTimeJump(at: 0.2)
+
+        #expect(tracker.revision == 0)
+        tracker.observeTimeJump(at: 0.3)
+        #expect(tracker.revision == 1)
+    }
+
+    @Test
+    func explicitPauseOrSeekAdvancesInteractionRevision() {
+        let tracker = PlaybackInteractionTracker()
+
+        tracker.markObserved()
+        tracker.markObserved()
+
+        #expect(tracker.hasObservedInteraction)
+        #expect(tracker.revision == 2)
+    }
+
+    @Test
+    func controlledRestartIsAnInteractionButIgnoresItsOwnTimeJump() {
+        let tracker = PlaybackInteractionTracker()
+
+        tracker.markObservedAllowingInternalSeek(to: 0)
+        let revision = tracker.revision
+        tracker.observeTimeJump(at: 0)
+
+        #expect(revision == 1)
+        #expect(tracker.revision == revision)
+    }
+
+    @Test
+    func pausedTransitionOnlyCountsAfterPlaybackSessionHasStarted() {
+        let tracker = PlaybackInteractionTracker()
+
+        tracker.observeTimeControlStatus(
+            isPaused: true,
+            isPlaying: false,
+            playbackRate: 0
+        )
+        #expect(tracker.revision == 0)
+
+        tracker.observeTimeControlStatus(
+            isPaused: false,
+            isPlaying: true,
+            playbackRate: 1
+        )
+        let playingRevision = tracker.revision
+        tracker.markObservedAllowingInternalSeek(to: 0)
+        let restartRevision = tracker.revision
+        tracker.observeTimeControlStatus(
+            isPaused: true,
+            isPlaying: false,
+            playbackRate: 0
+        )
+
+        #expect(playingRevision == 1)
+        #expect(restartRevision == 2)
+        #expect(tracker.revision == 3)
+    }
+
+    @Test
+    func internalPlayStartIgnoresBufferingButPauseStillCancelsCommit() {
+        let tracker = PlaybackInteractionTracker()
+        tracker.allowInternalPlayStart()
+
+        tracker.observeTimeControlStatus(
+            isPaused: false,
+            isPlaying: false,
+            playbackRate: 0
+        )
+        #expect(tracker.revision == 0)
+
+        tracker.observeTimeControlStatus(
+            isPaused: true,
+            isPlaying: false,
+            playbackRate: 0
+        )
+        #expect(tracker.revision == 1)
+    }
+
+    @Test
+    func playThenPauseDuringInitialSeekCancelsThePendingCommit() {
+        let tracker = PlaybackInteractionTracker()
+        tracker.allowInternalSeek(to: 42)
+
+        tracker.observeTimeControlStatus(
+            isPaused: false,
+            isPlaying: true,
+            playbackRate: 1
+        )
+        #expect(tracker.revision == 0)
+        tracker.observeTimeControlStatus(
+            isPaused: true,
+            isPlaying: false,
+            playbackRate: 0
+        )
+
+        #expect(tracker.revision == 1)
+    }
+
+    @Test
+    func requestedWaitingThenPauseDuringInitialSeekCancelsCommit() {
+        let tracker = PlaybackInteractionTracker()
+        tracker.allowInternalSeek(to: 42)
+
+        tracker.observeTimeControlStatus(
+            isPaused: false,
+            isPlaying: false,
+            playbackRate: 1
+        )
+        #expect(tracker.revision == 0)
+        tracker.observeTimeControlStatus(
+            isPaused: true,
+            isPlaying: false,
+            playbackRate: 0
+        )
+
+        #expect(tracker.revision == 1)
+    }
+
+    @Test
+    @MainActor
     func playImmediatelyUsesValidatedDefaultRateWhileWaitingForMedia() {
         let player = AVPlayer()
         player.defaultRate = 1.5

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
@@ -2454,23 +2454,29 @@ struct LoopbackPlaybackServerTests {
         )
 
         #expect(
-            !engine.beginPlayback(
+            await engine.beginPlayback(
                 identity: identity,
-                intent: PlaybackLoadIntent()
-            )
+                intent: PlaybackLoadIntent(),
+                initialPositionSeconds: nil
+            ) == .rejected
         )
         #expect(
-            !engine.beginPlayback(
+            await engine.beginPlayback(
                 identity: PlaybackItemIdentity(
                     bvid: "BV1StalePlayback",
                     cid: identity.cid
                 ),
-                intent: loadIntent
-            )
+                intent: loadIntent,
+                initialPositionSeconds: nil
+            ) == .rejected
         )
         engine.pause()
         #expect(
-            !engine.beginPlayback(identity: identity, intent: loadIntent)
+            await engine.beginPlayback(
+                identity: identity,
+                intent: loadIntent,
+                initialPositionSeconds: nil
+            ) == .rejected
         )
 
         engine.stop()
@@ -2482,7 +2488,11 @@ struct LoopbackPlaybackServerTests {
         )
         try await engine.seek(to: .milliseconds(100))
         #expect(
-            !engine.beginPlayback(identity: identity, intent: restartedIntent)
+            await engine.beginPlayback(
+                identity: identity,
+                intent: restartedIntent,
+                initialPositionSeconds: nil
+            ) == .rejected
         )
 
         engine.stop()
@@ -2496,15 +2506,74 @@ struct LoopbackPlaybackServerTests {
             ObjectIdentifier.init
         )
         #expect(
-            engine.beginPlayback(identity: identity, intent: playableIntent)
+            await engine.beginPlayback(
+                identity: identity,
+                intent: playableIntent,
+                initialPositionSeconds: nil
+            ) == .startedAtBeginning
         )
         #expect(
-            !engine.beginPlayback(identity: identity, intent: playableIntent)
+            await engine.beginPlayback(
+                identity: identity,
+                intent: playableIntent,
+                initialPositionSeconds: nil
+            ) == .rejected
         )
         try await waitUntilPlaybackTime(engine.player, reaches: 0.15)
         #expect(
             engine.player.currentItem.map(ObjectIdentifier.init)
                 == playableItemIdentity
+        )
+        engine.stop()
+
+        let resumeIntent = PlaybackLoadIntent()
+        try await engine.load(
+            request,
+            identity: identity,
+            intent: resumeIntent
+        )
+        let resumeOutcome = await engine.beginPlayback(
+            identity: identity,
+            intent: resumeIntent,
+            initialPositionSeconds: 0.3
+        )
+        let diagnosticDuration = engine.player.currentItem?.duration.seconds ?? -1
+        let diagnosticSeekableCount =
+            engine.player.currentItem?.seekableTimeRanges.count ?? -1
+        let diagnosticLoadedCount =
+            engine.player.currentItem?.loadedTimeRanges.count ?? -1
+        guard case .resumed(let position, let resumeToken, _) = resumeOutcome
+        else {
+            let diagnostic =
+                "有效首次断点未完成 seek-before-play；state=\(engine.currentTimelineSnapshot.state)，time=\(engine.player.currentTime().seconds)，duration=\(diagnosticDuration)，seekable=\(diagnosticSeekableCount)，loaded=\(diagnosticLoadedCount)"
+            Issue.record(Comment(rawValue: diagnostic))
+            engine.stop()
+            return
+        }
+        #expect(position >= 0.05)
+        #expect(engine.player.currentTime().seconds >= 0.05)
+        try await waitUntilPlaybackStarts(engine.player)
+
+        async let firstRestart = engine.restartFromBeginning(
+            identity: identity,
+            intent: resumeIntent,
+            resumeToken: resumeToken
+        )
+        async let overlappingRestart = engine.restartFromBeginning(
+            identity: identity,
+            intent: resumeIntent,
+            resumeToken: resumeToken
+        )
+        let restartResults = await [firstRestart, overlappingRestart]
+        #expect(restartResults.filter { $0 }.count == 1)
+        #expect(restartResults.filter { !$0 }.count == 1)
+        #expect(engine.player.currentTime().seconds < 0.25)
+        #expect(
+            !(await engine.restartFromBeginning(
+                identity: identity,
+                intent: resumeIntent,
+                resumeToken: resumeToken
+            ))
         )
         engine.stop()
     }
@@ -3884,6 +3953,20 @@ struct LoopbackPlaybackServerTests {
     ) async throws {
         for _ in 0..<100 {
             if player.currentTime().seconds >= target {
+                return
+            }
+            if player.currentItem?.status == .failed {
+                throw player.currentItem?.error
+                    ?? LoopbackFixtureError.itemFailedWithoutError
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        throw LoopbackFixtureError.timedOut
+    }
+
+    private func waitUntilPlaybackStarts(_ player: AVPlayer) async throws {
+        for _ in 0..<100 {
+            if player.timeControlStatus == .playing {
                 return
             }
             if player.currentItem?.status == .failed {

--- a/Scripts/check-project-contract.sh
+++ b/Scripts/check-project-contract.sh
@@ -25,6 +25,9 @@ project="BiliKitMac.xcodeproj/project.pbxproj"
 app="BiliKitMac/App/BiliKitMacApp.swift"
 entitlements="BiliKitMac/BiliKitMac.entitlements"
 package="Packages/BiliKitCore/Package.swift"
+ci_workflow=".github/workflows/ci.yml"
+app_source_roots="BiliKitMac/App/AppSourceRootViews.swift"
+player_host="BiliKitMac/Platform/PlayerHostView.swift"
 
 /usr/bin/plutil -lint "$project" >/dev/null || fail "Xcode 工程格式无效"
 /usr/bin/plutil -lint "$entitlements" >/dev/null || fail "entitlements 格式无效"
@@ -57,6 +60,9 @@ deployment=$(awk '/MACOSX_DEPLOYMENT_TARGET = / { total += 1; if ($0 !~ /15\.0;/
 set -- $deployment
 [ "$1" -gt 0 ] && [ "$2" -eq 0 ] || fail "Xcode target 必须统一支持 macOS 15"
 expect_count 1 '.macOS(.v15)' "$package" "Swift Package 必须支持 macOS 15"
+expect_count 1 'DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer' "$ci_workflow" "CI 必须显式使用统一的新 Xcode"
+expect_count 0 '#if compiler(>=6.2)' "$app_source_roots" "搜索栏不得为旧 SDK 保留编译期回退"
+expect_count 0 '#if compiler(>=6.2)' "$player_host" "播放器提示不得为旧 SDK 保留编译期回退"
 
 sh -n Scripts/run-quality-gates.sh || fail "质量 Gate 脚本语法无效"
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -109,6 +109,9 @@ BiliKit 是 macOS-first 的原生第三方 B 站浏览与播放客户端。v1 �
 - 登录态自动画质使用精确 legacy playurl endpoint 级 Cookie 授权；只有明确无本地凭据时
   保持匿名。凭据故障、HTTP 403/412 与业务拒绝不匿名降级，Cookie 不进入媒体、图片、
   相关推荐或 loopback。
+- 登录态进入详情时复用同一 playurl 响应的服务端分 P／毫秒断点，在首次发声和出帧前由
+  单一播放器完成定位再开播；匿名、无效、片尾和 CID 不匹配记录从头播放。播放器左下角以
+  当前 item token 约束的浮层提供“从头播放”操作，不增加本地进度持久化或历史写入。
 - 服务实际返回且 AVC/AAC decoder 可消费的全部 representations 继续进入既有单一
   `AVPlayerItem` 原生 ABR；没有手动画质菜单、双播放器或 4K 保证。
 

--- a/docs/adr/0003-raise-minimum-macos-to-15.md
+++ b/docs/adr/0003-raise-minimum-macos-to-15.md
@@ -18,6 +18,10 @@ CI 必须同时运行：
 - `macos-15`：代表最低支持运行时。
 - `macos-26`：代表当前开发运行时。
 
+两个 job 必须通过 `DEVELOPER_DIR` 显式使用同一套新 Xcode/SDK；矩阵只比较
+宿主运行时，不承诺旧 SDK 编译兼容。新 SDK 声明但要求新系统的 API 继续使用
+availability guard，以保持 macOS 15 deployment target。
+
 真实 B 站播放继续作为显式探针，而不是 PR 必过检查，因为游客 API、媒体 URL、样本和 CDN 行为均属于动态外部依赖。
 
 ## 影响

--- a/docs/development/QUALITY-GATES.md
+++ b/docs/development/QUALITY-GATES.md
@@ -15,7 +15,8 @@ sh Scripts/run-quality-gates.sh app
 Gate 每次使用私有临时目录保存 SwiftPM 与 Xcode 产物，退出时清理；不修改全局
 `xcode-select`。手写 `xcodebuild`、XCUI 和 App 启动也必须统一使用本任务唯一的临时产物
 根目录，并在任务结束时清理。其他 worktree 或旧共享 DerivedData 不算 fresh closure；仅用于
-临时运行时诊断时需注明证据边界。CI 使用同一入口。
+临时运行时诊断时需注明证据边界。CI 使用同一入口，并在 macOS 15/26
+宿主上显式选择同一套新 Xcode/SDK；这个矩阵不承诺旧 SDK 编译兼容。
 
 仅在明确的性能裁决中运行 Instruments/`xctrace`；事前限定问题、时长、次数和产物目录。
 摘要完成后默认删除 raw trace，并退出 Instruments、确认没有开放 trace、清理临时产物。

--- a/docs/security/M3-threat-model.md
+++ b/docs/security/M3-threat-model.md
@@ -110,6 +110,9 @@ Apple 将 Keychain 定位为替 App 安全存储小块秘密数据的加密数�
 - Cookie 在各 API 响应边界终止。`VideoPlayback.mediaHeaders`、媒体 CDN、图片、字幕正文
   与 loopback Range server 不得得到 Cookie；登录状态变化继续关闭当前播放，不在
   当前 item 上热换授权结果。
+- 同一已授权 playurl 响应中的 `last_play_cid` 与 `last_play_time` 只映射为当前进程内存中的
+  断点候选；匿名 provenance 必须丢弃这两个字段。候选只能匹配已解析的正 CID，位置按毫秒
+  转换并由分 P 时长裁剪；不写入本地存储，不因此增加写请求，也不向媒体链路传播账户信息。
 - AI 音轨现场探针只在内存读取受限语言目录，并通过生产 client 对每个目录项至多执行一次
   精确请求；不得再手工重复所选语言请求。A → B → A 生命周期验收中的 B 使用匿名公开
   playback，不扩大登录态请求集合。探针不保存语言标题、内容 identity、媒体 URL 或响应

--- a/docs/security/M4-data-privacy.md
+++ b/docs/security/M4-data-privacy.md
@@ -48,6 +48,10 @@ Cookie、token、二维码 key 和 refresh token 继续只由 `BiliAuth` 管理�
 - 账户读取 Cookie 必须在各 API 响应前终止；映射后的 playback manifest 与媒体 headers
   不保留 Cookie。DASH SIDX/媒体 Range、图片与 loopback 请求继续使用
   各自无认证 transport，不能从播放信息请求继承授权状态。
+- 登录态 playurl 可把同一响应中的服务端分 P 与毫秒位置映射为一次性的首次定位候选；匿名
+  响应不消费该账户字段。播放器在首次 `play` 前完成受 identity、load intent、item generation
+  与用户交互 revision 保护的 seek，切视频、切 P、暂停、拖动或 teardown 都能否决迟到提交。
+  该位置不落盘；本阶段不发送 heartbeat 或任何观看历史写请求。
 - 账户变化会由 App 级 owner 推进所有存活窗口 API transport 的 authentication epoch；各窗口
   的旧 Popular/Search 分页、视频详情、Related、UP 主签名、分 P、播放信息、字幕目录与弹幕
   响应不得越过该 epoch 写回。


### PR DESCRIPTION
## 变化

- 进入视频详情后，由当前播放 identity 的单一 load intent 驱动自动开播，保持单 `AppWindowOwner` / `AVPlayerEngine` / player host。
- 登录态读取服务端 `last_play_time` / `last_play_cid`，在首次 `play` 之前完成 seek；匿名响应不消费断点字段。
- 用 BVID/CID、load generation、intent、item identity、用户交互 revision 和 operation UUID 隔离切 P、A→B→A、Back、重试与迟到回调。
- 播放器左下角显示「从头播放」提示，5 秒后克制淡出；用户可回到 0 秒，且迟到 seek 不会覆盖新意图。
- 首次定位期间用立即不透明的黑幕、系统圆形进度指示和状态文字遮住 0 秒首帧；只在播放准备完成后淡出。
- CI 在 macOS 15/26 宿主上显式统一使用 Xcode 26.3 / Swift 6.2.4，删除为 Xcode 16.4 保留的 compiler gate 与 `weak var` 语法回退；macOS 15 运行时 availability fallback 继续保留。

## 原因与用户影响

详情页原有播放准备链路没有安全消费登录账户的服务端进度，而且 item ready、首次 seek 与 play 之间缺少一个能拒绝旧结果和用户新意图的事务边界。

本次后，用户从 Popular、Search、History、Related 进入详情时都走同一条播放生命周期；登录用户在有效断点存在时先定位再开播，匿名或无有效断点时直接从头开始。播放失败不会因断点逻辑匿名 fallback，也不会将服务端定位误当成观看历史写入成功。

## 安全边界

- 断点元数据仅通过已有 typed `accountRead` 能力读取，并受 authenticated session epoch 约束。
- 媒体 CDN、loopback、字幕、弹幕与第三方 URL 不携带 Cookie。
- 本 PR 不实现 heartbeat、历史写入或任何 `accountWrite` 能力，不保存本地观看进度。
- 不记录 Cookie、CSRF、完整认证 URL、具体观看内容或请求 body。

## 验证

- 最新 `origin/main` 上重放后运行 `sh Scripts/run-quality-gates.sh app`。
- static Gate 通过。
- Package：451 tests / 46 suites 通过。
- App build-for-testing 通过。
- App tests 通过；`SignedKeychainSmokeTests` 按环境条件跳过。
- GitHub Actions 最终 run `31784390423` 全绿：macOS 15.7.7 与 macOS 26.5.2 两个 job 均确认 Xcode 26.3（17C529）/ Swift 6.2.4，且无旧 `weak var` 警告。
- 重放前的同功能正式开发签名 Debug 构建已人工验证自动开播、服务端断点定位、「从头播放」与黑幕提示；这不替代重放后最终树的再次签名运行时验证。

## 未覆盖

- 真实服务端 heartbeat / 观看历史写入与长期稳定性。
- 最终重放树的正式签名真实媒体 runtime。
- 真人 VoiceOver / Full Keyboard Access、全屏、系统媒体键与性能证据。
