### PR TITLE
feat(video): 接入统一选集选择

### DIFF
--- a/BiliKitMac/App/AppNavigationCoordinator.swift
+++ b/BiliKitMac/App/AppNavigationCoordinator.swift
@@ -11,9 +11,19 @@ struct PlaybackDestination: Hashable {
     let surfaceID: UUID
 }
 
+struct PlaybackSelectionIntent: Hashable {
+    let bvid: String
+    let preferredCID: Int64?
+
+    init(bvid: String, preferredCID: Int64? = nil) {
+        self.bvid = bvid
+        self.preferredCID = preferredCID
+    }
+}
+
 private struct ActivePlayback: Equatable {
     let destination: PlaybackDestination
-    var bvid: String
+    var intent: PlaybackSelectionIntent
 }
 
 @MainActor
@@ -40,16 +50,19 @@ final class AppNavigationCoordinator {
         }
     }
     var currentPlaybackBVID: String? {
-        activePlayback?.bvid
+        activePlayback?.intent.bvid
+    }
+    var currentPlaybackIntent: PlaybackSelectionIntent? {
+        activePlayback?.intent
     }
     var searchDraft = ""
 
     private var activePlayback: ActivePlayback?
-    @ObservationIgnored private let startPlayback: (String) -> Void
+    @ObservationIgnored private let startPlayback: (PlaybackSelectionIntent) -> Void
     @ObservationIgnored private let stopPlayback: () -> Void
 
     init(
-        startPlayback: @escaping (String) -> Void,
+        startPlayback: @escaping (PlaybackSelectionIntent) -> Void,
         stopPlayback: @escaping () -> Void
     ) {
         self.startPlayback = startPlayback
@@ -58,24 +71,28 @@ final class AppNavigationCoordinator {
 
     /// 首次打开建立播放 surface；连续打开其他视频只替换媒体 identity。
     func openPlayback(_ bvid: String) {
-        guard !bvid.isEmpty else { return }
-        guard currentPlaybackBVID != bvid else { return }
+        openPlayback(PlaybackSelectionIntent(bvid: bvid))
+    }
+
+    func openPlayback(_ intent: PlaybackSelectionIntent) {
+        guard !intent.bvid.isEmpty else { return }
+        guard currentPlaybackIntent != intent else { return }
 
         if var activePlayback {
-            activePlayback.bvid = bvid
+            activePlayback.intent = intent
             self.activePlayback = activePlayback
         } else {
             activePlayback = ActivePlayback(
                 destination: PlaybackDestination(surfaceID: UUID()),
-                bvid: bvid
+                intent: intent
             )
         }
-        startPlayback(bvid)
+        startPlayback(intent)
     }
 
     func retryPlayback() {
-        guard let bvid = currentPlaybackBVID else { return }
-        startPlayback(bvid)
+        guard let intent = currentPlaybackIntent else { return }
+        startPlayback(intent)
     }
 
     /// 登出只关闭当前播放，不改变来源 Tab 或尚未提交的搜索草稿。

--- a/BiliKitMac/App/AppShellView.swift
+++ b/BiliKitMac/App/AppShellView.swift
@@ -121,7 +121,15 @@ struct AppShellView: View {
     private func playbackSidebar(for bvid: String) -> some View {
         PlaybackContextSidebar(
             model: videoModel,
-            onRetry: navigationCoordinator.retryPlayback
+            onRetry: navigationCoordinator.retryPlayback,
+            onSelectPlayback: { bvid, preferredCID in
+                navigationCoordinator.openPlayback(
+                    PlaybackSelectionIntent(
+                        bvid: bvid,
+                        preferredCID: preferredCID
+                    )
+                )
+            }
         )
     }
 

--- a/BiliKitMac/App/AppWindowOwner.swift
+++ b/BiliKitMac/App/AppWindowOwner.swift
@@ -27,8 +27,11 @@ final class AppWindowOwner {
         let videoModel = environment.makeVideoViewModel()
         let danmakuModel = environment.makeDanmakuViewModel()
         let navigationCoordinator = AppNavigationCoordinator(
-            startPlayback: { bvid in
-                videoModel.loadVideo(bvid)
+            startPlayback: { intent in
+                AppWindowOwner.handlePlaybackSelection(
+                    intent,
+                    with: videoModel
+                )
             },
             stopPlayback: {
                 videoModel.reset()
@@ -47,6 +50,26 @@ final class AppWindowOwner {
             openEnvironment: environment.open,
             closeEnvironment: environment.close
         )
+    }
+
+    static func handlePlaybackSelection(
+        _ intent: PlaybackSelectionIntent,
+        with videoModel: GuestVideoViewModel
+    ) {
+        guard videoModel.presentedBVID == intent.bvid,
+            let preferredCID = intent.preferredCID
+        else {
+            videoModel.loadVideo(
+                intent.bvid,
+                preferredCID: intent.preferredCID
+            )
+            return
+        }
+        if videoModel.failedPageCID == preferredCID {
+            videoModel.retry()
+        } else {
+            videoModel.selectPage(cid: preferredCID)
+        }
     }
 
     init(

--- a/BiliKitMacTests/AppNavigationCoordinatorTests.swift
+++ b/BiliKitMacTests/AppNavigationCoordinatorTests.swift
@@ -131,7 +131,7 @@ struct AppNavigationCoordinatorTests {
     func replacementKeepsSurfaceSourceAndDraftWhileOrderingSideEffects() {
         var events: [String] = []
         let coordinator = AppNavigationCoordinator(
-            startPlayback: { events.append("start:\($0)") },
+            startPlayback: { events.append("start:\($0.bvid)") },
             stopPlayback: { events.append("stop") }
         )
         coordinator.selectedTab = .search
@@ -161,7 +161,7 @@ struct AppNavigationCoordinatorTests {
     func nonemptyPathWriteCannotForgeOrReplacePlayback() {
         var events: [String] = []
         let coordinator = AppNavigationCoordinator(
-            startPlayback: { events.append("start:\($0)") },
+            startPlayback: { events.append("start:\($0.bvid)") },
             stopPlayback: { events.append("stop") }
         )
         let forgedDestination = PlaybackDestination(surfaceID: UUID())
@@ -198,20 +198,43 @@ struct AppNavigationCoordinatorTests {
 
     @Test
     @MainActor
-    func retryKeepsSurfaceAndMediaIdentity() {
-        var events: [String] = []
+    func sameBVIDDifferentCIDIsANewAtomicSelectionIntent() {
+        var intents: [PlaybackSelectionIntent] = []
         let coordinator = AppNavigationCoordinator(
-            startPlayback: { events.append("start:\($0)") },
-            stopPlayback: { events.append("stop") }
+            startPlayback: { intents.append($0) },
+            stopPlayback: {}
         )
 
-        coordinator.openPlayback("BV1RetryA")
+        coordinator.openPlayback(
+            PlaybackSelectionIntent(bvid: "BV1SameA", preferredCID: 101)
+        )
+        coordinator.openPlayback(
+            PlaybackSelectionIntent(bvid: "BV1SameA", preferredCID: 102)
+        )
+
+        #expect(intents.map(\.preferredCID) == [101, 102])
+        #expect(coordinator.currentPlaybackIntent?.preferredCID == 102)
+        #expect(coordinator.playbackPath.count == 1)
+    }
+
+    @Test
+    @MainActor
+    func retryKeepsSurfaceAndMediaIdentity() {
+        var intents: [PlaybackSelectionIntent] = []
+        let coordinator = AppNavigationCoordinator(
+            startPlayback: { intents.append($0) },
+            stopPlayback: {}
+        )
+
+        coordinator.openPlayback(
+            PlaybackSelectionIntent(bvid: "BV1RetryA", preferredCID: 202)
+        )
         let destination = coordinator.playbackPath.first
         coordinator.retryPlayback()
 
         #expect(coordinator.playbackPath.first == destination)
         #expect(coordinator.currentPlaybackBVID == "BV1RetryA")
-        #expect(events == ["start:BV1RetryA", "start:BV1RetryA"])
+        #expect(intents.map(\.preferredCID) == [202, 202])
     }
 
     @Test
@@ -282,7 +305,7 @@ struct AppNavigationCoordinatorTests {
     func emptyBVIDDoesNotCreatePlaybackState() {
         var events: [String] = []
         let coordinator = AppNavigationCoordinator(
-            startPlayback: { events.append("start:\($0)") },
+            startPlayback: { events.append("start:\($0.bvid)") },
             stopPlayback: { events.append("stop") }
         )
 

--- a/BiliKitMacTests/VideoDetailLifecycleTests.swift
+++ b/BiliKitMacTests/VideoDetailLifecycleTests.swift
@@ -112,8 +112,11 @@ struct VideoDetailLifecycleTests {
             )
         )
         let coordinator = AppNavigationCoordinator(
-            startPlayback: { bvid in
-                videoModel.loadVideo(bvid)
+            startPlayback: { intent in
+                videoModel.loadVideo(
+                    intent.bvid,
+                    preferredCID: intent.preferredCID
+                )
             },
             stopPlayback: {
                 videoModel.reset()
@@ -164,8 +167,11 @@ struct VideoDetailLifecycleTests {
             )
         )
         let coordinator = AppNavigationCoordinator(
-            startPlayback: { bvid in
-                videoModel.loadVideo(bvid)
+            startPlayback: { intent in
+                videoModel.loadVideo(
+                    intent.bvid,
+                    preferredCID: intent.preferredCID
+                )
             },
             stopPlayback: {
                 videoModel.reset()
@@ -301,7 +307,9 @@ struct VideoDetailLifecycleTests {
             qrCodeProvider: LifecycleQRCodeProvider()
         )
         let coordinator = AppNavigationCoordinator(
-            startPlayback: { videoModel.loadVideo($0) },
+            startPlayback: {
+                videoModel.loadVideo($0.bvid, preferredCID: $0.preferredCID)
+            },
             stopPlayback: {
                 videoModel.reset()
                 danmakuModel.reset()
@@ -354,6 +362,49 @@ struct VideoDetailLifecycleTests {
         #expect(playback.loadedIdentities.isEmpty)
         #expect(playback.stopCallCount == 1)
         window.contentView = NSView()
+    }
+
+    @Test
+    @MainActor
+    func failedPageSelectionRoutesANewCIDInsteadOfRetryingTheOldTarget() async {
+        let fixture = PageSelectionRoutingFixture()
+        let repository = PageSelectionRoutingRepository(fixture: fixture)
+        let videoModel = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: RecordingLifecyclePlayback()
+        )
+
+        videoModel.loadVideo(
+            fixture.bvid,
+            preferredCID: fixture.initialPage.cid
+        )
+        await videoModel.waitForCurrentTask()
+        videoModel.selectPage(cid: fixture.failingPage.cid)
+        await videoModel.waitForCurrentTask()
+        guard case .failedPage(_, let failedPage, _) = videoModel.state else {
+            Issue.record("切换失败后应保留失败的分 P 目标")
+            return
+        }
+        #expect(failedPage.cid == fixture.failingPage.cid)
+
+        AppWindowOwner.handlePlaybackSelection(
+            PlaybackSelectionIntent(
+                bvid: fixture.bvid,
+                preferredCID: fixture.replacementPage.cid
+            ),
+            with: videoModel
+        )
+        await videoModel.waitForCurrentTask()
+
+        #expect(videoModel.requestedPreferredCID == fixture.replacementPage.cid)
+        #expect(videoModel.presentedPlaybackIdentity?.cid == fixture.replacementPage.cid)
+        #expect(
+            await repository.playbackCIDs() == [
+                fixture.initialPage.cid,
+                fixture.failingPage.cid,
+                fixture.replacementPage.cid,
+            ]
+        )
     }
 
     @MainActor
@@ -475,6 +526,103 @@ private actor VideoDetailLifecycleRepository: GuestContentRepository {
     ) async throws -> VideoPlayback {
         if let playbackError { throw playbackError }
         return fixture.playback
+    }
+}
+
+private struct PageSelectionRoutingFixture: Sendable {
+    let bvid = "BV1PageRoute"
+    let initialPage = VideoPage(
+        cid: 910_001,
+        index: 1,
+        title: "P1",
+        durationSeconds: 60
+    )
+    let failingPage = VideoPage(
+        cid: 910_002,
+        index: 2,
+        title: "P2",
+        durationSeconds: 60
+    )
+    let replacementPage = VideoPage(
+        cid: 910_003,
+        index: 3,
+        title: "P3",
+        durationSeconds: 60
+    )
+
+    var pages: [VideoPage] {
+        [initialPage, failingPage, replacementPage]
+    }
+
+    var detail: VideoDetail {
+        VideoDetail(
+            bvid: bvid,
+            title: "分 P 路由测试",
+            summary: "手写测试数据",
+            coverURL: nil,
+            owner: VideoOwner(id: 10_001, name: "测试 UP 主"),
+            statistics: VideoStatistics(
+                viewCount: 10,
+                danmakuCount: 2,
+                likeCount: 3
+            ),
+            durationSeconds: 180,
+            publishedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            pages: pages
+        )
+    }
+
+    var playback: VideoPlayback {
+        VideoPlayback(
+            manifest: PlaybackManifest(
+                videoRepresentations: [],
+                originalAudioRepresentations: []
+            ),
+            mediaHeaders: [:]
+        )
+    }
+}
+
+private actor PageSelectionRoutingRepository: GuestContentRepository {
+    let fixture: PageSelectionRoutingFixture
+    private var observedPlaybackCIDs: [Int64] = []
+
+    init(fixture: PageSelectionRoutingFixture) {
+        self.fixture = fixture
+    }
+
+    func popular(page: Int, pageSize: Int) async throws -> PopularPage {
+        PopularPage(videos: [], pageNumber: page, pageSize: pageSize)
+    }
+
+    func searchVideos(keyword: String, page: Int) async throws -> SearchPage {
+        SearchPage(
+            videos: [],
+            pageNumber: page,
+            pageSize: 20,
+            totalResults: 0,
+            totalPages: 0
+        )
+    }
+
+    func videoDetail(for bvid: String) async throws -> VideoDetail {
+        fixture.detail
+    }
+
+    func pages(for bvid: String) async throws -> [VideoPage] {
+        fixture.pages
+    }
+
+    func playback(for bvid: String, cid: Int64) async throws -> VideoPlayback {
+        observedPlaybackCIDs.append(cid)
+        if cid == fixture.failingPage.cid {
+            throw GuestApplicationError.transportFailure
+        }
+        return fixture.playback
+    }
+
+    func playbackCIDs() -> [Int64] {
+        observedPlaybackCIDs
     }
 }
 

--- a/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestVideoUseCase.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestVideoUseCase.swift
@@ -33,9 +33,15 @@ public struct GuestVideoUseCase: Sendable {
         self.repository = repository
     }
 
-    public func prepareVideo(bvid: String) async throws -> GuestVideoContext {
+    public func prepareVideo(
+        bvid: String,
+        preferredCID: Int64? = nil
+    ) async throws -> GuestVideoContext {
         let resolvedDetail = try await repository.videoDetail(for: bvid)
         try Task.checkCancellation()
+        guard resolvedDetail.bvid == bvid else {
+            throw GuestApplicationError.invalidResponse
+        }
 
         let resolvedPages =
             resolvedDetail.pages.isEmpty
@@ -43,21 +49,43 @@ public struct GuestVideoUseCase: Sendable {
             : resolvedDetail.pages
         try Task.checkCancellation()
         let sortedPages = resolvedPages.sorted(by: { $0.index < $1.index })
-        guard let provisionalPage = sortedPages.first else {
+        guard let firstPage = sortedPages.first else {
             throw GuestApplicationError.invalidResponse
         }
+
+        if let preferredCID {
+            guard
+                let selectedPage = sortedPages.first(where: {
+                    $0.cid == preferredCID
+                })
+            else {
+                throw GuestApplicationError.invalidRequest
+            }
+            let playback = try await repository.playback(
+                for: bvid,
+                cid: selectedPage.cid
+            )
+            try Task.checkCancellation()
+            return GuestVideoContext(
+                detail: resolvedDetail,
+                pages: sortedPages,
+                selectedPage: selectedPage,
+                playback: playback
+            )
+        }
+
         let provisionalPlayback = try await repository.playback(
             for: bvid,
-            cid: provisionalPage.cid
+            cid: firstPage.cid
         )
         try Task.checkCancellation()
 
         let selectedPage =
             provisionalPlayback.resumeMetadata.flatMap { metadata in
                 sortedPages.first(where: { $0.cid == metadata.lastPlayedCID })
-            } ?? provisionalPage
+            } ?? firstPage
         let playback: VideoPlayback
-        if selectedPage.cid == provisionalPage.cid {
+        if selectedPage.cid == firstPage.cid {
             playback = provisionalPlayback
         } else {
             playback = try await repository.playback(

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/GuestVideoViewModel.swift
@@ -55,6 +55,10 @@ private struct PlaybackStartPreparationFailure: Error {}
 /// 新视频、重试或 reset 都使旧任务失效；旧任务即使忽略取消，也不能覆盖当前状态。
 public final class GuestVideoViewModel {
     public private(set) var state: GuestVideoState = .idle
+    public var failedPageCID: Int64? {
+        guard case .failedPage(_, let targetPage, _) = state else { return nil }
+        return targetPage.cid
+    }
     public private(set) var relatedVideoState: RelatedVideoState = .idle
     public private(set) var uploaderSignatureState: VideoUploaderSignatureState =
         .loaded(nil)
@@ -67,11 +71,16 @@ public final class GuestVideoViewModel {
     public var presentedBVID: String? { presentedContext?.detail.bvid }
     /// 用户最新请求的媒体身份；在 playurl 或播放器准备失败时仍保留给 retry。
     public private(set) var requestedPlaybackIdentity: PlaybackItemIdentity?
+    /// App 层最新选择意图的 BVID；与已成功安装的媒体身份分离。
+    public private(set) var requestedSelectionBVID: String?
+    /// 显式用户 CID；未知 pages 时可以先存在，绝不据此伪造已呈现媒体。
+    public private(set) var requestedPreferredCID: Int64?
     /// 已经由播放器成功安装的媒体身份；切换开始和失败后必须为 nil。
     public private(set) var presentedPlaybackIdentity: PlaybackItemIdentity?
     /// 仅在确认凭据失效时递增，由 App 层协调账户重校验；其他播放失败不能触发登出。
     public private(set) var authenticationRevalidationGeneration = 0
-    public private(set) var expandedCollectionEpisodes: Set<VideoCollectionEpisodeIdentity> = []
+    /// Picker 当前请求的合集 episode；可能先于新视频 context 到达。
+    public private(set) var selectedCollectionEpisode: VideoCollectionEpisodeIdentity?
     public private(set) var collectionEpisodePageStates:
         [VideoCollectionEpisodeIdentity: CollectionEpisodePagesState] = [:]
     /// 只在当前 item 已完成首次定位并开始播放后出现。
@@ -94,6 +103,8 @@ public final class GuestVideoViewModel {
     @ObservationIgnored private var pendingCollectionEpisodeBVIDs: [String] = []
     @ObservationIgnored private var collectionEpisodeCache: [String: [VideoPage]] = [:]
     @ObservationIgnored private var collectionEpisodeCacheOrder: [String] = []
+    @ObservationIgnored private var collectionEpisodeSelectionHandler: ((String, Int64?) -> Void)?
+    @ObservationIgnored private var selectedCollectionEpisodeIsExplicit = false
     @ObservationIgnored private var collectionSeasonID: Int64?
     @ObservationIgnored private var collectionEpisodeRequestGeneration = 0
     @ObservationIgnored private var generation = 0
@@ -128,7 +139,7 @@ public final class GuestVideoViewModel {
     }
 
     /// 取代当前播放意图；已有非 idle 会话会先停止，避免两个 bridge/server 并存。
-    public func loadVideo(_ bvid: String) {
+    public func loadVideo(_ bvid: String, preferredCID: Int64? = nil) {
         generation += 1
         let currentGeneration = generation
         loadTask?.cancel()
@@ -139,6 +150,14 @@ public final class GuestVideoViewModel {
         }
         requestedPlaybackIdentity = nil
         presentedPlaybackIdentity = nil
+        requestedSelectionBVID = bvid
+        requestedPreferredCID = preferredCID
+        if let preferredCID {
+            requestedPlaybackIdentity = PlaybackItemIdentity(
+                bvid: bvid,
+                cid: preferredCID
+            )
+        }
         playbackIntent = nil
         clearResumeNotice()
         state = .loading(bvid: bvid)
@@ -146,31 +165,33 @@ public final class GuestVideoViewModel {
         loadTask = Task { [weak self] in
             await self?.performLoad(
                 bvid: bvid,
+                preferredCID: preferredCID,
                 generation: currentGeneration
             )
         }
     }
 
-    /// 合集 episode 的展开由 Feature 持有；远端未内嵌 pages 时才按 BVID 请求详情。
-    public func setCollectionEpisodeExpanded(
+    /// Picker 选择 episode 后解析其 pages；未知 pages 只在校验完成后提交跨 BVID 意图。
+    public func selectCollectionEpisode(
         _ episode: VideoCollectionEpisode,
-        expanded: Bool
+        onResolved: @escaping (String, Int64?) -> Void
     ) {
         guard collectionContains(episode) else { return }
-        if !expanded {
-            expandedCollectionEpisodes.remove(episode.id)
-            removeCollectionEpisodeWaiter(episode)
-            return
+        if selectedCollectionEpisode != episode.id {
+            clearSelectedCollectionEpisodeRequest(
+                preservingRequestForBVID: episode.bvid
+            )
         }
-
-        expandedCollectionEpisodes.insert(episode.id)
+        selectedCollectionEpisode = episode.id
+        selectedCollectionEpisodeIsExplicit = true
+        collectionEpisodeSelectionHandler = onResolved
         resolveOrEnqueueCollectionEpisode(episode)
     }
 
     public func retryCollectionEpisodePages(
         _ episode: VideoCollectionEpisode
     ) {
-        guard expandedCollectionEpisodes.contains(episode.id),
+        guard selectedCollectionEpisode == episode.id,
             collectionContains(episode),
             episode.isIdentityConsistent,
             let bvid = episode.bvid
@@ -208,6 +229,8 @@ public final class GuestVideoViewModel {
         playback.stop()
         clearResumeNotice()
         requestedPlaybackIdentity = targetIdentity
+        requestedSelectionBVID = context.detail.bvid
+        requestedPreferredCID = targetPage.cid
         presentedPlaybackIdentity = nil
         let intent = PlaybackLoadIntent()
         playbackIntent = intent
@@ -226,7 +249,7 @@ public final class GuestVideoViewModel {
     public func retry() {
         switch state {
         case .failed(let bvid, _):
-            loadVideo(bvid)
+            loadVideo(bvid, preferredCID: requestedPreferredCID)
         case .failedPage(_, let targetPage, _):
             requestedPlaybackIdentity = nil
             selectPage(cid: targetPage.cid)
@@ -254,6 +277,8 @@ public final class GuestVideoViewModel {
         presentedContext = nil
         requestedPlaybackIdentity = nil
         presentedPlaybackIdentity = nil
+        requestedSelectionBVID = nil
+        requestedPreferredCID = nil
         playbackIntent = nil
         clearResumeNotice()
         state = .idle
@@ -377,10 +402,14 @@ public final class GuestVideoViewModel {
 
     private func performLoad(
         bvid: String,
+        preferredCID: Int64?,
         generation currentGeneration: Int
     ) async {
         do {
-            let context = try await useCase.prepareVideo(bvid: bvid)
+            let context = try await useCase.prepareVideo(
+                bvid: bvid,
+                preferredCID: preferredCID
+            )
             try Task.checkCancellation()
             guard generation == currentGeneration else { return }
 
@@ -392,6 +421,8 @@ public final class GuestVideoViewModel {
                 cid: context.selectedPage.cid
             )
             requestedPlaybackIdentity = identity
+            requestedSelectionBVID = context.detail.bvid
+            requestedPreferredCID = preferredCID
             let intent = PlaybackLoadIntent()
             playbackIntent = intent
             state = .preparingPlayback(context)
@@ -628,6 +659,7 @@ public final class GuestVideoViewModel {
         if collectionEpisodeCache[bvid] != nil {
             touchCollectionEpisodeCache(bvid)
             collectionEpisodePageStates[episode.id] = .loaded(bvid: bvid)
+            completeSelectedCollectionEpisodeIfPossible(episode)
             return
         }
         enqueueCollectionEpisode(episode, bvid: bvid)
@@ -700,6 +732,7 @@ public final class GuestVideoViewModel {
                 for identity in waiters {
                     collectionEpisodePageStates[identity] = .loaded(bvid: request.bvid)
                 }
+                completeSelectedCollectionEpisodeIfPossible()
             } catch let error as GuestApplicationError {
                 for identity in waiters {
                     collectionEpisodePageStates[identity] = .failed(error)
@@ -734,13 +767,8 @@ public final class GuestVideoViewModel {
         do {
             let resolved = try validatedCollectionPages(pages)
             storeCollectionEpisodeCache(resolved, for: bvid)
-            let matchingExpanded = expandedCollectionEpisodes.filter {
-                collectionEpisode(identity: $0)?.bvid == bvid
-            }
-            for matchingIdentity in matchingExpanded {
-                collectionEpisodePageStates[matchingIdentity] = .loaded(bvid: bvid)
-            }
             collectionEpisodePageStates[identity] = .loaded(bvid: bvid)
+            completeSelectedCollectionEpisodeIfPossible()
         } catch let error as GuestApplicationError {
             collectionEpisodePageStates[identity] = .failed(error)
         } catch {
@@ -769,7 +797,7 @@ public final class GuestVideoViewModel {
     {
         Set(
             (collectionEpisodeWaitersByBVID[bvid] ?? []).filter { identity in
-                expandedCollectionEpisodes.contains(identity)
+                selectedCollectionEpisode == identity
                     && collectionEpisode(identity: identity)?.bvid == bvid
             }
         )
@@ -792,9 +820,7 @@ public final class GuestVideoViewModel {
         pendingCollectionEpisodeBVIDs.removeAll()
     }
 
-    private func removeCollectionEpisodeWaiter(
-        _ episode: VideoCollectionEpisode
-    ) {
+    private func removeCollectionEpisodeWaiter(_ episode: VideoCollectionEpisode) {
         collectionEpisodePageStates[episode.id] = .idle
         guard let bvid = episode.bvid else { return }
         collectionEpisodeWaitersByBVID[bvid]?.remove(episode.id)
@@ -817,31 +843,72 @@ public final class GuestVideoViewModel {
             return
         }
         if collectionSeasonID != collection.id {
+            let explicitSelection =
+                selectedCollectionEpisodeIsExplicit
+                ? selectedCollectionEpisode : nil
             clearCollectionEpisodeState()
             collectionSeasonID = collection.id
+            if let explicitSelection,
+                collection.sections.flatMap(\.episodes).contains(where: {
+                    $0.id == explicitSelection
+                })
+            {
+                selectedCollectionEpisode = explicitSelection
+                selectedCollectionEpisodeIsExplicit = true
+            }
+            synchronizeSelectedCollectionEpisodeWithPresentedContext()
             return
         }
         let validIdentities = Set(
             collection.sections.flatMap(\.episodes).map(\.id)
         )
-        expandedCollectionEpisodes.formIntersection(validIdentities)
+        if let selectedCollectionEpisode,
+            !validIdentities.contains(selectedCollectionEpisode)
+        {
+            self.selectedCollectionEpisode = nil
+            selectedCollectionEpisodeIsExplicit = false
+            collectionEpisodeSelectionHandler = nil
+        }
         collectionEpisodePageStates = collectionEpisodePageStates.filter {
             validIdentities.contains($0.key)
         }
-        resumeExpandedCollectionEpisodeLoads()
+        synchronizeSelectedCollectionEpisodeWithPresentedContext()
     }
 
-    private func resumeExpandedCollectionEpisodeLoads() {
-        let identities = expandedCollectionEpisodes
-        for identity in identities {
-            guard let episode = collectionEpisode(identity: identity) else { continue }
-            resolveOrEnqueueCollectionEpisode(episode)
+    private func synchronizeSelectedCollectionEpisodeWithPresentedContext() {
+        guard let context = presentedContext else { return }
+        let episodes = context.detail.collection?.sections.flatMap(\.episodes) ?? []
+        let explicitSelection =
+            selectedCollectionEpisodeIsExplicit
+            ? selectedCollectionEpisode : nil
+        let explicitSelectionForContext = explicitSelection.flatMap { identity in
+            episodes.first(where: {
+                $0.id == identity && $0.bvid == context.detail.bvid
+            })?.id
         }
+        let currentEpisode = PlaybackCollectionEpisodeResolver.resolve(
+            episodes: episodes,
+            explicitlySelectedID: explicitSelectionForContext,
+            bvid: context.detail.bvid,
+            cid: requestedPreferredCID ?? context.selectedPage.cid
+        )
+        selectedCollectionEpisode = currentEpisode?.id
+        selectedCollectionEpisodeIsExplicit =
+            currentEpisode?.id == explicitSelectionForContext
+        collectionEpisodeSelectionHandler = nil
+        guard let currentEpisode else { return }
+        cacheAndMarkCollectionPages(
+            context.pages,
+            bvid: context.detail.bvid,
+            requested: currentEpisode.id
+        )
     }
 
     private func clearCollectionEpisodeState() {
         cancelCollectionEpisodeRequest(markWaitersIdle: false)
-        expandedCollectionEpisodes.removeAll()
+        selectedCollectionEpisode = nil
+        selectedCollectionEpisodeIsExplicit = false
+        collectionEpisodeSelectionHandler = nil
         collectionEpisodePageStates.removeAll()
         collectionEpisodeCache.removeAll()
         collectionEpisodeCacheOrder.removeAll()
@@ -874,7 +941,6 @@ public final class GuestVideoViewModel {
             }
             for identity in evictedIdentities {
                 collectionEpisodePageStates[identity] = .idle
-                expandedCollectionEpisodes.remove(identity)
             }
         }
     }
@@ -882,6 +948,56 @@ public final class GuestVideoViewModel {
     private func touchCollectionEpisodeCache(_ bvid: String) {
         collectionEpisodeCacheOrder.removeAll(where: { $0 == bvid })
         collectionEpisodeCacheOrder.append(bvid)
+    }
+
+    private func clearSelectedCollectionEpisodeRequest(
+        preservingRequestForBVID preservedBVID: String? = nil
+    ) {
+        guard let selectedCollectionEpisode,
+            let episode = collectionEpisode(identity: selectedCollectionEpisode)
+        else {
+            self.selectedCollectionEpisode = nil
+            selectedCollectionEpisodeIsExplicit = false
+            collectionEpisodeSelectionHandler = nil
+            return
+        }
+        if episode.bvid == preservedBVID,
+            let bvid = episode.bvid,
+            activeCollectionEpisodeRequest?.bvid == bvid
+        {
+            collectionEpisodePageStates[episode.id] = .idle
+            collectionEpisodeWaitersByBVID[bvid]?.remove(episode.id)
+        } else {
+            removeCollectionEpisodeWaiter(episode)
+        }
+        self.selectedCollectionEpisode = nil
+        selectedCollectionEpisodeIsExplicit = false
+        collectionEpisodeSelectionHandler = nil
+    }
+
+    private func completeSelectedCollectionEpisodeIfPossible(
+        _ resolvedEpisode: VideoCollectionEpisode? = nil
+    ) {
+        guard let selectedCollectionEpisode,
+            let episode = resolvedEpisode
+                ?? collectionEpisode(identity: selectedCollectionEpisode),
+            episode.id == selectedCollectionEpisode,
+            episode.isIdentityConsistent,
+            let bvid = episode.bvid,
+            case .loaded(let loadedBVID) = collectionEpisodePageStates[episode.id],
+            loadedBVID == bvid,
+            let pages = collectionEpisodeCache[bvid],
+            !pages.isEmpty
+        else { return }
+        if let defaultCID = episode.defaultCID,
+            !pages.contains(where: { $0.cid == defaultCID })
+        {
+            collectionEpisodePageStates[episode.id] = .failed(.invalidResponse)
+            return
+        }
+        let handler = collectionEpisodeSelectionHandler
+        collectionEpisodeSelectionHandler = nil
+        handler?(bvid, episode.defaultCID ?? pages.first?.cid)
     }
 }
 

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/PlaybackContextSidebar.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/PlaybackContextSidebar.swift
@@ -11,16 +11,17 @@ public struct PlaybackContextSidebar: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let model: GuestVideoViewModel
     private let onRetry: () -> Void
+    private let onSelectPlayback: (String, Int64?) -> Void
     @State private var isSummaryExpanded = true
-    @State private var arePartsExpanded = true
-    @ScaledMetric(relativeTo: .callout) private var partRowHeight: CGFloat = 40
 
     public init(
         model: GuestVideoViewModel,
-        onRetry: @escaping () -> Void
+        onRetry: @escaping () -> Void,
+        onSelectPlayback: @escaping (String, Int64?) -> Void
     ) {
         self.model = model
         self.onRetry = onRetry
+        self.onSelectPlayback = onSelectPlayback
     }
 
     public var body: some View {
@@ -63,8 +64,9 @@ public struct PlaybackContextSidebar: View {
                     Divider()
                 }
 
-                if context.pages.count > 1 {
-                    partsSection(context)
+                let projection = selectionProjection(context)
+                if !projection.isHidden {
+                    playbackSelectionSection(context, projection: projection)
                     Divider()
                 }
 
@@ -89,148 +91,173 @@ public struct PlaybackContextSidebar: View {
         .font(.headline)
     }
 
-    private func partsSection(_ context: GuestVideoContext) -> some View {
-        ScrollViewReader { proxy in
-            DisclosureGroup(isExpanded: $arePartsExpanded) {
-                List {
-                    ForEach(context.pages) { page in
-                        partRow(
-                            page,
-                            identity: PlaybackItemIdentity(
-                                bvid: context.detail.bvid,
-                                cid: page.cid
-                            )
-                        )
-                        .id(page.cid)
-                    }
-                }
-                .listStyle(.plain)
-                .scrollContentBackground(.hidden)
-                .frame(height: partsListHeight(pageCount: context.pages.count))
-                .padding(.top, 8)
-            } label: {
-                Text("分 P（\(context.pages.count)）")
-            }
-            .font(.headline)
-            .onChange(of: arePartsExpanded) { _, isExpanded in
-                guard isExpanded,
-                    let selectedCID = model.presentedPlaybackIdentity?.cid,
-                    context.pages.contains(where: { $0.cid == selectedCID })
-                else { return }
-                Task { @MainActor in
-                    await Task.yield()
-                    proxy.scrollTo(selectedCID, anchor: .center)
+    private func selectionProjection(
+        _ context: GuestVideoContext
+    ) -> PlaybackSelectionProjection {
+        let episodes = context.detail.collection?.sections.flatMap(\.episodes) ?? []
+        let pagesByEpisode = Dictionary(
+            uniqueKeysWithValues: episodes.compactMap { episode in
+                model.collectionEpisodePages(for: episode.id).map {
+                    (episode.id, $0)
                 }
             }
-        }
+        )
+        return PlaybackSelectionProjection(
+            context: context,
+            selectedEpisodeID: model.selectedCollectionEpisode,
+            requestedBVID: model.requestedSelectionBVID,
+            requestedCID: model.requestedPreferredCID,
+            presentedIdentity: model.presentedPlaybackIdentity,
+            pageStates: model.collectionEpisodePageStates,
+            pagesByEpisode: pagesByEpisode
+        )
     }
 
-    private func partRow(
-        _ page: VideoPage,
-        identity: PlaybackItemIdentity
+    @ViewBuilder
+    private func playbackSelectionSection(
+        _ context: GuestVideoContext,
+        projection: PlaybackSelectionProjection
     ) -> some View {
-        let isSelected = model.presentedPlaybackIdentity == identity
-        let isRequested = model.requestedPlaybackIdentity == identity
-        let isFailed = isRequested && isPageFailure
-        let isLoading = isRequested && !isSelected && !isFailed
-        let accessibilityStatus = accessibilityStatus(
-            isLoading: isLoading,
-            isFailed: isFailed
-        )
-        return Button {
-            if isFailed {
-                model.retry()
-            } else {
-                model.selectPage(cid: page.cid)
-            }
-        } label: {
-            HStack(alignment: .top, spacing: 8) {
-                Group {
-                    if isLoading {
-                        ProgressView()
-                            .controlSize(.small)
-                    } else {
-                        Image(
-                            systemName: isFailed
-                                ? "exclamationmark.circle"
-                                : (isSelected ? "play.circle.fill" : "circle")
-                        )
-                        .foregroundStyle(
-                            isFailed
-                                ? Color.red
-                                : (isSelected ? Color.accentColor : .secondary)
-                        )
+        VStack(alignment: .leading, spacing: 10) {
+            if let collectionTitle = projection.collectionTitle {
+                HStack(alignment: .firstTextBaseline, spacing: 12) {
+                    Text(collectionTitle)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer(minLength: 8)
+                    if let position = projection.episodePositionText {
+                        Text(position)
+                            .font(.callout.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                            .fixedSize()
                     }
                 }
-                .frame(width: 16, height: 16)
-                .accessibilityHidden(true)
-
-                Text("P\(page.index)")
-                    .font(.callout.monospacedDigit())
-                    .foregroundStyle(.secondary)
-                    .frame(minWidth: 30, alignment: .leading)
-
-                Text(page.title)
-                    .font(.callout)
-                    .lineLimit(2)
-                    .layoutPriority(1)
-
-                Spacer(minLength: 8)
-
-                Text(
-                    VideoDurationFormatting.string(
-                        seconds: page.durationSeconds
-                    )
-                )
-                .font(.caption.monospacedDigit())
-                .foregroundStyle(.secondary)
-                .fixedSize()
+                .font(.headline)
             }
-            .contentShape(.rect)
+
+            if projection.showsEpisodePicker {
+                episodePicker(context, projection: projection)
+            } else if projection.showsStaticEpisodeTitle,
+                let episodeTitle = projection.selectedEpisodeTitle
+            {
+                LabeledContent("选集") {
+                    Text(episodeTitle)
+                        .multilineTextAlignment(.trailing)
+                }
+                .font(.callout)
+            }
+
+            if let placeholder = projection.episodePlaceholder {
+                Text(placeholder)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            selectedEpisodePages(context, projection: projection)
         }
-        .buttonStyle(.plain)
-        .disabled(isSelected || isLoading)
-        .frame(minHeight: partRowHeight)
-        .listRowInsets(
-            EdgeInsets(top: 0, leading: 6, bottom: 0, trailing: 6)
-        )
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(
-            "第 \(page.index) 分 P，\(page.title)，"
-                + VideoDurationFormatting.string(
-                    seconds: page.durationSeconds
+    }
+
+    private func episodePicker(
+        _ context: GuestVideoContext,
+        projection: PlaybackSelectionProjection
+    ) -> some View {
+        Picker(
+            "选集",
+            selection: Binding(
+                get: { projection.selectedEpisodeID },
+                set: { identity in
+                    guard let identity,
+                        let episode = context.detail.collection?.sections
+                            .flatMap(\.episodes)
+                            .first(where: { $0.id == identity })
+                    else { return }
+                    selectEpisode(episode)
+                }
+            )
+        ) {
+            if projection.selectedEpisodeID == nil {
+                Text("当前视频不在合集目录中")
+                    .tag(Optional<VideoCollectionEpisodeIdentity>.none)
+                    .disabled(true)
+            }
+            ForEach(projection.episodeSections) { section in
+                Section(section.title.isEmpty ? "选集" : section.title) {
+                    ForEach(section.episodes) { episode in
+                        Text(episode.title)
+                            .tag(Optional(episode.id))
+                            .disabled(!episode.isEnabled)
+                    }
+                }
+            }
+        }
+        .pickerStyle(.menu)
+    }
+
+    @ViewBuilder
+    private func selectedEpisodePages(
+        _ context: GuestVideoContext,
+        projection: PlaybackSelectionProjection
+    ) -> some View {
+        switch projection.selectedPages {
+        case .ready(let pages) where pages.count > 1:
+            Picker(
+                "分 P",
+                selection: Binding(
+                    get: { projection.selectedPageCID },
+                    set: { cid in
+                        guard let cid else { return }
+                        onSelectPlayback(context.detail.bvid, cid)
+                    }
                 )
-                + (accessibilityStatus.map { "，\($0)" } ?? "")
-        )
-        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
-        .accessibilityHint(
-            isFailed
-                ? "点按重试"
-                : (isSelected
-                    ? ""
-                    : (isLoading ? "" : "切换到此分 P"))
-        )
-        .help(isFailed ? "加载失败，点按重试" : "")
-    }
-
-    private func partsListHeight(pageCount: Int) -> CGFloat {
-        CGFloat(min(pageCount, 5)) * partRowHeight + 4
-    }
-
-    private func accessibilityStatus(
-        isLoading: Bool,
-        isFailed: Bool
-    ) -> String? {
-        if isFailed { return "加载失败，可重试" }
-        if isLoading { return "正在载入" }
-        return nil
-    }
-
-    private var isPageFailure: Bool {
-        if case .failedPage = model.state {
-            return true
+            ) {
+                if projection.selectedPageCID == nil {
+                    Text("请选择分 P")
+                        .tag(Optional<Int64>.none)
+                        .disabled(true)
+                }
+                ForEach(pages) { page in
+                    Text(
+                        "P\(page.index) · \(page.title) · "
+                            + VideoDurationFormatting.string(
+                                seconds: page.durationSeconds
+                            )
+                    )
+                    .tag(Optional(page.cid))
+                }
+            }
+            .pickerStyle(.menu)
+        case .loading:
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("正在加载所选视频的分 P")
+            }
+            .font(.callout)
+            .foregroundStyle(.secondary)
+        case .failed:
+            HStack(spacing: 8) {
+                Text("无法加载所选视频的分 P")
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 8)
+                Button("重试") {
+                    guard let identity = projection.selectedEpisodeID,
+                        let episode = context.detail.collection?.sections
+                            .flatMap(\.episodes)
+                            .first(where: { $0.id == identity })
+                    else { return }
+                    model.retryCollectionEpisodePages(episode)
+                }
+            }
+            .font(.callout)
+        case .ready, .empty:
+            EmptyView()
         }
-        return false
+    }
+
+    private func selectEpisode(_ episode: VideoCollectionEpisode) {
+        model.selectCollectionEpisode(episode) { bvid, preferredCID in
+            onSelectPlayback(bvid, preferredCID)
+        }
     }
 
     private var commentsUnavailableSection: some View {

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/PlaybackSelectionProjection.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/PlaybackSelectionProjection.swift
@@ -1,0 +1,220 @@
+import BiliApplication
+import BiliModels
+
+enum PlaybackCollectionEpisodeResolver {
+    static func resolve(
+        episodes: [VideoCollectionEpisode],
+        explicitlySelectedID: VideoCollectionEpisodeIdentity?,
+        bvid: String,
+        cid: Int64?
+    ) -> VideoCollectionEpisode? {
+        let eligibleEpisodes = episodes.filter {
+            $0.isIdentityConsistent
+                && $0.bvid?.isEmpty == false
+                && $0.knownPages != []
+        }
+        if let explicitlySelectedID,
+            let explicit = eligibleEpisodes.first(where: {
+                $0.id == explicitlySelectedID
+            })
+        {
+            return explicit
+        }
+        let candidates = eligibleEpisodes.filter { $0.bvid == bvid }
+        guard let cid else {
+            return candidates.count == 1 ? candidates[0] : nil
+        }
+        let defaultCIDMatches = candidates.filter { $0.defaultCID == cid }
+        if defaultCIDMatches.count == 1 {
+            return defaultCIDMatches[0]
+        }
+        guard defaultCIDMatches.isEmpty else { return nil }
+        let knownPageMatches = candidates.filter {
+            $0.knownPages?.contains(where: { $0.cid == cid }) == true
+        }
+        if knownPageMatches.count == 1 {
+            return knownPageMatches[0]
+        }
+        guard knownPageMatches.isEmpty,
+            candidates.count == 1,
+            candidates[0].defaultCID == nil,
+            candidates[0].knownPages == nil
+        else { return nil }
+        return candidates[0]
+    }
+}
+
+public struct PlaybackEpisodeOption: Identifiable, Sendable, Equatable {
+    public let id: VideoCollectionEpisodeIdentity
+    public let sectionID: VideoCollectionSectionIdentity
+    public let title: String
+    public let bvid: String?
+    public let preferredCID: Int64?
+    public let isEnabled: Bool
+}
+
+public struct PlaybackEpisodeSectionPresentation: Identifiable, Sendable, Equatable {
+    public let id: VideoCollectionSectionIdentity
+    public let title: String
+    public let episodes: [PlaybackEpisodeOption]
+}
+
+public struct PlaybackPageOption: Identifiable, Sendable, Equatable {
+    public var id: Int64 { cid }
+
+    public let cid: Int64
+    public let index: Int
+    public let title: String
+    public let durationSeconds: Int
+}
+
+public enum PlaybackSelectedEpisodePagesPresentation: Sendable, Equatable {
+    case ready([PlaybackPageOption])
+    case loading
+    case failed
+    case empty
+}
+
+/// 把真实 collection/page 状态投影为紧凑 Picker 所需的稳定语义，不拥有网络或播放状态。
+public struct PlaybackSelectionProjection: Sendable, Equatable {
+    public let collectionTitle: String?
+    public let episodeSections: [PlaybackEpisodeSectionPresentation]
+    public let selectedEpisodeID: VideoCollectionEpisodeIdentity?
+    public let selectedEpisodeTitle: String?
+    public let episodePositionText: String?
+    public let episodePlaceholder: String?
+    public let selectedPages: PlaybackSelectedEpisodePagesPresentation
+    public let selectedPageCID: Int64?
+
+    public var episodeCount: Int {
+        episodeSections.reduce(into: 0) { $0 += $1.episodes.count }
+    }
+
+    public var showsEpisodePicker: Bool { episodeCount > 1 }
+
+    public var showsStaticEpisodeTitle: Bool {
+        episodeCount == 1 && selectedEpisodeTitle != nil
+    }
+
+    public var showsPagePicker: Bool {
+        guard case .ready(let pages) = selectedPages else { return false }
+        return pages.count > 1
+    }
+
+    public var isHidden: Bool {
+        collectionTitle == nil && !showsPagePicker
+    }
+
+    public init(
+        context: GuestVideoContext,
+        selectedEpisodeID requestedEpisodeID: VideoCollectionEpisodeIdentity?,
+        requestedBVID: String?,
+        requestedCID: Int64?,
+        presentedIdentity: PlaybackItemIdentity?,
+        pageStates: [VideoCollectionEpisodeIdentity: CollectionEpisodePagesState],
+        pagesByEpisode: [VideoCollectionEpisodeIdentity: [VideoPage]]
+    ) {
+        let collection = context.detail.collection
+        collectionTitle = collection?.title
+        episodeSections =
+            collection?.sections.map { section in
+                PlaybackEpisodeSectionPresentation(
+                    id: section.id,
+                    title: section.title,
+                    episodes: section.episodes.map { episode in
+                        PlaybackEpisodeOption(
+                            id: episode.id,
+                            sectionID: section.id,
+                            title: episode.title.isEmpty
+                                ? "无法识别的选集" : episode.title,
+                            bvid: episode.bvid,
+                            preferredCID: episode.defaultCID,
+                            isEnabled: episode.isIdentityConsistent
+                                && episode.bvid?.isEmpty == false
+                                && episode.knownPages != []
+                        )
+                    }
+                )
+            } ?? []
+
+        let episodes = collection?.sections.flatMap(\.episodes) ?? []
+        let targetCID =
+            requestedBVID == context.detail.bvid
+            ? requestedCID ?? context.selectedPage.cid
+            : presentedIdentity?.bvid == context.detail.bvid
+                ? presentedIdentity?.cid : context.selectedPage.cid
+        let selectedEpisode = PlaybackCollectionEpisodeResolver.resolve(
+            episodes: episodes,
+            explicitlySelectedID: requestedEpisodeID,
+            bvid: context.detail.bvid,
+            cid: targetCID
+        )
+        selectedEpisodeID = selectedEpisode?.id
+        selectedEpisodeTitle = selectedEpisode?.title.nonempty
+        episodePositionText = selectedEpisode.flatMap { episode in
+            episodes.firstIndex(where: { $0.id == episode.id }).map {
+                "\($0 + 1)/\(episodes.count)"
+            }
+        }
+        episodePlaceholder =
+            collection == nil || selectedEpisode != nil
+            ? nil : "当前视频不在合集目录中"
+
+        let resolvedPages: [VideoPage]?
+        if collection == nil || selectedEpisode?.bvid == context.detail.bvid {
+            resolvedPages = context.pages
+        } else if let selectedEpisode {
+            resolvedPages = pagesByEpisode[selectedEpisode.id]
+        } else {
+            resolvedPages = nil
+        }
+
+        if let resolvedPages {
+            let pages = resolvedPages.sorted(by: { $0.index < $1.index })
+            selectedPages =
+                pages.isEmpty
+                ? .empty
+                : .ready(
+                    pages.map {
+                        PlaybackPageOption(
+                            cid: $0.cid,
+                            index: $0.index,
+                            title: $0.title,
+                            durationSeconds: $0.durationSeconds
+                        )
+                    }
+                )
+            let candidateCID: Int64?
+            if presentedIdentity?.bvid == selectedEpisode?.bvid
+                || (collection == nil
+                    && presentedIdentity?.bvid == context.detail.bvid)
+            {
+                candidateCID = presentedIdentity?.cid
+            } else if requestedBVID == selectedEpisode?.bvid {
+                candidateCID = requestedCID
+            } else {
+                candidateCID = selectedEpisode?.defaultCID
+            }
+            selectedPageCID = candidateCID.flatMap { candidate in
+                pages.contains(where: { $0.cid == candidate }) ? candidate : nil
+            }
+        } else if let selectedEpisode {
+            switch pageStates[selectedEpisode.id] ?? .idle {
+            case .loading:
+                selectedPages = .loading
+            case .failed:
+                selectedPages = .failed
+            case .idle, .loaded:
+                selectedPages = .empty
+            }
+            selectedPageCID = nil
+        } else {
+            selectedPages = .empty
+            selectedPageCID = nil
+        }
+    }
+}
+
+extension String {
+    fileprivate var nonempty: String? { isEmpty ? nil : self }
+}

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoLoadingSkeletons.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/VideoLoadingSkeletons.swift
@@ -78,7 +78,7 @@ struct PlaybackContextSidebarSkeleton: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+            LazyVStack(alignment: .leading, spacing: 16) {
                 uploader
 
                 Divider()
@@ -90,10 +90,9 @@ struct PlaybackContextSidebarSkeleton: View {
 
                 Divider()
 
-                sectionTitle(width: 92)
-                ForEach(0..<3, id: \.self) { _ in
-                    partRow
-                }
+                sectionTitle(width: 132)
+                selectionField
+                selectionField
 
                 Divider()
 
@@ -154,19 +153,15 @@ struct PlaybackContextSidebarSkeleton: View {
         .frame(height: 13)
     }
 
-    private var partRow: some View {
-        HStack(spacing: 8) {
-            Circle()
-                .fill(.quinary)
-                .frame(width: 16, height: 16)
+    private var selectionField: some View {
+        HStack(spacing: 10) {
             RoundedRectangle(cornerRadius: 3)
                 .fill(.quinary)
-                .frame(width: 32, height: 14)
+                .frame(width: 42, height: 14)
             RoundedRectangle(cornerRadius: 3)
                 .fill(.quaternary)
                 .frame(maxWidth: .infinity)
-                .frame(height: 14)
+                .frame(height: 24)
         }
-        .frame(height: 32)
     }
 }

--- a/Packages/BiliKitCore/Tests/BiliApplicationTests/GuestVideoUseCaseTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliApplicationTests/GuestVideoUseCaseTests.swift
@@ -83,6 +83,41 @@ struct GuestVideoUseCaseTests {
     }
 
     @Test
+    func explicitCIDRequestsOnlyTheValidatedTargetAndOverridesResume() async throws {
+        let repository = GuestRepositoryStub(
+            resumeMetadata: PlaybackResumeMetadata(
+                lastPlayedCID: 900_001,
+                positionMilliseconds: 5_000
+            )
+        )
+        let useCase = GuestVideoUseCase(repository: repository)
+
+        let context = try await useCase.prepareVideo(
+            bvid: "BV1FixtureA1",
+            preferredCID: 900_002
+        )
+
+        #expect(context.selectedPage.cid == 900_002)
+        #expect(context.resumePositionSeconds == nil)
+        #expect(await repository.playbackCIDs() == [900_002])
+    }
+
+    @Test
+    func invalidExplicitCIDNeverRequestsPlayback() async {
+        let repository = GuestRepositoryStub()
+        let useCase = GuestVideoUseCase(repository: repository)
+
+        await #expect(throws: GuestApplicationError.invalidRequest) {
+            try await useCase.prepareVideo(
+                bvid: "BV1FixtureA1",
+                preferredCID: 999_999
+            )
+        }
+
+        #expect(await repository.playbackCIDs().isEmpty)
+    }
+
+    @Test
     func cancellationDuringPagelistFallbackPreventsPlayback() async throws {
         let repository = FallbackCancellationRepository()
         let useCase = GuestVideoUseCase(repository: repository)
@@ -181,12 +216,18 @@ private actor FallbackCancellationRepository: GuestContentRepository {
 private actor GuestRepositoryStub: GuestContentRepository {
     private let hasPages: Bool
     private let detailHasPages: Bool
+    private let resumeMetadata: PlaybackResumeMetadata?
     private var observedPlaybackCIDs: [Int64] = []
     private var observedPageRequestCount = 0
 
-    init(hasPages: Bool = true, detailHasPages: Bool = false) {
+    init(
+        hasPages: Bool = true,
+        detailHasPages: Bool = false,
+        resumeMetadata: PlaybackResumeMetadata? = nil
+    ) {
         self.hasPages = hasPages
         self.detailHasPages = detailHasPages
+        self.resumeMetadata = resumeMetadata
     }
 
     func popular(page: Int, pageSize: Int) async throws -> PopularPage {
@@ -298,7 +339,8 @@ private actor GuestRepositoryStub: GuestContentRepository {
                     )
                 ]
             ),
-            mediaHeaders: [:]
+            mediaHeaders: [:],
+            resumeMetadata: resumeMetadata
         )
     }
 }

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
@@ -1349,6 +1349,93 @@ struct GuestBrowseAndVideoViewModelTests {
 
     @Test
     @MainActor
+    func crossBVIDExplicitCIDLoadsOnlyTheAtomicTarget() async {
+        let fixtures = CollectionFixtures()
+        let repository = CollectionEpisodeRepositoryStub(fixtures: fixtures)
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: RecordingPlayerEngine()
+        )
+
+        model.loadVideo(
+            fixtures.episodeBVID,
+            preferredCID: fixtures.episodePages[1].cid
+        )
+        #expect(model.requestedSelectionBVID == fixtures.episodeBVID)
+        #expect(model.requestedPreferredCID == fixtures.episodePages[1].cid)
+        #expect(model.presentedPlaybackIdentity == nil)
+        await model.waitForCurrentTask()
+
+        #expect(model.presentedPlaybackIdentity?.bvid == fixtures.episodeBVID)
+        #expect(model.presentedPlaybackIdentity?.cid == fixtures.episodePages[1].cid)
+        #expect(await repository.playbackBVIDs() == [fixtures.episodeBVID])
+        #expect(await repository.playbackCIDs() == [fixtures.episodePages[1].cid])
+    }
+
+    @Test
+    @MainActor
+    func crossBVIDFailureRetryRetainsExplicitCID() async {
+        let fixtures = CollectionFixtures()
+        let repository = CollectionEpisodeRepositoryStub(
+            fixtures: fixtures,
+            failsFirstEpisodeDetail: true
+        )
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: RecordingPlayerEngine()
+        )
+
+        model.loadVideo(
+            fixtures.episodeBVID,
+            preferredCID: fixtures.episodePages[1].cid
+        )
+        await model.waitForCurrentTask()
+        #expect(model.requestedPreferredCID == fixtures.episodePages[1].cid)
+        #expect(model.presentedPlaybackIdentity == nil)
+
+        model.retry()
+        await model.waitForCurrentTask()
+
+        #expect(model.presentedPlaybackIdentity?.cid == fixtures.episodePages[1].cid)
+        #expect(await repository.playbackBVIDs() == [fixtures.episodeBVID])
+        #expect(await repository.playbackCIDs() == [fixtures.episodePages[1].cid])
+    }
+
+    @Test
+    @MainActor
+    func unknownEpisodePagesStayPendingThenResolveOneValidatedIntent() async {
+        let fixtures = CollectionFixtures()
+        let repository = CollectionEpisodeRepositoryStub(
+            fixtures: fixtures,
+            blocksEpisodeDetail: true
+        )
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: RecordingPlayerEngine()
+        )
+        model.loadVideo(fixtures.rootBVID)
+        await model.waitForCurrentTask()
+        var resolved: [(String, Int64?)] = []
+
+        model.selectCollectionEpisode(fixtures.lazyEpisode) {
+            resolved.append(($0, $1))
+        }
+        await repository.waitForEpisodeDetailRequest()
+
+        #expect(model.selectedCollectionEpisode == fixtures.lazyEpisode.id)
+        #expect(model.collectionEpisodePageStates[fixtures.lazyEpisode.id] == .loading)
+        #expect(resolved.isEmpty)
+
+        await repository.releaseEpisodeDetail()
+        await model.waitForCurrentCollectionEpisodeTask()
+
+        #expect(resolved.count == 1)
+        #expect(resolved.first?.0 == fixtures.episodeBVID)
+        #expect(resolved.first?.1 == fixtures.episodePages.first?.cid)
+    }
+
+    @Test
+    @MainActor
     func embeddedCollectionPagesLoadWithoutAnotherDetailRequest() async throws {
         let fixtures = CollectionFixtures()
         let repository = CollectionEpisodeRepositoryStub(fixtures: fixtures)
@@ -1359,10 +1446,10 @@ struct GuestBrowseAndVideoViewModelTests {
 
         model.loadVideo(fixtures.rootBVID)
         await model.waitForCurrentTask()
-        model.setCollectionEpisodeExpanded(
-            fixtures.embeddedEpisode,
-            expanded: true
-        )
+        var resolvedSelection: (String, Int64?)?
+        model.selectCollectionEpisode(fixtures.embeddedEpisode) {
+            resolvedSelection = ($0, $1)
+        }
 
         #expect(
             model.collectionEpisodePageStates[fixtures.embeddedEpisode.id]
@@ -1372,11 +1459,36 @@ struct GuestBrowseAndVideoViewModelTests {
             model.collectionEpisodePages(for: fixtures.embeddedEpisode.id) == fixtures.rootPages
         )
         #expect(await repository.episodeDetailRequestCount() == 0)
+        #expect(resolvedSelection?.0 == fixtures.rootBVID)
     }
 
     @Test
     @MainActor
-    func duplicateBVIDEpisodeExpansionsShareOneDetailRequest() async throws {
+    func explicitDuplicateBVIDOccurrenceSurvivesContextReconciliation() async {
+        let fixtures = CollectionFixtures()
+        let repository = CollectionEpisodeRepositoryStub(fixtures: fixtures)
+        let model = GuestVideoViewModel(
+            useCase: GuestVideoUseCase(repository: repository),
+            playback: RecordingPlayerEngine()
+        )
+
+        model.loadVideo(fixtures.rootBVID)
+        await model.waitForCurrentTask()
+        model.selectCollectionEpisode(fixtures.rootSummaryEpisode) { _, _ in }
+        #expect(model.selectedCollectionEpisode == fixtures.rootSummaryEpisode.id)
+
+        model.loadVideo(
+            fixtures.rootBVID,
+            preferredCID: fixtures.rootPages[1].cid
+        )
+        await model.waitForCurrentTask()
+
+        #expect(model.selectedCollectionEpisode == fixtures.rootSummaryEpisode.id)
+    }
+
+    @Test
+    @MainActor
+    func duplicateBVIDEpisodeSelectionsShareOneDetailRequest() async throws {
         let fixtures = CollectionFixtures()
         let repository = CollectionEpisodeRepositoryStub(
             fixtures: fixtures,
@@ -1389,19 +1501,15 @@ struct GuestBrowseAndVideoViewModelTests {
 
         model.loadVideo(fixtures.rootBVID)
         await model.waitForCurrentTask()
-        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
-        model.setCollectionEpisodeExpanded(
-            fixtures.duplicateLazyEpisode,
-            expanded: true
-        )
+        model.selectCollectionEpisode(fixtures.lazyEpisode) { _, _ in }
+        model.selectCollectionEpisode(fixtures.duplicateLazyEpisode) { _, _ in }
         await repository.waitForEpisodeDetailRequest()
         await repository.releaseEpisodeDetail()
         await model.waitForCurrentCollectionEpisodeTask()
 
         #expect(await repository.episodeDetailRequestCount() == 1)
         #expect(
-            model.collectionEpisodePageStates[fixtures.lazyEpisode.id]
-                == .loaded(bvid: fixtures.episodeBVID)
+            model.collectionEpisodePageStates[fixtures.lazyEpisode.id] == .idle
         )
         #expect(
             model.collectionEpisodePageStates[fixtures.duplicateLazyEpisode.id]
@@ -1411,7 +1519,7 @@ struct GuestBrowseAndVideoViewModelTests {
 
     @Test
     @MainActor
-    func collapsingOneDuplicateWaiterKeepsTheSharedRequestAlive() async throws {
+    func replacingDuplicateBVIDSelectionKeepsTheSharedRequestAlive() async throws {
         let fixtures = CollectionFixtures()
         let repository = CollectionEpisodeRepositoryStub(
             fixtures: fixtures,
@@ -1424,13 +1532,9 @@ struct GuestBrowseAndVideoViewModelTests {
 
         model.loadVideo(fixtures.rootBVID)
         await model.waitForCurrentTask()
-        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
-        model.setCollectionEpisodeExpanded(
-            fixtures.duplicateLazyEpisode,
-            expanded: true
-        )
+        model.selectCollectionEpisode(fixtures.lazyEpisode) { _, _ in }
         await repository.waitForEpisodeDetailRequest()
-        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: false)
+        model.selectCollectionEpisode(fixtures.duplicateLazyEpisode) { _, _ in }
         await repository.releaseEpisodeDetail()
         await model.waitForCurrentCollectionEpisodeTask()
 
@@ -1447,7 +1551,7 @@ struct GuestBrowseAndVideoViewModelTests {
 
     @Test
     @MainActor
-    func collapsingAndImmediatelyReexpandingStartsANewGeneration() async throws {
+    func replacingDifferentBVIDSelectionStartsANewGeneration() async throws {
         let fixtures = CollectionFixtures()
         let repository = CollectionEpisodeRepositoryStub(
             fixtures: fixtures,
@@ -1460,19 +1564,18 @@ struct GuestBrowseAndVideoViewModelTests {
 
         model.loadVideo(fixtures.rootBVID)
         await model.waitForCurrentTask()
-        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        model.selectCollectionEpisode(fixtures.lazyEpisode) { _, _ in }
         await repository.waitForEpisodeDetailRequest(count: 1)
-        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: false)
-        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        model.selectCollectionEpisode(fixtures.thirdLazyEpisode) { _, _ in }
         await repository.waitForEpisodeDetailRequest(count: 2)
         await repository.releaseEpisodeDetail()
         await model.waitForCurrentCollectionEpisodeTask()
 
         #expect(await repository.episodeDetailRequestCount() == 2)
-        #expect(model.expandedCollectionEpisodes.contains(fixtures.lazyEpisode.id))
+        #expect(model.selectedCollectionEpisode == fixtures.thirdLazyEpisode.id)
         #expect(
-            model.collectionEpisodePageStates[fixtures.lazyEpisode.id]
-                == .loaded(bvid: fixtures.episodeBVID)
+            model.collectionEpisodePageStates[fixtures.thirdLazyEpisode.id]
+                == .loaded(bvid: fixtures.thirdBVID)
         )
     }
 
@@ -1492,12 +1595,12 @@ struct GuestBrowseAndVideoViewModelTests {
 
         model.loadVideo(fixtures.rootBVID)
         await model.waitForCurrentTask()
-        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        model.selectCollectionEpisode(fixtures.lazyEpisode) { _, _ in }
         await repository.waitForEpisodeDetailRequest()
         let cancelledTask = try #require(
             model.collectionEpisodeTaskSnapshotForTesting()
         )
-        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: false)
+        model.selectCollectionEpisode(fixtures.embeddedEpisode) { _, _ in }
         await repository.releaseEpisodeDetail()
         await cancelledTask.value
 
@@ -1520,7 +1623,7 @@ struct GuestBrowseAndVideoViewModelTests {
 
         model.loadVideo(fixtures.rootBVID)
         await model.waitForCurrentTask()
-        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        model.selectCollectionEpisode(fixtures.lazyEpisode) { _, _ in }
         await model.waitForCurrentCollectionEpisodeTask()
 
         #expect(
@@ -1554,7 +1657,7 @@ struct GuestBrowseAndVideoViewModelTests {
 
         model.loadVideo(fixtures.rootBVID)
         await model.waitForCurrentTask()
-        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        model.selectCollectionEpisode(fixtures.lazyEpisode) { _, _ in }
         await repository.waitForEpisodeDetailRequest()
         let lateTask = try #require(
             model.collectionEpisodeTaskSnapshotForTesting()
@@ -1564,14 +1667,14 @@ struct GuestBrowseAndVideoViewModelTests {
         await repository.releaseEpisodeDetail()
         await lateTask.value
 
-        #expect(model.expandedCollectionEpisodes.isEmpty)
+        #expect(model.selectedCollectionEpisode == nil)
         #expect(model.collectionEpisodePageStates.isEmpty)
         #expect(model.presentedContext == nil)
     }
 
     @Test
     @MainActor
-    func differentBVIDExpansionsRunSeriallyWithoutLeavingIdleExpandedItem() async throws {
+    func differentBVIDSelectionCancelsOldRequestAndRejectsItsLateResult() async throws {
         let fixtures = CollectionFixtures()
         let repository = CollectionEpisodeRepositoryStub(
             fixtures: fixtures,
@@ -1584,23 +1687,21 @@ struct GuestBrowseAndVideoViewModelTests {
 
         model.loadVideo(fixtures.rootBVID)
         await model.waitForCurrentTask()
-        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        model.selectCollectionEpisode(fixtures.lazyEpisode) { _, _ in }
         await repository.waitForEpisodeDetailRequest(count: 1)
-        model.setCollectionEpisodeExpanded(fixtures.thirdLazyEpisode, expanded: true)
+        model.selectCollectionEpisode(fixtures.thirdLazyEpisode) { _, _ in }
 
-        #expect(await repository.episodeDetailRequestCount() == 1)
-        #expect(model.collectionEpisodePageStates[fixtures.lazyEpisode.id] == .loading)
+        await repository.waitForEpisodeDetailRequest(count: 2)
+        #expect(await repository.episodeDetailRequestCount() == 2)
+        #expect(model.collectionEpisodePageStates[fixtures.lazyEpisode.id] == .idle)
         #expect(model.collectionEpisodePageStates[fixtures.thirdLazyEpisode.id] == .loading)
 
-        await repository.releaseEpisodeDetail()
-        await repository.waitForEpisodeDetailRequest(count: 2)
         await repository.releaseEpisodeDetail()
         await model.waitForCurrentCollectionEpisodeTask()
 
         #expect(await repository.episodeDetailRequestCount() == 2)
         #expect(
-            model.collectionEpisodePageStates[fixtures.lazyEpisode.id]
-                == .loaded(bvid: fixtures.episodeBVID)
+            model.collectionEpisodePageStates[fixtures.lazyEpisode.id] == .idle
         )
         #expect(
             model.collectionEpisodePageStates[fixtures.thirdLazyEpisode.id]
@@ -1610,7 +1711,7 @@ struct GuestBrowseAndVideoViewModelTests {
 
     @Test
     @MainActor
-    func currentAndEmbeddedPagesPopulateBVIDCacheWithoutRemoteDetail() async {
+    func knownEpisodePagesResolveSelectionsWithoutRemoteDetail() async {
         let fixtures = CollectionFixtures()
         let repository = CollectionEpisodeRepositoryStub(fixtures: fixtures)
         let model = GuestVideoViewModel(
@@ -1620,15 +1721,11 @@ struct GuestBrowseAndVideoViewModelTests {
 
         model.loadVideo(fixtures.rootBVID)
         await model.waitForCurrentTask()
-        model.setCollectionEpisodeExpanded(fixtures.rootSummaryEpisode, expanded: true)
-        model.setCollectionEpisodeExpanded(fixtures.embeddedRemoteEpisode, expanded: true)
-        model.setCollectionEpisodeExpanded(fixtures.lazyEpisode, expanded: true)
+        model.selectCollectionEpisode(fixtures.rootSummaryEpisode) { _, _ in }
+        model.selectCollectionEpisode(fixtures.embeddedRemoteEpisode) { _, _ in }
+        model.selectCollectionEpisode(fixtures.lazyEpisode) { _, _ in }
 
         #expect(await repository.episodeDetailRequestCount() == 0)
-        #expect(
-            model.collectionEpisodePages(for: fixtures.rootSummaryEpisode.id)
-                == fixtures.rootPages
-        )
         #expect(
             model.collectionEpisodePages(for: fixtures.lazyEpisode.id)
                 == fixtures.episodePages
@@ -1649,12 +1746,12 @@ struct GuestBrowseAndVideoViewModelTests {
         model.loadVideo(fixtures.rootBVID)
         await model.waitForCurrentTask()
         for episode in fixtures.episodes {
-            model.setCollectionEpisodeExpanded(episode, expanded: true)
+            model.selectCollectionEpisode(episode) { _, _ in }
         }
 
         let first = fixtures.episodes[0]
         let last = fixtures.episodes[12]
-        #expect(!model.expandedCollectionEpisodes.contains(first.id))
+        #expect(model.selectedCollectionEpisode == last.id)
         #expect(model.collectionEpisodePageStates[first.id] == .idle)
         #expect(model.collectionEpisodePages(for: first.id) == nil)
         #expect(model.collectionEpisodePageStates[last.id] == .loaded(bvid: last.bvid!))
@@ -1929,6 +2026,7 @@ private actor CollectionEpisodeRepositoryStub: GuestContentRepository {
     let episodeFailureAfterRelease: GuestApplicationError?
     var failsFirstEpisodeDetail: Bool
     private var episodeRequests = 0
+    private var observedPlaybackRequests: [(String, Int64)] = []
     private let episodeRequestEvents = TestEventCounter()
     private var episodeReleaseWaiters: [CheckedContinuation<Void, Never>] = []
 
@@ -1986,7 +2084,16 @@ private actor CollectionEpisodeRepositoryStub: GuestContentRepository {
     }
 
     func playback(for bvid: String, cid: Int64) async throws -> VideoPlayback {
-        fixtures.playback
+        observedPlaybackRequests.append((bvid, cid))
+        return fixtures.playback
+    }
+
+    func playbackBVIDs() -> [String] {
+        observedPlaybackRequests.map(\.0)
+    }
+
+    func playbackCIDs() -> [Int64] {
+        observedPlaybackRequests.map(\.1)
     }
 
     func episodeDetailRequestCount() -> Int {

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/PlaybackSelectionProjectionTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/PlaybackSelectionProjectionTests.swift
@@ -1,0 +1,294 @@
+import BiliApplication
+import BiliModels
+import Foundation
+import Testing
+
+@testable import BiliBrowseFeature
+
+struct PlaybackSelectionProjectionTests {
+    @Test
+    func noCollectionSinglePageHidesSelectionAndMultiplePagesShowOnlyPagePicker() {
+        let single = projection(context: context(pages: [page(1)]))
+        let multiple = projection(context: context(pages: [page(1), page(2)]))
+
+        #expect(single.isHidden)
+        #expect(!single.showsEpisodePicker)
+        #expect(!single.showsPagePicker)
+        #expect(!multiple.isHidden)
+        #expect(!multiple.showsEpisodePicker)
+        #expect(multiple.showsPagePicker)
+    }
+
+    @Test
+    func singleEpisodeCollectionUsesStaticTitleAndShowsPagePickerOnlyForMultiplePages() {
+        let onePage = [page(1)]
+        let twoPages = [page(1), page(2)]
+        let episode = episode(ordinal: 0, bvid: "BVCurrent", pages: twoPages)
+        let collection = collection(sections: [[episode]])
+
+        let single = projection(
+            context: context(pages: onePage, collection: collection)
+        )
+        let multiple = projection(
+            context: context(pages: twoPages, collection: collection)
+        )
+
+        #expect(single.collectionTitle == "合集")
+        #expect(single.showsStaticEpisodeTitle)
+        #expect(!single.showsEpisodePicker)
+        #expect(!single.showsPagePicker)
+        #expect(multiple.showsStaticEpisodeTitle)
+        #expect(multiple.showsPagePicker)
+    }
+
+    @Test
+    func eightyEpisodesPreserveSectionsAndUnavailableOptionsRemainVisibleDisabled() {
+        let sections = (0..<4).map { section in
+            (0..<20).map { item in
+                episode(
+                    ordinal: section * 20 + item,
+                    bvid: item == 19 && section == 3
+                        ? nil
+                        : "BV\(section)-\(item)",
+                    pages: [page(1)],
+                    isConsistent: !(item == 19 && section == 3),
+                    section: section
+                )
+            }
+        }
+        let projection = projection(
+            context: context(
+                pages: [page(1)],
+                collection: collection(sections: sections)
+            )
+        )
+
+        #expect(projection.episodeCount == 80)
+        #expect(projection.episodeSections.count == 4)
+        #expect(projection.showsEpisodePicker)
+        #expect(projection.episodeSections.last?.episodes.last?.isEnabled == false)
+    }
+
+    @Test
+    func missingCurrentEpisodeAndPendingPagesNeverFabricateEpisodeOrCID() {
+        let remote = episode(
+            ordinal: 0,
+            bvid: "BVRemote",
+            pages: nil
+        )
+        let collection = collection(sections: [[remote]])
+        let missing = projection(
+            context: context(pages: [page(1)], collection: collection)
+        )
+        let pending = projection(
+            context: context(pages: [page(1)], collection: collection),
+            selectedEpisodeID: remote.id,
+            requestedBVID: "BVRemote",
+            requestedCID: 99,
+            pageStates: [remote.id: .loading]
+        )
+
+        #expect(missing.selectedEpisodeID == nil)
+        #expect(missing.episodePositionText == nil)
+        #expect(missing.episodePlaceholder != nil)
+        #expect(missing.selectedPageCID == nil)
+        #expect(pending.selectedEpisodeID == remote.id)
+        #expect(pending.episodePositionText == "1/1")
+        #expect(pending.selectedPages == .loading)
+        #expect(pending.selectedPageCID == nil)
+    }
+
+    @Test
+    func currentEpisodePositionUsesFlattenedRealCollectionOrder() {
+        let episodes = (0..<10).map { ordinal in
+            episode(
+                ordinal: ordinal,
+                bvid: ordinal == 4 ? "BVCurrent" : "BV\(ordinal)",
+                pages: [page(1)]
+            )
+        }
+        let projection = projection(
+            context: context(
+                pages: [page(1)],
+                collection: collection(sections: [
+                    Array(episodes[0..<3]),
+                    Array(episodes[3..<10]),
+                ])
+            )
+        )
+
+        #expect(projection.episodePositionText == "5/10")
+    }
+
+    @Test
+    func duplicateBVIDUsesCIDToResolveOccurrenceAndDoesNotGuessWhenAmbiguous() {
+        let first = episode(
+            ordinal: 0,
+            bvid: "BVCurrent",
+            pages: [page(1), page(2)]
+        )
+        let second = episode(
+            ordinal: 1,
+            bvid: "BVCurrent",
+            pages: [page(2), page(1)]
+        )
+        let duplicateCollection = collection(sections: [[first, second]])
+        let resolved = projection(
+            context: context(
+                pages: [page(1), page(2)],
+                collection: duplicateCollection
+            ),
+            requestedBVID: "BVCurrent",
+            requestedCID: page(2).cid
+        )
+        let ambiguousEpisode = episode(
+            ordinal: 1,
+            bvid: "BVCurrent",
+            pages: [page(1)]
+        )
+        let ambiguous = projection(
+            context: context(
+                pages: [page(1)],
+                collection: collection(sections: [[first, ambiguousEpisode]])
+            )
+        )
+
+        #expect(resolved.selectedEpisodeID == second.id)
+        #expect(resolved.episodePositionText == "2/2")
+        #expect(ambiguous.selectedEpisodeID == nil)
+        #expect(ambiguous.episodePositionText == nil)
+        #expect(ambiguous.episodePlaceholder != nil)
+    }
+
+    @Test
+    func explicitDuplicateBVIDOccurrenceAlwaysWinsOverAutomaticMatching() {
+        let first = episode(
+            ordinal: 0,
+            bvid: "BVCurrent",
+            pages: [page(1)]
+        )
+        let second = episode(
+            ordinal: 1,
+            bvid: "BVCurrent",
+            pages: [page(1)]
+        )
+        let projection = projection(
+            context: context(
+                pages: [page(1)],
+                collection: collection(sections: [[first, second]])
+            ),
+            selectedEpisodeID: second.id
+        )
+
+        #expect(projection.selectedEpisodeID == second.id)
+        #expect(projection.episodePositionText == "2/2")
+    }
+
+    private func projection(
+        context: GuestVideoContext,
+        selectedEpisodeID: VideoCollectionEpisodeIdentity? = nil,
+        requestedBVID: String? = nil,
+        requestedCID: Int64? = nil,
+        pageStates: [VideoCollectionEpisodeIdentity: CollectionEpisodePagesState] = [:],
+        pagesByEpisode: [VideoCollectionEpisodeIdentity: [VideoPage]] = [:]
+    ) -> PlaybackSelectionProjection {
+        PlaybackSelectionProjection(
+            context: context,
+            selectedEpisodeID: selectedEpisodeID,
+            requestedBVID: requestedBVID,
+            requestedCID: requestedCID,
+            presentedIdentity: nil,
+            pageStates: pageStates,
+            pagesByEpisode: pagesByEpisode
+        )
+    }
+
+    private func context(
+        pages: [VideoPage],
+        collection: VideoCollection? = nil
+    ) -> GuestVideoContext {
+        let detail = VideoDetail(
+            bvid: "BVCurrent",
+            title: "当前视频",
+            summary: "说明",
+            coverURL: nil,
+            owner: VideoOwner(id: 1, name: "作者"),
+            statistics: VideoStatistics(
+                viewCount: 1,
+                danmakuCount: 1,
+                likeCount: 1
+            ),
+            durationSeconds: 10,
+            publishedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            pages: pages,
+            collection: collection
+        )
+        return GuestVideoContext(
+            detail: detail,
+            pages: pages,
+            selectedPage: pages[0],
+            playback: VideoPlayback(
+                manifest: PlaybackManifest(
+                    videoRepresentations: [],
+                    originalAudioRepresentations: []
+                ),
+                mediaHeaders: [:]
+            )
+        )
+    }
+
+    private func page(_ index: Int) -> VideoPage {
+        VideoPage(
+            cid: Int64(1_000 + index),
+            index: index,
+            title: "P\(index)",
+            durationSeconds: 10
+        )
+    }
+
+    private func episode(
+        ordinal: Int,
+        bvid: String?,
+        pages: [VideoPage]?,
+        isConsistent: Bool = true,
+        section: Int = 0
+    ) -> VideoCollectionEpisode {
+        VideoCollectionEpisode(
+            id: VideoCollectionEpisodeIdentity(
+                seasonID: 1,
+                sectionID: Int64(section + 10),
+                episodeID: Int64(ordinal + 100)
+            ),
+            ordinal: ordinal,
+            aid: nil,
+            bvid: bvid,
+            title: "第 \(ordinal + 1) 集",
+            coverURL: nil,
+            durationSeconds: 10,
+            defaultCID: pages?.first?.cid,
+            knownPages: pages,
+            isIdentityConsistent: isConsistent
+        )
+    }
+
+    private func collection(
+        sections: [[VideoCollectionEpisode]]
+    ) -> VideoCollection {
+        VideoCollection(
+            id: 1,
+            title: "合集",
+            reportedEpisodeCount: sections.reduce(0) { $0 + $1.count },
+            sections: sections.enumerated().map { ordinal, episodes in
+                VideoCollectionSection(
+                    id: VideoCollectionSectionIdentity(
+                        seasonID: 1,
+                        sectionID: Int64(ordinal + 10)
+                    ),
+                    ordinal: ordinal,
+                    title: "分区 \(ordinal + 1)",
+                    episodes: episodes
+                )
+            }
+        )
+    }
+}


### PR DESCRIPTION
## 变化

- 在 App 层引入 `PlaybackSelectionIntent(bvid:preferredCID:)`，让普通视频、合集 episode 与分 P page 使用同一条播放导航意图。
- 跨 BVID 且带 CID 时先加载详情和 pages、校验目标 CID，再只请求目标 playurl；显式用户 CID 优先于服务端续播，retry 保留完整意图。
- 同 BVID 分 P 沿用现有 `selectPage(cid:)`，并修复失败分 P 后改选新 CID 时误重试旧目标的问题。
- 将播放侧栏旧的展开式分 P List 替换为 SwiftUI `Picker(.menu)`，保持唯一外层 `ScrollView + LazyVStack`。
- 新增纯 `PlaybackSelectionProjection`，覆盖单 P 隐藏、合集静态标题、episode/page Picker、不可用项、loading/error/empty、缺失当前项 fallback，以及标题右侧 `5/10` 位置提示。
- 保留 episode occurrence identity：显式选择优先；自动匹配按 `defaultCID`、known pages 逐级消歧，仍有歧义时不伪造当前选集或序号。

## 原因

原有侧栏使用固定五行内嵌 List 和展开式分 P UI，无法统一表达 UGC 合集、跨 BVID episode 与当前分 P，也会引入第二个常驻滚动 owner。播放导航此前只携带 BVID，无法保证跨 BVID + CID 原子切换。

## 用户影响

- 多分 P 视频和 UGC 合集使用紧凑的系统菜单选择。
- 选择跨视频 episode 时不会先播放默认 P 再补切目标 P。
- loading target 与实际已呈现媒体身份分离，不会把尚未安装的目标标成正在播放。
- 同一 BVID 重复出现在不同 section/episode 时，保留真实 occurrence；无法消歧时显示说明而不是错误的 `1/N`。
- 继续复用唯一 `AppWindowOwner`、`AVPlayerEngine` 和 player host。

## 验证

- 最终静态 Gate 通过：architecture、secrets、project contract、strict swift-format、diff check。
- 最终统一选集相关 3 个 suite 共 70 tests 通过。
- `sh Scripts/run-quality-gates.sh app` 通过：Package 465 tests / 47 suites、App build-for-testing 与全部 App tests 通过；Signed Keychain smoke 因无签名环境跳过 1 项。
- 完整 App Gate 后仅进一步收紧 occurrence resolver 的匹配顺序；该最终窄调整重新通过上述 70 项定向测试与静态 Gate，未重复完整 App Gate。
- 两轮独立只读代码评审完成，最终结论 GO，无阻断 finding。

## 未覆盖边界

- 真人 VoiceOver 与 Full Keyboard Access。
- 真实网络下的选集播放全链路。
- 评论容器、评论 API、XCUI 与性能裁决均不在本 PR 范围。
