### PR TITLE
feat(danmaku): 调整视觉间距与长弹幕速度

### DIFF
--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuStyle.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuStyle.swift
@@ -29,7 +29,7 @@ public struct CoreAnimationDanmakuStyle: Sendable, Equatable {
     public init(
         fontScale: Double = 1,
         fontWeight: CoreAnimationDanmakuFontWeight = .semibold,
-        shadowBlurRadius: Double = 1.5
+        shadowBlurRadius: Double = 2
     ) {
         self.fontScale = Self.normalized(
             fontScale,
@@ -39,7 +39,7 @@ public struct CoreAnimationDanmakuStyle: Sendable, Equatable {
         self.fontWeight = fontWeight
         self.shadowBlurRadius = Self.normalized(
             shadowBlurRadius,
-            fallback: 1.5,
+            fallback: 2,
             range: Self.shadowBlurRadiusRange
         )
     }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneModels.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneModels.swift
@@ -12,7 +12,7 @@ public struct DanmakuLaneConfiguration: Sendable, Equatable {
             surfaceWidth: surfaceWidth,
             surfaceHeight: surfaceHeight,
             laneHeight: 36,
-            minimumHorizontalGap: 24,
+            minimumHorizontalGap: 40,
             maximumActiveCount: hardMaximumActiveCount,
             displayAreaFraction: 1
         )

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
@@ -9,10 +9,10 @@ struct DanmakuDensityAdmissionPolicy: Sendable, Equatable {
     init(_ density: DanmakuDensity) {
         switch density {
         case .normal:
-            minimumHorizontalGap = 24
+            minimumHorizontalGap = 40
             maximumOverlapDepth = 1
         case .increased:
-            minimumHorizontalGap = 12
+            minimumHorizontalGap = 20
             maximumOverlapDepth = 1
         case .overlapping:
             minimumHorizontalGap = 0

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuRenderingBackend.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuRenderingBackend.swift
@@ -46,8 +46,8 @@ public struct DanmakuMotionPolicy: Sendable, Equatable {
     public init(
         basePointSpeed: Double = 130,
         lengthReferenceWidth: Double = 960,
-        lengthCoefficient: Double = 0.25,
-        maximumLengthBonus: Double = 0.45,
+        lengthCoefficient: Double = 0.3,
+        maximumLengthBonus: Double = .infinity,
         minimumScrollingSeconds: Double = 1.5,
         maximumScrollingSeconds: Double = 60,
         fixedSeconds: Double = 4
@@ -65,8 +65,8 @@ public struct DanmakuMotionPolicy: Sendable, Equatable {
     init(fixedDurations: DanmakuRendererDurations) {
         basePointSpeed = 130
         lengthReferenceWidth = 960
-        lengthCoefficient = 0.25
-        maximumLengthBonus = 0.45
+        lengthCoefficient = 0.3
+        maximumLengthBonus = .infinity
         minimumScrollingSeconds = 4
         maximumScrollingSeconds = 30
         fixedSeconds = fixedDurations.fixedSeconds
@@ -92,7 +92,7 @@ public struct DanmakuMotionPolicy: Sendable, Equatable {
                 lengthReferenceWidth > 0,
                 lengthCoefficient.isFinite,
                 lengthCoefficient >= 0,
-                maximumLengthBonus.isFinite,
+                !maximumLengthBonus.isNaN,
                 maximumLengthBonus >= 0,
                 minimumScrollingSeconds.isFinite,
                 minimumScrollingSeconds > 0,

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
@@ -17,7 +17,7 @@ struct DanmakuPresentationControllerTests {
                 == CoreAnimationDanmakuStyle(
                     fontScale: 1,
                     fontWeight: .semibold,
-                    shadowBlurRadius: 1.5
+                    shadowBlurRadius: 2
                 )
         )
 
@@ -40,14 +40,14 @@ struct DanmakuPresentationControllerTests {
         )
         #expect(nonfinite.fontScale == 1)
         #expect(nonfinite.fontWeight == .regular)
-        #expect(nonfinite.shadowBlurRadius == 1.5)
+        #expect(nonfinite.shadowBlurRadius == 2)
 
         let laneConfiguration = DanmakuLaneConfiguration.production(
             surfaceWidth: 1_280,
             surfaceHeight: 720
         )
         #expect(laneConfiguration.laneHeight == 36)
-        #expect(laneConfiguration.minimumHorizontalGap == 24)
+        #expect(laneConfiguration.minimumHorizontalGap == 40)
         #expect(
             laneConfiguration.maximumActiveCount
                 == DanmakuLaneConfiguration.hardMaximumActiveCount
@@ -62,7 +62,7 @@ struct DanmakuPresentationControllerTests {
             DanmakuDensityAdmissionPolicy.init
         )
 
-        #expect(policies.map(\.minimumHorizontalGap) == [24, 12, 0])
+        #expect(policies.map(\.minimumHorizontalGap) == [40, 20, 0])
         #expect(policies.map(\.maximumOverlapDepth) == [1, 1, 3])
     }
 
@@ -233,10 +233,7 @@ struct DanmakuPresentationControllerTests {
         for scenario in scenarios {
             let lengthFactor =
                 1
-                + min(
-                    0.25 * scenario.textWidth / 960,
-                    0.45
-                )
+                + 0.3 * scenario.textWidth / 960
             var actualSpeeds: [Double] = []
             for (level, pointSpeed) in levelPointSpeeds {
                 let duration = policy.duration(
@@ -259,11 +256,11 @@ struct DanmakuPresentationControllerTests {
     }
 
     @Test
-    func lengthBonusIsContinuousAtItsCap() {
+    func lengthBonusGrowsLinearlyWithoutCap() {
         let policy = DanmakuMotionPolicy()
         let surfaceWidth = 1_100.0
-        let capWidth = 1_728.0
-        let epsilon = 0.001
+
+        #expect(policy.maximumLengthBonus == .infinity)
 
         func speed(textWidth: Double) -> Double {
             let duration = policy.duration(
@@ -275,19 +272,27 @@ struct DanmakuPresentationControllerTests {
             return (surfaceWidth + textWidth) / duration
         }
 
-        #expect(abs(speed(textWidth: capWidth) - 188.5) < 0.001)
-        #expect(
-            abs(
-                speed(textWidth: capWidth - epsilon)
-                    - speed(textWidth: capWidth)
-            ) < 0.001
-        )
-        #expect(
-            abs(
-                speed(textWidth: capWidth + epsilon)
-                    - speed(textWidth: capWidth)
-            ) < 0.001
-        )
+        #expect(abs(speed(textWidth: 960) - 169) < 0.001)
+        #expect(abs(speed(textWidth: 1_728) - 200.2) < 0.001)
+        #expect(abs(speed(textWidth: 4_000) - 292.5) < 0.001)
+    }
+
+    @Test
+    func explicitLengthBonusCapRemainsAvailableForCompatibility() {
+        let policy = DanmakuMotionPolicy(maximumLengthBonus: 0.45)
+        let surfaceWidth = 1_100.0
+
+        func speed(textWidth: Double) -> Double {
+            let duration = policy.duration(
+                for: .scrolling,
+                textWidth: textWidth,
+                surfaceWidth: surfaceWidth,
+                speedLevel: .three
+            )
+            return (surfaceWidth + textWidth) / duration
+        }
+
+        #expect(abs(speed(textWidth: 1_728) - 188.5) < 0.001)
         #expect(abs(speed(textWidth: 4_000) - 188.5) < 0.001)
     }
 
@@ -755,7 +760,7 @@ struct DanmakuPresentationControllerTests {
         )
 
         #expect(layer.shadowOpacity == 0)
-        #expect(shadow.shadowBlurRadius == 1.5)
+        #expect(shadow.shadowBlurRadius == 2)
         #expect(shadow.shadowOffset == .zero)
         #expect(renderer.activeLayerCount == 1)
     }


### PR DESCRIPTION
## 变化

- 将生产弹幕阴影模糊半径从 1.5 pt 调整为 2 pt，并同步非有限输入回退值。
- 将普通、增密、重叠三档滚动弹幕横向安全间隔调整为 40 / 20 / 0 pt，并同步生产初始配置。
- 将长弹幕速度补偿系数从 0.25 调整为 0.3；生产默认 `maximumLengthBonus` 改为 `.infinity`，使补偿按测量宽度线性增长且不再封顶。
- 保留公开 `maximumLengthBonus` 属性与 initializer 参数，显式有限 cap 的现有调用继续保持原语义。

## 原因与用户影响

本次是小范围弹幕视觉与运动校准：略微增强文字阴影，提高同轨弹幕的安全距离，并让长弹幕获得更充分的速度补偿。顶部/底部固定弹幕、纵向 lane 高度、阴影偏移与自适应黑白阴影逻辑均未改变。

## 验证

- 独立 agent 初审发现公开 API 兼容问题；修复后复审 no findings。
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer sh Scripts/run-quality-gates.sh package`
- 结果：static contracts、Swift format、518 tests / 54 suites 全部通过。
- 使用任务专属临时产物构建并打开 Danmaku Lab 预览。

## 未覆盖边界

- 未运行完整 App gate 或生产 BiliKit App。
- Computer Use 原生通道异常，未形成截图或自动目视结论。
- 未执行真实 100 字远端弹幕测量、长期高密度性能或 Instruments 验证。
