### PR TITLE
refactor(video): 精简原生视频卡片文字与封面层级

### DIFF
--- a/BiliKitMac/Platform/NativeVideoCardTextLayout.swift
+++ b/BiliKitMac/Platform/NativeVideoCardTextLayout.swift
@@ -1,0 +1,153 @@
+import AppKit
+import CoreText
+import QuartzCore
+
+enum NativeVideoCardTextLayout {
+    static func singleLineWidth(
+        _ text: String,
+        font: NSFont
+    ) -> CGFloat {
+        guard !text.isEmpty else { return 0 }
+        let line = CTLineCreateWithAttributedString(
+            NSAttributedString(
+                string: text,
+                attributes: [.font: font]
+            )
+        )
+        return ceil(CGFloat(CTLineGetTypographicBounds(line, nil, nil, nil)))
+    }
+
+    static func ctFont(_ font: NSFont) -> CTFont {
+        CTFontCreateWithFontDescriptor(
+            font.fontDescriptor as CTFontDescriptor,
+            font.pointSize,
+            nil
+        )
+    }
+
+    nonisolated(unsafe) static let disabledLayerActions: [String: CAAction] = [
+        "bounds": NSNull(),
+        "contents": NSNull(),
+        "font": NSNull(),
+        "fontSize": NSNull(),
+        "foregroundColor": NSNull(),
+        "hidden": NSNull(),
+        "position": NSNull(),
+        "string": NSNull(),
+    ]
+}
+
+@MainActor
+final class NativeVideoCardTextRenderer {
+    let titleLayer = NativeVideoCardTextRenderer.makeTextLayer(isWrapped: true)
+    let footerLeadingLayer = NativeVideoCardTextRenderer.makeTextLayer(isWrapped: false)
+    let footerTrailingLayer = NativeVideoCardTextRenderer.makeTextLayer(
+        isWrapped: false,
+        alignmentMode: .right
+    )
+
+    private var title = ""
+    private var footerLeading = ""
+    private var footerTrailing: String?
+    private var footerTrailingWidthCache = NativeVideoSingleLineWidthCache()
+
+    var showsFooterTrailing: Bool { footerTrailing != nil }
+
+    func install(in parentLayer: CALayer) {
+        parentLayer.addSublayer(titleLayer)
+        parentLayer.addSublayer(footerLeadingLayer)
+        parentLayer.addSublayer(footerTrailingLayer)
+        reset()
+    }
+
+    func configure(
+        title: String,
+        footerLeading: String,
+        footerTrailing: String?
+    ) {
+        self.title = title
+        self.footerLeading = footerLeading
+        self.footerTrailing = footerTrailing
+    }
+
+    func reset() {
+        title = ""
+        footerLeading = ""
+        footerTrailing = nil
+        footerTrailingWidthCache.reset()
+        for textLayer in [titleLayer, footerLeadingLayer, footerTrailingLayer] {
+            textLayer.removeAllAnimations()
+            textLayer.string = nil
+            textLayer.isHidden = true
+        }
+    }
+
+    func trailingWidth(font: NSFont) -> CGFloat {
+        guard let footerTrailing else { return 0 }
+        return footerTrailingWidthCache.width(for: footerTrailing) {
+            NativeVideoCardTextLayout.singleLineWidth(footerTrailing, font: font)
+        }
+    }
+
+    func layout(
+        titleFrame: NSRect,
+        footerLeadingFrame: NSRect,
+        footerTrailingFrame: NSRect,
+        titleFont: NSFont,
+        footerFont: NSFont,
+        appearance: NSAppearance,
+        contentsScale: CGFloat
+    ) {
+        let colors = Self.resolvedColors(appearance: appearance)
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+
+        titleLayer.frame = titleFrame
+        titleLayer.contentsScale = contentsScale
+        titleLayer.font = NativeVideoCardTextLayout.ctFont(titleFont)
+        titleLayer.fontSize = titleFont.pointSize
+        titleLayer.foregroundColor = colors.title.cgColor
+        titleLayer.string = title.isEmpty ? nil : title
+        titleLayer.isHidden = title.isEmpty
+
+        let footerCTFont = NativeVideoCardTextLayout.ctFont(footerFont)
+        for footerLayer in [footerLeadingLayer, footerTrailingLayer] {
+            footerLayer.contentsScale = contentsScale
+            footerLayer.font = footerCTFont
+            footerLayer.fontSize = footerFont.pointSize
+            footerLayer.foregroundColor = colors.footer.cgColor
+        }
+        footerLeadingLayer.frame = footerLeadingFrame
+        footerLeadingLayer.string = footerLeading.isEmpty ? nil : footerLeading
+        footerLeadingLayer.isHidden = footerLeading.isEmpty
+        footerTrailingLayer.frame = footerTrailingFrame
+        footerTrailingLayer.string = footerTrailing
+        footerTrailingLayer.isHidden = footerTrailing == nil
+
+        CATransaction.commit()
+    }
+
+    private static func makeTextLayer(
+        isWrapped: Bool,
+        alignmentMode: CATextLayerAlignmentMode = .left
+    ) -> CATextLayer {
+        let textLayer = CATextLayer()
+        textLayer.isWrapped = isWrapped
+        textLayer.truncationMode = .end
+        textLayer.alignmentMode = alignmentMode
+        textLayer.actions = NativeVideoCardTextLayout.disabledLayerActions
+        return textLayer
+    }
+
+    private static func resolvedColors(
+        appearance: NSAppearance
+    ) -> (title: NSColor, footer: NSColor) {
+        var title = NSColor.labelColor
+        var footer = NSColor.secondaryLabelColor
+        appearance.performAsCurrentDrawingAppearance {
+            title = NSColor.labelColor.usingColorSpace(.deviceRGB) ?? .labelColor
+            footer = NSColor.secondaryLabelColor.usingColorSpace(.deviceRGB) ?? .secondaryLabelColor
+        }
+        return (title, footer)
+    }
+}

--- a/BiliKitMac/Platform/NativeVideoCardView.swift
+++ b/BiliKitMac/Platform/NativeVideoCardView.swift
@@ -1,6 +1,5 @@
 import AppKit
 import CoreGraphics
-import CoreText
 import QuartzCore
 
 extension NSUserInterfaceItemIdentifier {
@@ -43,11 +42,6 @@ enum NativeVideoCardLayout {
             ),
             trailing: trailingWidth
         )
-    }
-
-    @MainActor
-    static func measuredSingleLineWidth(_ field: NSTextField) -> CGFloat {
-        ceil(field.fittingSize.width)
     }
 }
 
@@ -282,20 +276,17 @@ final class NativeVideoCollectionItem: NSCollectionViewItem {
 
 @MainActor
 final class NativeVideoCardView: NSView {
-    private let coverContainer = NativeVideoFlippedView()
-    private let cover = NativeVideoLayerImageView(
-        placeholderSystemSymbolName: "photo",
-        placeholderTintColor: .tertiaryLabelColor,
-        placeholderFrameSize: NSSize(width: 32, height: 32)
-    )
-    private let coverOverlay = NativeVideoCoverOverlayView()
+    private let cover = NativeVideoMergedCoverView(frame: .zero)
     private let avatar = NativeVideoLayerImageView(
         placeholderSystemSymbolName: "person.crop.circle.fill",
         placeholderTintColor: .quaternaryLabelColor
     )
-    private let title = NativeVideoTextField(wrappingLabelWithString: "")
-    private let footerLeading = NativeVideoTextField(labelWithString: "")
-    private let footerTrailing = NativeVideoTextField(labelWithString: "")
+    private let titleFont = NSFont.systemFont(
+        ofSize: NSFont.preferredFont(forTextStyle: .title3).pointSize,
+        weight: .medium
+    )
+    private let footerFont = NSFont.preferredFont(forTextStyle: .body)
+    private let textRenderer = NativeVideoCardTextRenderer()
     private var activation: (() -> Void)?
     private var hoverDidChange: ((Bool) -> Void)?
     private var trackingArea: NSTrackingArea?
@@ -304,7 +295,6 @@ final class NativeVideoCardView: NSView {
     private var selected = false
     private var showsKeyboardFocus = false
     private var isPressed = false
-    private var footerTrailingWidthCache = NativeVideoSingleLineWidthCache()
 
     override var isFlipped: Bool { true }
 
@@ -312,37 +302,11 @@ final class NativeVideoCardView: NSView {
         super.init(frame: frame)
         wantsLayer = true
         layer?.cornerRadius = 12
-        coverContainer.wantsLayer = true
-        coverContainer.layer?.cornerRadius = 10
-        coverContainer.layer?.masksToBounds = true
-        coverContainer.layer?.backgroundColor =
-            NSColor.secondaryLabelColor
-            .withAlphaComponent(0.12).cgColor
-
-        title.font = .systemFont(
-            ofSize: NSFont.preferredFont(forTextStyle: .title3).pointSize,
-            weight: .medium
-        )
-        title.maximumNumberOfLines = 2
-        title.lineBreakMode = .byWordWrapping
-        title.cell?.wraps = true
-        title.cell?.truncatesLastVisibleLine = true
-        for field in [footerLeading, footerTrailing] {
-            field.font = .preferredFont(forTextStyle: .body)
-            field.textColor = .secondaryLabelColor
-            field.lineBreakMode = .byTruncatingTail
-        }
-        footerTrailing.alignment = .right
-
-        addSubview(coverContainer)
-        for subview in [cover, coverOverlay] {
-            subview.setAccessibilityElement(false)
-            coverContainer.addSubview(subview)
-        }
-        for subview in [avatar, title, footerLeading, footerTrailing] {
+        for subview in [cover, avatar] {
             subview.setAccessibilityElement(false)
             addSubview(subview)
         }
+        if let layer { textRenderer.install(in: layer) }
         setAccessibilityElement(true)
         setAccessibilityRole(.button)
     }
@@ -360,14 +324,15 @@ final class NativeVideoCardView: NSView {
         self.hoverDidChange = hoverDidChange
         showsAvatar = presentation.showsAvatar
         avatar.isHidden = !showsAvatar
-        title.stringValue = presentation.title
-        coverOverlay.configure(
+        cover.configure(
             metrics: presentation.coverMetrics,
             trailingText: presentation.coverTrailingText
         )
-        footerLeading.stringValue = presentation.footerLeadingText
-        footerTrailing.stringValue = presentation.footerTrailingText ?? ""
-        footerTrailing.isHidden = presentation.footerTrailingText == nil
+        textRenderer.configure(
+            title: presentation.title,
+            footerLeading: presentation.footerLeadingText,
+            footerTrailing: presentation.footerTrailingText
+        )
         setAccessibilityLabel(presentation.accessibilityLabel)
         setAccessibilityHelp(presentation.accessibilityHelp)
         setAccessibilityValue(selected ? "已选择" : nil)
@@ -410,12 +375,8 @@ final class NativeVideoCardView: NSView {
         layer?.removeAllAnimations()
         let wasHovered = isHovered
         activation = nil
-        title.stringValue = ""
-        coverOverlay.reset()
-        footerLeading.stringValue = ""
-        footerTrailing.stringValue = ""
-        footerTrailing.isHidden = true
-        footerTrailingWidthCache.reset()
+        cover.reset()
+        textRenderer.reset()
         avatar.isHidden = false
         showsAvatar = true
         setCover(nil, animated: false)
@@ -434,53 +395,68 @@ final class NativeVideoCardView: NSView {
 
     func refreshEnvironmentAppearance() {
         updateInteractionAppearance(animated: false)
+        needsLayout = true
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        needsLayout = true
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        needsLayout = true
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        needsLayout = true
     }
 
     override func layout() {
         super.layout()
         let coverHeight = floor(bounds.width * 9 / 16)
-        coverContainer.frame = NSRect(x: 0, y: 0, width: bounds.width, height: coverHeight)
-        cover.frame = coverContainer.bounds
-        let overlayHeight = min(NativeVideoCoverOverlayView.preferredHeight, coverHeight)
-        coverOverlay.frame = NSRect(
-            x: 0,
-            y: coverHeight - overlayHeight,
-            width: bounds.width,
-            height: overlayHeight
-        )
+        cover.frame = NSRect(x: 0, y: 0, width: bounds.width, height: coverHeight)
         let textX: CGFloat = showsAvatar ? 44 : 0
         avatar.frame = NSRect(x: 0, y: coverHeight + 10, width: 34, height: 34)
         avatar.layer?.cornerRadius = 17
-        title.frame = NSRect(
+        let titleFrame = NSRect(
             x: textX,
             y: coverHeight + 10,
             width: max(1, bounds.width - textX),
             height: 47
         )
         let footerY = coverHeight + 63
-        let trailingWidth =
-            footerTrailing.isHidden
-            ? 0
-            : footerTrailingWidthCache.width(for: footerTrailing.stringValue) {
-                NativeVideoCardLayout.measuredSingleLineWidth(footerTrailing)
-            }
+        let showsFooterTrailing = textRenderer.showsFooterTrailing
+        let trailingWidth = textRenderer.trailingWidth(font: footerFont)
         let footerWidths = NativeVideoCardLayout.footerWidths(
             contentWidth: bounds.width,
             leadingInset: textX,
             trailingIntrinsicWidth: trailingWidth,
-            showsTrailing: !footerTrailing.isHidden
+            showsTrailing: showsFooterTrailing
         )
-        footerLeading.frame = NSRect(
+        let footerLeadingFrame = NSRect(
             x: textX,
             y: footerY,
             width: footerWidths.leading,
             height: 21
         )
-        footerTrailing.frame = NSRect(
+        let footerTrailingFrame = NSRect(
             x: max(textX, bounds.width - footerWidths.trailing),
             y: footerY,
             width: footerWidths.trailing,
             height: 21
+        )
+        textRenderer.layout(
+            titleFrame: titleFrame,
+            footerLeadingFrame: footerLeadingFrame,
+            footerTrailingFrame: footerTrailingFrame,
+            titleFont: titleFont,
+            footerFont: footerFont,
+            appearance: effectiveAppearance,
+            contentsScale: window?.backingScaleFactor
+                ?? NSScreen.main?.backingScaleFactor
+                ?? 2
         )
     }
 
@@ -600,12 +576,7 @@ final class NativeVideoCardView: NSView {
 }
 
 @MainActor
-private final class NativeVideoTextField: NSTextField {
-    override func hitTest(_ point: NSPoint) -> NSView? { nil }
-}
-
-@MainActor
-private final class NativeVideoCoverOverlayView: NSView {
+private final class NativeVideoMergedCoverView: NSView {
     private struct SymbolRasterKey: Hashable {
         let name: String
         let pointSize: CGFloat
@@ -615,7 +586,7 @@ private final class NativeVideoCoverOverlayView: NSView {
         let tintName: String
     }
 
-    static let preferredHeight: CGFloat = 35
+    private static let overlayHeight: CGFloat = 35
     private static let metricBottomOffset: CGFloat = 22
     private static let leadingInset: CGFloat = 9
     private static let iconSize: CGFloat = 12
@@ -627,42 +598,52 @@ private final class NativeVideoCoverOverlayView: NSView {
     private static let maximumSymbolRasterCount = 32
     private static var symbolRasters: [SymbolRasterKey: CGImage] = [:]
 
+    private let placeholderLayer = CALayer()
+    private let imageLayer = CALayer()
     private let gradientLayer = CAGradientLayer()
     private let metricIconLayers = [CALayer(), CALayer()]
     private let metricTextLayers = [
-        NativeVideoCoverOverlayView.makeTextLayer(
+        NativeVideoMergedCoverView.makeTextLayer(
             font: .systemFont(ofSize: 12, weight: .medium)
         ),
-        NativeVideoCoverOverlayView.makeTextLayer(
+        NativeVideoMergedCoverView.makeTextLayer(
             font: .systemFont(ofSize: 12, weight: .medium)
         ),
     ]
     private let metricCells = [
-        NativeVideoCoverOverlayView.makeLabelCell(
+        NativeVideoMergedCoverView.makeLabelCell(
             font: .systemFont(ofSize: 12, weight: .medium)
         ),
-        NativeVideoCoverOverlayView.makeLabelCell(
+        NativeVideoMergedCoverView.makeLabelCell(
             font: .systemFont(ofSize: 12, weight: .medium)
         ),
     ]
     private var metricIconNames: [String?] = [nil, nil]
     private var metricSizes: [NSSize] = [.zero, .zero]
     private var metricCount = 0
-    private let trailingCell = NativeVideoCoverOverlayView.makeLabelCell(
+    private let trailingCell = NativeVideoMergedCoverView.makeLabelCell(
         font: .monospacedDigitSystemFont(ofSize: 12, weight: .medium)
     )
-    private let trailingTextLayer = NativeVideoCoverOverlayView.makeTextLayer(
+    private let trailingTextLayer = NativeVideoMergedCoverView.makeTextLayer(
         font: .monospacedDigitSystemFont(ofSize: 12, weight: .medium),
         alignmentMode: .right
     )
     private var trailingSize = NSSize.zero
+    private var imageGeneration: UInt64 = 0
 
     override var isFlipped: Bool { true }
 
     override init(frame: NSRect) {
         super.init(frame: frame)
         wantsLayer = true
+        layer?.cornerRadius = 10
         layer?.masksToBounds = true
+        layer?.backgroundColor = Self.backgroundColor
+
+        placeholderLayer.contentsGravity = .center
+        placeholderLayer.actions = Self.imageLayerActions
+        imageLayer.contentsGravity = .resizeAspectFill
+        imageLayer.actions = Self.imageLayerActions
         gradientLayer.colors = [
             NSColor.clear.cgColor,
             NSColor.black.withAlphaComponent(0.78).cgColor,
@@ -670,6 +651,8 @@ private final class NativeVideoCoverOverlayView: NSView {
         gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
         gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
         gradientLayer.actions = Self.disabledLayerActions
+        layer?.addSublayer(placeholderLayer)
+        layer?.addSublayer(imageLayer)
         layer?.addSublayer(gradientLayer)
         for index in metricIconLayers.indices {
             let iconLayer = metricIconLayers[index]
@@ -683,6 +666,8 @@ private final class NativeVideoCoverOverlayView: NSView {
         }
         trailingTextLayer.isHidden = true
         layer?.addSublayer(trailingTextLayer)
+        refreshPlaceholderImage()
+        setImage(nil, animated: false)
         updateContentsScale()
         setAccessibilityElement(false)
     }
@@ -734,13 +719,44 @@ private final class NativeVideoCoverOverlayView: NSView {
         trailingTextLayer.string = nil
         trailingTextLayer.isHidden = true
         trailingSize = .zero
+        setImage(nil, animated: false)
         needsLayout = true
+    }
+
+    func setImage(_ image: CGImage?, animated: Bool) {
+        imageGeneration &+= 1
+        let generation = imageGeneration
+        imageLayer.removeAnimation(forKey: "native-video-image.fade")
+        imageLayer.contents = image
+        imageLayer.opacity = 1
+        guard
+            image != nil,
+            animated,
+            !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        else {
+            placeholderLayer.isHidden = image != nil
+            return
+        }
+        placeholderLayer.isHidden = false
+        let animation = CABasicAnimation(keyPath: "opacity")
+        animation.fromValue = 0
+        animation.toValue = 1
+        animation.duration = 0.15
+        animation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+        CATransaction.begin()
+        CATransaction.setCompletionBlock { [weak self] in
+            guard let self, imageGeneration == generation else { return }
+            placeholderLayer.isHidden = true
+        }
+        imageLayer.add(animation, forKey: "native-video-image.fade")
+        CATransaction.commit()
     }
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         updateContentsScale()
         refreshMetricIcons()
+        needsLayout = true
     }
 
     override func viewDidChangeBackingProperties() {
@@ -751,12 +767,29 @@ private final class NativeVideoCoverOverlayView: NSView {
 
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
+        layer?.backgroundColor = Self.backgroundColor
+        refreshPlaceholderImage()
         refreshMetricIcons()
     }
 
     override func layout() {
         super.layout()
-        gradientLayer.frame = bounds
+        let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2
+        let placeholderSize = NSSize(width: 32, height: 32)
+        placeholderLayer.frame = NSRect(
+            x: floor((bounds.width - placeholderSize.width) / 2),
+            y: floor((bounds.height - placeholderSize.height) / 2),
+            width: placeholderSize.width,
+            height: placeholderSize.height
+        )
+        imageLayer.frame = bounds
+        let overlayHeight = min(Self.overlayHeight, bounds.height)
+        gradientLayer.frame = NSRect(
+            x: 0,
+            y: bounds.height - overlayHeight,
+            width: bounds.width,
+            height: overlayHeight
+        )
         let metricY = bounds.height - Self.metricBottomOffset
         var nextX = Self.leadingInset
         for index in 0..<metricCount {
@@ -785,6 +818,8 @@ private final class NativeVideoCoverOverlayView: NSView {
                 height: trailingSize.height
             )
         }
+        placeholderLayer.contentsScale = scale
+        imageLayer.contentsScale = scale
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? { nil }
@@ -814,8 +849,20 @@ private final class NativeVideoCoverOverlayView: NSView {
         needsLayout = true
     }
 
+    private func refreshPlaceholderImage() {
+        let configuration = NSImage.SymbolConfiguration(
+            paletteColors: [.tertiaryLabelColor]
+        )
+        placeholderLayer.contents = NSImage(
+            systemSymbolName: "photo",
+            accessibilityDescription: nil
+        )?.withSymbolConfiguration(configuration)
+    }
+
     private func updateContentsScale() {
         let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2
+        placeholderLayer.contentsScale = scale
+        imageLayer.contentsScale = scale
         for textLayer in metricTextLayers {
             textLayer.contentsScale = scale
         }
@@ -841,11 +888,7 @@ private final class NativeVideoCoverOverlayView: NSView {
         alignmentMode: CATextLayerAlignmentMode = .left
     ) -> CATextLayer {
         let textLayer = CATextLayer()
-        textLayer.font = CTFontCreateWithFontDescriptor(
-            font.fontDescriptor as CTFontDescriptor,
-            font.pointSize,
-            nil
-        )
+        textLayer.font = NativeVideoCardTextLayout.ctFont(font)
         textLayer.fontSize = font.pointSize
         textLayer.foregroundColor = NSColor.white.cgColor
         textLayer.alignmentMode = alignmentMode
@@ -861,6 +904,14 @@ private final class NativeVideoCoverOverlayView: NSView {
         "hidden": NSNull(),
         "position": NSNull(),
         "string": NSNull(),
+    ]
+
+    private static let imageLayerActions: [String: CAAction] = [
+        "bounds": NSNull(),
+        "contents": NSNull(),
+        "hidden": NSNull(),
+        "opacity": NSNull(),
+        "position": NSNull(),
     ]
 
     private static func symbolRaster(
@@ -939,11 +990,10 @@ private final class NativeVideoCoverOverlayView: NSView {
         symbolRasters[key] = raster
         return raster
     }
-}
 
-@MainActor
-private final class NativeVideoFlippedView: NSView {
-    override var isFlipped: Bool { true }
+    private static var backgroundColor: CGColor {
+        NSColor.secondaryLabelColor.withAlphaComponent(0.12).cgColor
+    }
 }
 
 @MainActor

--- a/BiliKitMacTests/NativeVideoCardTextLayoutTests.swift
+++ b/BiliKitMacTests/NativeVideoCardTextLayoutTests.swift
@@ -1,0 +1,122 @@
+import AppKit
+import QuartzCore
+import Testing
+
+@testable import BiliKit
+
+struct NativeVideoCardTextLayoutTests {
+    @Test
+    func singleLineMeasurementHandlesEmptyAndMixedText() {
+        let font = NSFont.preferredFont(forTextStyle: .body)
+
+        #expect(NativeVideoCardTextLayout.singleLineWidth("", font: font) == 0)
+        let width = NativeVideoCardTextLayout.singleLineWidth(
+            "中日韩 English 👨‍👩‍👧‍👦",
+            font: font
+        )
+        #expect(width.isFinite)
+        #expect(width > 0)
+    }
+
+    @Test @MainActor
+    func rendererUsesPlainStringsAndClearsReusedContent() throws {
+        let renderer = NativeVideoCardTextRenderer()
+        let parent = CALayer()
+        renderer.install(in: parent)
+        renderer.configure(
+            title: "旧标题 old 👨‍👩‍👧‍👦",
+            footerLeading: "旧作者",
+            footerTrailing: "昨天"
+        )
+        let appearance = try #require(NSAppearance(named: .aqua))
+        layout(renderer, scale: 2, appearance: appearance)
+
+        #expect(renderer.titleLayer.string as? String == "旧标题 old 👨‍👩‍👧‍👦")
+        #expect(renderer.footerLeadingLayer.string as? String == "旧作者")
+        #expect(renderer.footerTrailingLayer.string as? String == "昨天")
+        #expect(!(renderer.titleLayer.string is NSAttributedString))
+        #expect(renderer.titleLayer.isWrapped)
+        #expect(renderer.titleLayer.truncationMode == .end)
+        #expect(!renderer.footerLeadingLayer.isWrapped)
+        #expect(renderer.footerLeadingLayer.truncationMode == .end)
+        #expect(renderer.footerTrailingLayer.alignmentMode == .right)
+        #expect(renderer.titleLayer.contentsScale == 2)
+
+        renderer.configure(
+            title: "新标题",
+            footerLeading: "新作者",
+            footerTrailing: nil
+        )
+        layout(renderer, scale: 1, appearance: appearance)
+        #expect(renderer.titleLayer.string as? String == "新标题")
+        #expect(renderer.footerLeadingLayer.string as? String == "新作者")
+        #expect(renderer.footerTrailingLayer.string == nil)
+        #expect(renderer.footerTrailingLayer.isHidden)
+        #expect(renderer.titleLayer.contentsScale == 1)
+
+        renderer.reset()
+        for layer in [
+            renderer.titleLayer,
+            renderer.footerLeadingLayer,
+            renderer.footerTrailingLayer,
+        ] {
+            #expect(layer.string == nil)
+            #expect(layer.isHidden)
+            #expect(layer.animationKeys()?.isEmpty ?? true)
+        }
+    }
+
+    @Test @MainActor
+    func cardRetainsAggregatedButtonAccessibilityAcrossReset() {
+        let card = NativeVideoCardView(
+            frame: NSRect(x: 0, y: 0, width: 224, height: 210)
+        )
+        card.configure(
+            presentation: NativeVideoCardPresentation(
+                id: "BV-text-layer",
+                title: "标题",
+                coverURL: nil,
+                avatarURL: nil,
+                showsAvatar: false,
+                coverMetrics: [],
+                coverTrailingText: nil,
+                footerLeadingText: "作者",
+                footerTrailingText: nil,
+                accessibilityLabel: "标题，作者",
+                accessibilityHelp: "播放视频"
+            ),
+            hoverDidChange: { _ in },
+            activation: {}
+        )
+
+        #expect(card.accessibilityRole() == .button)
+        #expect(card.accessibilityLabel() == "标题，作者")
+        #expect(card.accessibilityHelp() == "播放视频")
+
+        card.reset()
+        #expect(card.accessibilityRole() == .button)
+        #expect(card.accessibilityLabel() == nil)
+        #expect(card.accessibilityHelp() == nil)
+        #expect(card.accessibilityValue() == nil)
+    }
+
+    @MainActor
+    private func layout(
+        _ renderer: NativeVideoCardTextRenderer,
+        scale: CGFloat,
+        appearance: NSAppearance
+    ) {
+        renderer.layout(
+            titleFrame: NSRect(x: 44, y: 136, width: 180, height: 47),
+            footerLeadingFrame: NSRect(x: 44, y: 189, width: 100, height: 21),
+            footerTrailingFrame: NSRect(x: 152, y: 189, width: 72, height: 21),
+            titleFont: .systemFont(
+                ofSize: NSFont.preferredFont(forTextStyle: .title3).pointSize,
+                weight: .medium
+            ),
+            footerFont: .preferredFont(forTextStyle: .body),
+            appearance: appearance,
+            contentsScale: scale
+        )
+    }
+}

--- a/BiliKitMacTests/PopularNativeGridTests.swift
+++ b/BiliKitMacTests/PopularNativeGridTests.swift
@@ -639,26 +639,20 @@ struct PopularNativeGridTests {
         #expect(content.accessibilityLabel == history.accessibilityLabel)
     }
 
-    @Test @MainActor
-    func historyFooterUsesAppKitFittingWidthWithoutTruncatingTime() throws {
-        let field = NSTextField(labelWithString: "12月31日 19:59")
-        field.font = .preferredFont(forTextStyle: .body)
-        field.lineBreakMode = .byTruncatingTail
-        let measured = NativeVideoCardLayout.measuredSingleLineWidth(field)
+    @Test
+    func historyFooterReservesMeasuredWidthWithoutTruncatingTime() {
+        let measured = NativeVideoCardTextLayout.singleLineWidth(
+            "12月31日 19:59",
+            font: .preferredFont(forTextStyle: .body)
+        )
         let widths = NativeVideoCardLayout.footerWidths(
             contentWidth: 300,
             leadingInset: 0,
             trailingIntrinsicWidth: measured,
             showsTrailing: true
         )
-        let cell = try #require(field.cell)
-        let expansion = cell.expansionFrame(
-            withFrame: NSRect(x: 0, y: 0, width: widths.trailing, height: 21),
-            in: field
-        )
 
         #expect(widths.trailing == measured)
-        #expect(expansion.isEmpty)
         #expect(widths.leading + widths.trailing + NativeVideoCardLayout.footerSpacing == 300)
     }
 

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/RemoteVideoTitleNormalizer.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/RemoteVideoTitleNormalizer.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// 把远端列表接口中的 HTML-escaped 视频标题一次性规范为语义纯文本。
+enum RemoteVideoTitleNormalizer {
+    static func plainText(_ value: String) -> String {
+        decodingHTMLEntities(in: value)
+    }
+
+    static func searchResult(_ value: String) -> String {
+        decodingHTMLEntities(in: strippingTags(from: value))
+    }
+
+    private static func decodingHTMLEntities(in value: String) -> String {
+        guard value.contains("&") else { return value }
+
+        var result = ""
+        result.reserveCapacity(value.count)
+        var index = value.startIndex
+        while index < value.endIndex {
+            guard value[index] == "&" else {
+                result.append(value[index])
+                index = value.index(after: index)
+                continue
+            }
+
+            let entityStart = value.index(after: index)
+            let maximumEnd =
+                value.index(
+                    entityStart,
+                    offsetBy: 32,
+                    limitedBy: value.endIndex
+                ) ?? value.endIndex
+            guard
+                let semicolon = value[entityStart..<maximumEnd]
+                    .firstIndex(of: ";"),
+                let decoded = decodedEntity(value[entityStart..<semicolon])
+            else {
+                result.append("&")
+                index = entityStart
+                continue
+            }
+
+            result.append(decoded)
+            index = value.index(after: semicolon)
+        }
+        return result
+    }
+
+    private static func decodedEntity(_ entity: Substring) -> String? {
+        switch entity {
+        case "amp":
+            return "&"
+        case "apos":
+            return "'"
+        case "gt":
+            return ">"
+        case "lt":
+            return "<"
+        case "nbsp":
+            return "\u{00A0}"
+        case "quot":
+            return "\""
+        default:
+            return decodedNumericEntity(entity)
+        }
+    }
+
+    private static func decodedNumericEntity(_ entity: Substring) -> String? {
+        guard entity.first == "#" else { return nil }
+        let numeric = entity.dropFirst()
+        let radix: Int
+        let digits: Substring
+        if numeric.first == "x" || numeric.first == "X" {
+            radix = 16
+            digits = numeric.dropFirst()
+        } else {
+            radix = 10
+            digits = numeric
+        }
+        guard
+            !digits.isEmpty,
+            let value = UInt32(digits, radix: radix),
+            let scalar = UnicodeScalar(value),
+            scalar.properties.generalCategory != .control
+        else {
+            return nil
+        }
+        return String(scalar)
+    }
+
+    private static func strippingTags(from value: String) -> String {
+        var result = ""
+        var isInsideTag = false
+        for character in value {
+            switch character {
+            case "<":
+                isInsideTag = true
+            case ">":
+                isInsideTag = false
+            default:
+                if !isInsideTag {
+                    result.append(character)
+                }
+            }
+        }
+        return result
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/SearchPayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/SearchPayloads.swift
@@ -60,7 +60,7 @@ struct SearchVideoPayload: Decodable, Sendable {
         }
         return SearchVideo(
             bvid: bvid,
-            title: Self.strippingTags(title),
+            title: RemoteVideoTitleNormalizer.searchResult(title),
             coverURL: WebImageURL.parse(pic),
             owner: VideoOwner(
                 id: mid,
@@ -75,24 +75,6 @@ struct SearchVideoPayload: Decodable, Sendable {
             durationSeconds: Self.durationSeconds(duration),
             publishedAt: Date(timeIntervalSince1970: TimeInterval(pubdate))
         )
-    }
-
-    private static func strippingTags(_ value: String) -> String {
-        var result = ""
-        var isInsideTag = false
-        for character in value {
-            switch character {
-            case "<":
-                isInsideTag = true
-            case ">":
-                isInsideTag = false
-            default:
-                if !isInsideTag {
-                    result.append(character)
-                }
-            }
-        }
-        return result
     }
 
     private static func durationSeconds(_ value: String) -> Int? {

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/VideoEndpointPayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/VideoEndpointPayloads.swift
@@ -27,7 +27,7 @@ struct PopularVideoPayload: Decodable, Sendable {
         }
         return PopularVideo(
             bvid: bvid,
-            title: title,
+            title: RemoteVideoTitleNormalizer.plainText(title),
             coverURL: WebImageURL.parse(pic),
             owner: owner.model(),
             statistics: stat.model(),
@@ -62,7 +62,7 @@ struct RelatedVideoPayload: Decodable, Sendable {
         }
         return RelatedVideo(
             bvid: bvid,
-            title: title,
+            title: RemoteVideoTitleNormalizer.plainText(title),
             coverURL: pic.flatMap(WebImageURL.parse),
             ownerName: owner.name,
             viewCount: stat.view,

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/WatchHistoryPayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/WatchHistoryPayloads.swift
@@ -117,7 +117,7 @@ struct WatchHistoryItemPayload: Decodable, Sendable {
             : min(progress, duration)
         return WatchHistoryItem(
             bvid: bvid,
-            title: title,
+            title: RemoteVideoTitleNormalizer.plainText(title),
             coverURL: WebImageURL.parse(cover),
             owner: VideoOwner(
                 id: authorID,

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
@@ -18,6 +18,7 @@ struct BiliAPIClientTests {
         #expect(page.hasMore)
         #expect(page.videos.count == 2)
         #expect(page.videos[0].bvid == "BV1FixtureA1")
+        #expect(page.videos[0].title == "合成热门样本 'A' <测试>")
         #expect(page.videos[0].owner.name == "测试作者甲")
         #expect(page.videos[0].statistics.viewCount == 12_345)
         #expect(page.videos[0].coverURL?.scheme == "https")
@@ -282,6 +283,7 @@ struct BiliAPIClientTests {
         let videos = try await client.relatedVideos(to: "BV1FixtureA1")
 
         #expect(videos.map(\.bvid) == ["BV1RelatedA1", "BV1RelatedB2"])
+        #expect(videos[0].title == "合成相关推荐 'A' <测试>")
         #expect(videos[0].ownerName == "相关作者甲")
         #expect(videos[0].viewCount == 22_222)
         #expect(videos[0].durationSeconds == 222)
@@ -454,7 +456,7 @@ struct BiliAPIClientTests {
 
         #expect(page.totalResults == 3)
         #expect(page.videos.count == 2)
-        #expect(page.videos[0].title == "学习macOS 的第一步")
+        #expect(page.videos[0].title == "学习macOS 'A' <测试>")
         #expect(page.videos[0].durationSeconds == 3_723)
         #expect(page.videos[0].coverURL?.scheme == "https")
         #expect(page.videos[1].durationSeconds == 754)
@@ -1477,6 +1479,7 @@ struct BiliAPIClientTests {
         let page = try await client.watchHistory(pageSize: 2)
 
         #expect(page.items.map(\.bvid) == ["BV1HistoryA1", "BV1HistoryB2"])
+        #expect(page.items[0].title == "手写历史视频 '甲' <测试>")
         #expect(page.items[0].progressSeconds == 125)
         #expect(page.items[1].progressSeconds == 300)
         #expect(page.items[0].coverURL?.scheme == "https")

--- a/Packages/BiliKitCore/Tests/BiliAPITests/Fixtures/history.json
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/Fixtures/history.json
@@ -11,7 +11,7 @@
     },
     "list": [
       {
-        "title": "手写历史视频甲",
+        "title": "手写历史视频 &#x27;甲&#x27; &lt;测试&gt;",
         "cover": "//i0.hdslb.com/bfs/archive/FIXTURE_HISTORY_A.jpg",
         "author_name": "测试作者甲",
         "author_face": "//i1.hdslb.com/bfs/face/FIXTURE_HISTORY_AUTHOR_A.jpg",

--- a/Packages/BiliKitCore/Tests/BiliAPITests/Fixtures/popular.json
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/Fixtures/popular.json
@@ -6,7 +6,7 @@
     "list": [
       {
         "bvid": "BV1FixtureA1",
-        "title": "合成热门样本 A",
+        "title": "合成热门样本 &#x27;A&#x27; &lt;测试&gt;",
         "pic": "http://images.example.invalid/cover-a.jpg",
         "owner": {
           "mid": 10001,

--- a/Packages/BiliKitCore/Tests/BiliAPITests/Fixtures/related.json
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/Fixtures/related.json
@@ -4,7 +4,7 @@
   "data": [
     {
       "bvid": "BV1RelatedA1",
-      "title": "合成相关推荐 A",
+      "title": "合成相关推荐 &#39;A&#39; &lt;测试&gt;",
       "pic": "//image.example.invalid/related-a.jpg",
       "owner": { "name": "相关作者甲" },
       "stat": { "view": 22222, "danmaku": 222 },

--- a/Packages/BiliKitCore/Tests/BiliAPITests/Fixtures/search.json
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/Fixtures/search.json
@@ -11,7 +11,7 @@
       {
         "type": "video",
         "bvid": "BV1SearchA01",
-        "title": "学习<em class=\"keyword\">macOS</em> 的第一步",
+        "title": "学习<em class=\"keyword\">macOS</em> &#x27;A&#x27; &lt;测试&gt;",
         "description": "手写的脱敏搜索结果。",
         "pic": "//images.example.invalid/search-a.jpg",
         "author": "测试作者甲",

--- a/Packages/BiliKitCore/Tests/BiliAPITests/RemoteVideoTitleNormalizerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/RemoteVideoTitleNormalizerTests.swift
@@ -1,0 +1,49 @@
+import Testing
+
+@testable import BiliAPI
+
+struct RemoteVideoTitleNormalizerTests {
+    @Test
+    func plainTextDecodesNamedDecimalAndHexEntitiesOnce() {
+        let cases = [
+            ("Tom&#x27;s", "Tom's"),
+            ("A &lt; B &gt; C", "A < B > C"),
+            ("A &amp; B &quot;C&quot; &apos;D&apos;", "A & B \"C\" 'D'"),
+            ("&#39;&#x27;&#X1F600;", "''😀"),
+            ("A&nbsp;B", "A\u{00A0}B"),
+            ("&amp;lt;", "&lt;"),
+        ]
+
+        for (input, expected) in cases {
+            #expect(RemoteVideoTitleNormalizer.plainText(input) == expected)
+        }
+    }
+
+    @Test
+    func malformedAndUnknownEntitiesRemainLiteral() {
+        let cases = [
+            "&unknown;",
+            "&amp",
+            "&#;",
+            "&#x;",
+            "&#xD800;",
+            "&#x110000;",
+            "&#0;",
+            "&#10;",
+        ]
+
+        for value in cases {
+            #expect(RemoteVideoTitleNormalizer.plainText(value) == value)
+        }
+    }
+
+    @Test
+    func searchResultStripsMarkupBeforeDecodingEntities() {
+        let title = "学习<em class=\"keyword\">macOS</em> &#x27;A&#x27; &lt;测试&gt; &amp;lt;"
+
+        #expect(
+            RemoteVideoTitleNormalizer.searchResult(title)
+                == "学习macOS 'A' <测试> &lt;"
+        )
+    }
+}


### PR DESCRIPTION
## 变更

- 将 `NativeVideoCardView` 的标题、左 footer 和右 footer 改为 plain-string `CATextLayer`，保留两行标题、单行 footer、截断、像素对齐、appearance/scale 刷新和 reset 清空契约。
- 落地已验证的 merged cover View 方案 D，减少封面容器 View/Layer 层级；overlay 文字与图标仍保持独立，没有带入被否决的合并或自绘方案。
- 在 `BiliAPI/Remote` payload → model 边界单次解码列表标题中的常见 HTML entity，统一修复 Popular、Search、History、Related 卡片显示 `&#x27;`、`&lt;`、`&gt;` 等转义文本的问题。
- 为稳定的文字布局、reset/刷新与远端标题规范化契约补充定向测试。

## 原因与影响

原生视频卡片原先仍保留三个 `NSTextField`，在长滚动场景中产生额外 CPU 和视图层级成本。已完成的 A/B spike 支持 plain-string `CATextLayer` 与 cover 方案 D 进入生产，同时否决严格 Core Text 双行布局、文字层合并和 overlay 自绘扁平化。

此外，列表接口返回的标题实体此前基本按原字符串进入卡片 renderer，因此列表会显示 HTML 转义文本；详情页重新请求另一份标题，所以不受影响。本次在远端数据转换边界恢复语义文本，renderer 与详情链路无需增加特殊处理。

用户可见结果是 Popular、Search、History、Related 共用卡片的文字渲染更轻量，封面层级更少，常见标题实体显示为正常字符。BVID identity、generation/revision、防旧结果、图片任务取消、reuse、hover/selection/focus 和聚合 accessibility button 契约保持不变。

## 明确边界

- 未修改 `NativeVideoImagePipeline`、CDN URL、640×360 WebP、解码尺寸、缓存、预取或图片任务策略。
- 未实现严格 Core Text 双行算法，未合并全部文字层或 overlay 文字，未做 overlay 自绘扁平化。
- 标题实体规范化只支持明确 allowlist 的常见 named entity 和带分号数字实体，不宣称完整 HTML5 entity 兼容。
- 未引入性能 harness、DEBUG 开关、AX test ID 或脆弱的内部层级/截图断言。

## 验证

- 原生卡片生产切片的 fresh App Gate 通过。
- 标题规范化定向测试：3 tests / 1 suite 通过。
- `BiliAPIClientTests`：67 tests / 1 suite 通过，覆盖四个真实 client + fixture 映射入口。
- fresh Package Gate：452 tests / 46 suites 通过，包含架构、秘密、工程、格式与 diff 检查。
- 当前 Debug App 重新构建成功并可启动。
- 两轮聚焦独立代码评审均为 no findings。

未使用真实接口样本验证完整实体集合；标题修复后未重复执行完整 UI/AX 人工矩阵，renderer 与 AX 树本身未改。
