### PR TITLE
fix(video): 稳定原生卡片简中文字形

### DIFF
--- a/BiliKitMac/Platform/NativeVideoCardTextLayout.swift
+++ b/BiliKitMac/Platform/NativeVideoCardTextLayout.swift
@@ -4,6 +4,13 @@ import QuartzCore
 
 enum NativeVideoCardTextLayout {
     static let typesettingLanguage = "zh-Hans"
+    static let languageDescriptorAttribute: String = {
+        #if compiler(>=6.3)
+            kCTFontDescriptorLanguageAttribute as String
+        #else
+            "CTFontDescriptorLanguageAttribute"
+        #endif
+    }()
 
     static func singleLineWidth(
         _ text: String,
@@ -32,7 +39,7 @@ enum NativeVideoCardTextLayout {
         let descriptor = CTFontDescriptorCreateCopyWithAttributes(
             font.fontDescriptor as CTFontDescriptor,
             [
-                kCTFontDescriptorLanguageAttribute: typesettingLanguage
+                languageDescriptorAttribute: typesettingLanguage
             ] as CFDictionary
         )
         return CTFontCreateWithFontDescriptor(

--- a/BiliKitMac/Platform/NativeVideoCardTextLayout.swift
+++ b/BiliKitMac/Platform/NativeVideoCardTextLayout.swift
@@ -3,23 +3,40 @@ import CoreText
 import QuartzCore
 
 enum NativeVideoCardTextLayout {
+    static let typesettingLanguage = "zh-Hans"
+
     static func singleLineWidth(
         _ text: String,
         font: NSFont
+    ) -> CGFloat {
+        singleLineWidth(text, font: languageAwareCTFont(font))
+    }
+
+    static func singleLineWidth(
+        _ text: String,
+        font: CTFont
     ) -> CGFloat {
         guard !text.isEmpty else { return 0 }
         let line = CTLineCreateWithAttributedString(
             NSAttributedString(
                 string: text,
-                attributes: [.font: font]
+                attributes: [
+                    kCTFontAttributeName as NSAttributedString.Key: font
+                ]
             )
         )
         return ceil(CGFloat(CTLineGetTypographicBounds(line, nil, nil, nil)))
     }
 
-    static func ctFont(_ font: NSFont) -> CTFont {
-        CTFontCreateWithFontDescriptor(
+    static func languageAwareCTFont(_ font: NSFont) -> CTFont {
+        let descriptor = CTFontDescriptorCreateCopyWithAttributes(
             font.fontDescriptor as CTFontDescriptor,
+            [
+                kCTFontDescriptorLanguageAttribute: typesettingLanguage
+            ] as CFDictionary
+        )
+        return CTFontCreateWithFontDescriptor(
+            descriptor,
             font.pointSize,
             nil
         )
@@ -50,6 +67,8 @@ final class NativeVideoCardTextRenderer {
     private var footerLeading = ""
     private var footerTrailing: String?
     private var footerTrailingWidthCache = NativeVideoSingleLineWidthCache()
+    private var cachedTitleFont: (source: NSFont, resolved: CTFont)?
+    private var cachedFooterFont: (source: NSFont, resolved: CTFont)?
 
     var showsFooterTrailing: Bool { footerTrailing != nil }
 
@@ -84,6 +103,7 @@ final class NativeVideoCardTextRenderer {
 
     func trailingWidth(font: NSFont) -> CGFloat {
         guard let footerTrailing else { return 0 }
+        let font = resolvedFooterFont(for: font)
         return footerTrailingWidthCache.width(for: footerTrailing) {
             NativeVideoCardTextLayout.singleLineWidth(footerTrailing, font: font)
         }
@@ -104,13 +124,13 @@ final class NativeVideoCardTextRenderer {
 
         titleLayer.frame = titleFrame
         titleLayer.contentsScale = contentsScale
-        titleLayer.font = NativeVideoCardTextLayout.ctFont(titleFont)
+        titleLayer.font = resolvedTitleFont(for: titleFont)
         titleLayer.fontSize = titleFont.pointSize
         titleLayer.foregroundColor = colors.title.cgColor
         titleLayer.string = title.isEmpty ? nil : title
         titleLayer.isHidden = title.isEmpty
 
-        let footerCTFont = NativeVideoCardTextLayout.ctFont(footerFont)
+        let footerCTFont = resolvedFooterFont(for: footerFont)
         for footerLayer in [footerLeadingLayer, footerTrailingLayer] {
             footerLayer.contentsScale = contentsScale
             footerLayer.font = footerCTFont
@@ -125,6 +145,25 @@ final class NativeVideoCardTextRenderer {
         footerTrailingLayer.isHidden = footerTrailing == nil
 
         CATransaction.commit()
+    }
+
+    private func resolvedTitleFont(for font: NSFont) -> CTFont {
+        if let cachedTitleFont, cachedTitleFont.source == font {
+            return cachedTitleFont.resolved
+        }
+        let resolved = NativeVideoCardTextLayout.languageAwareCTFont(font)
+        cachedTitleFont = (font, resolved)
+        return resolved
+    }
+
+    private func resolvedFooterFont(for font: NSFont) -> CTFont {
+        if let cachedFooterFont, cachedFooterFont.source == font {
+            return cachedFooterFont.resolved
+        }
+        let resolved = NativeVideoCardTextLayout.languageAwareCTFont(font)
+        cachedFooterFont = (font, resolved)
+        footerTrailingWidthCache.reset()
+        return resolved
     }
 
     private static func makeTextLayer(

--- a/BiliKitMac/Platform/NativeVideoCardView.swift
+++ b/BiliKitMac/Platform/NativeVideoCardView.swift
@@ -888,7 +888,7 @@ private final class NativeVideoMergedCoverView: NSView {
         alignmentMode: CATextLayerAlignmentMode = .left
     ) -> CATextLayer {
         let textLayer = CATextLayer()
-        textLayer.font = NativeVideoCardTextLayout.ctFont(font)
+        textLayer.font = NativeVideoCardTextLayout.languageAwareCTFont(font)
         textLayer.fontSize = font.pointSize
         textLayer.foregroundColor = NSColor.white.cgColor
         textLayer.alignmentMode = alignmentMode

--- a/BiliKitMacTests/NativeVideoCardTextLayoutTests.swift
+++ b/BiliKitMacTests/NativeVideoCardTextLayoutTests.swift
@@ -13,10 +13,16 @@ struct NativeVideoCardTextLayoutTests {
         let language =
             CTFontDescriptorCopyAttribute(
                 descriptor,
-                kCTFontDescriptorLanguageAttribute
+                NativeVideoCardTextLayout.languageDescriptorAttribute as CFString
             ) as? String
 
         #expect(language == NativeVideoCardTextLayout.typesettingLanguage)
+        #if compiler(>=6.3)
+            #expect(
+                NativeVideoCardTextLayout.languageDescriptorAttribute
+                    == kCTFontDescriptorLanguageAttribute as String
+            )
+        #endif
         #expect(CTFontGetSize(font) == source.pointSize)
         let sourceCTFont = CTFontCreateWithFontDescriptor(
             source.fontDescriptor as CTFontDescriptor,
@@ -76,7 +82,7 @@ struct NativeVideoCardTextLayoutTests {
         #expect(
             CTFontDescriptorCopyAttribute(
                 CTFontCopyFontDescriptor(titleFont),
-                kCTFontDescriptorLanguageAttribute
+                NativeVideoCardTextLayout.languageDescriptorAttribute as CFString
             ) as? String == NativeVideoCardTextLayout.typesettingLanguage
         )
         #expect(

--- a/BiliKitMacTests/NativeVideoCardTextLayoutTests.swift
+++ b/BiliKitMacTests/NativeVideoCardTextLayoutTests.swift
@@ -6,6 +6,36 @@ import Testing
 
 struct NativeVideoCardTextLayoutTests {
     @Test
+    func languageAwareFontCopiesSourceDescriptorAndAddsSimplifiedChineseLanguage() {
+        let source = NSFont.systemFont(ofSize: 15, weight: .medium)
+        let font = NativeVideoCardTextLayout.languageAwareCTFont(source)
+        let descriptor = CTFontCopyFontDescriptor(font)
+        let language =
+            CTFontDescriptorCopyAttribute(
+                descriptor,
+                kCTFontDescriptorLanguageAttribute
+            ) as? String
+
+        #expect(language == NativeVideoCardTextLayout.typesettingLanguage)
+        #expect(CTFontGetSize(font) == source.pointSize)
+        let sourceCTFont = CTFontCreateWithFontDescriptor(
+            source.fontDescriptor as CTFontDescriptor,
+            source.pointSize,
+            nil
+        )
+        #expect(CTFontGetSymbolicTraits(font) == CTFontGetSymbolicTraits(sourceCTFont))
+        let sourceWeight =
+            (CTFontCopyTraits(sourceCTFont) as NSDictionary)[
+                kCTFontWeightTrait
+            ] as? NSNumber
+        let resolvedWeight =
+            (CTFontCopyTraits(font) as NSDictionary)[
+                kCTFontWeightTrait
+            ] as? NSNumber
+        #expect(resolvedWeight == sourceWeight)
+    }
+
+    @Test
     func singleLineMeasurementHandlesEmptyAndMixedText() {
         let font = NSFont.preferredFont(forTextStyle: .body)
 
@@ -41,6 +71,23 @@ struct NativeVideoCardTextLayoutTests {
         #expect(renderer.footerLeadingLayer.truncationMode == .end)
         #expect(renderer.footerTrailingLayer.alignmentMode == .right)
         #expect(renderer.titleLayer.contentsScale == 2)
+        let titleFont = renderer.titleLayer.font as! CTFont
+        let footerFont = renderer.footerTrailingLayer.font as! CTFont
+        #expect(
+            CTFontDescriptorCopyAttribute(
+                CTFontCopyFontDescriptor(titleFont),
+                kCTFontDescriptorLanguageAttribute
+            ) as? String == NativeVideoCardTextLayout.typesettingLanguage
+        )
+        #expect(
+            renderer.trailingWidth(font: .preferredFont(forTextStyle: .body))
+                == NativeVideoCardTextLayout.singleLineWidth("昨天", font: footerFont)
+        )
+        let cachedTitleFont = renderer.titleLayer.font
+        let cachedFooterFont = renderer.footerTrailingLayer.font
+        layout(renderer, scale: 2, appearance: appearance)
+        #expect(renderer.titleLayer.font === cachedTitleFont)
+        #expect(renderer.footerTrailingLayer.font === cachedFooterFont)
 
         renderer.configure(
             title: "新标题",


### PR DESCRIPTION
## 变化

- 从现有 title/footer `NSFont` descriptor 复制 CTFont，并通过公开的 `kCTFontDescriptorLanguageAttribute = "zh-Hans"` 固定简体中文字体 fallback。
- 分别缓存 title/footer CTFont，footer trailing 测量和实际 layer 渲染复用同一字体。
- 将 cover overlay 的播放量、弹幕量与 trailing text 接入同一语言感知 helper。
- 保持 `CATextLayer.string` 为 plain `String`，保留两行标题、footer 单行尾截断、复用/reset、appearance 与 contentsScale 行为。
- 增加稳定契约测试，覆盖语言 descriptor、字号/traits、plain-string 路径、字体复用、同字体测量/渲染和 AX reset。

## 原因

App 的本地化与 SwiftUI typesetting language 已是 `zh-Hans`，但原生卡片使用 plain-string `CATextLayer` 时，CTFont descriptor 没有语言信息，Core Text 仍可能按系统首选语言选择日文字形 fallback。

采用已批准的候选 C，不硬编码 PingFang/Hiragino 等具体字体名，也不使用 `NSAttributedString + kCTLanguageAttributeName`。此前受控 spike 中，C 的软件合成 CPU 约 +2.9%、median frame 约 +1.1%，明显低于候选 B 的约 +17.4%；60 Hz 无回归，240 Hz 仅有小幅尾部代价。

## 用户影响

Popular、Search、History 与 Related 共用的原生视频卡片会稳定遵循简体中文 CJK 字形偏好；Latin、数字、emoji 继续沿用系统字体与 fallback 语义。系统菜单、本地化配置、AX 树、图片 pipeline 和交互状态未修改。

## 验证

- 定向 `NativeVideoCardTextLayoutTests`：4/4 通过。
- `sh Scripts/run-quality-gates.sh app`：通过。
  - 静态架构、秘密、工程契约、格式和 diff 检查通过。
  - Swift Package：452 个测试通过。
  - App build-for-testing 与全部 `BiliKitMacTests` 通过。
  - 禁签名 Gate 中的 Keychain smoke 按设计跳过。
- 聚焦 code review：未发现阻断或需修改 finding。

## 未覆盖边界

当前机器缺少 `com.shiinayane.BiliKit` 的开发 provisioning profile，因此没有修改签名设置或启用自动 profile 下载。真实 Popular/Search/History/Related 字形矩阵、2–5 列与 224 pt shelf、跨屏/Increase Contrast、真人 VoiceOver/FKA，以及当前 production build 的短 60/240 Hz 滚动回归仍待签名环境复核。未运行 Instruments。