### PR TITLE
feat(comments): 渲染评论富内容

### DIFF
--- a/BiliKitMac/App/AppRootView.swift
+++ b/BiliKitMac/App/AppRootView.swift
@@ -47,6 +47,9 @@ struct AppRootView: View {
         authenticationModel: AuthenticationViewModel,
         historyModel: WatchHistoryViewModel,
         playerContent: AnyView,
+        commentAssetURLResolver: @escaping CommentAssetURLResolver = { _ in nil },
+        commentVideoLinkResolver: @escaping CommentVideoLinkResolver = { _ in nil },
+        commentLinkURLResolver: @escaping CommentLinkURLResolver = { _ in nil },
         accountSessionCoordinator: AccountSessionCoordinator = AccountSessionCoordinator()
     ) {
         self.accountSessionCoordinator = accountSessionCoordinator
@@ -59,7 +62,10 @@ struct AppRootView: View {
                 danmakuModel: danmakuModel,
                 authenticationModel: authenticationModel,
                 historyModel: historyModel,
-                playerContent: playerContent
+                playerContent: playerContent,
+                commentAssetURLResolver: commentAssetURLResolver,
+                commentVideoLinkResolver: commentVideoLinkResolver,
+                commentLinkURLResolver: commentLinkURLResolver
             )
         )
     }
@@ -74,6 +80,9 @@ struct AppRootView: View {
             authenticationModel: authenticationModel,
             historyModel: historyModel,
             playerContent: playerContent,
+            commentAssetURLResolver: windowOwner.commentAssetURLResolver,
+            commentVideoLinkResolver: windowOwner.commentVideoLinkResolver,
+            commentLinkURLResolver: windowOwner.commentLinkURLResolver,
             isAuthenticationPresented: $isAuthenticationPresented,
             submittedSearchQuery: submittedSearchQuery,
             onSubmitSearch: performSearch

--- a/BiliKitMac/App/AppShellView.swift
+++ b/BiliKitMac/App/AppShellView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// 系统返回通过 path Binding 回写 coordinator，使播放停止与视觉导航保持同一事实来源；
 /// SwiftUI `body` 与普通样式 modifier 不承担资源生命周期。
 struct AppShellView: View {
+    @Environment(\.openURL) private var openURL
     let navigationCoordinator: AppNavigationCoordinator
     let browseModel: GuestBrowseViewModel
     let videoModel: GuestVideoViewModel
@@ -16,6 +17,9 @@ struct AppShellView: View {
     let authenticationModel: AuthenticationViewModel
     let historyModel: WatchHistoryViewModel
     let playerContent: AnyView
+    let commentAssetURLResolver: CommentAssetURLResolver
+    let commentVideoLinkResolver: CommentVideoLinkResolver
+    let commentLinkURLResolver: CommentLinkURLResolver
     @Binding var isAuthenticationPresented: Bool
     let submittedSearchQuery: String?
     let onSubmitSearch: () -> Void
@@ -122,6 +126,7 @@ struct AppShellView: View {
         NativePlaybackSidebarView(
             model: videoModel,
             commentsModel: commentsModel,
+            commentAssetURLResolver: commentAssetURLResolver,
             onRetry: navigationCoordinator.retryPlayback,
             onSelectPlayback: { bvid, preferredCID in
                 navigationCoordinator.openPlayback(
@@ -131,7 +136,13 @@ struct AppShellView: View {
                     )
                 )
             },
-            onSelectCommentVideo: navigationCoordinator.openPlayback
+            onOpenCommentLink: { target in
+                if let bvid = commentVideoLinkResolver(target) {
+                    navigationCoordinator.openPlayback(bvid)
+                } else if let url = commentLinkURLResolver(target) {
+                    openURL(url)
+                }
+            }
         )
         .ignoresSafeArea(.container, edges: .top)
     }

--- a/BiliKitMac/App/AppWindowOwner.swift
+++ b/BiliKitMac/App/AppWindowOwner.swift
@@ -17,6 +17,9 @@ final class AppWindowOwner {
     let authenticationModel: AuthenticationViewModel
     let historyModel: WatchHistoryViewModel
     let playerContent: AnyView
+    let commentAssetURLResolver: CommentAssetURLResolver
+    let commentVideoLinkResolver: CommentVideoLinkResolver
+    let commentLinkURLResolver: CommentLinkURLResolver
     private let playbackPreferencesController: PlaybackPreferencesController?
     private let openEnvironment: (@MainActor @Sendable () -> Void)?
     private let closeEnvironment: (@MainActor @Sendable () -> Void)?
@@ -49,6 +52,9 @@ final class AppWindowOwner {
             authenticationModel: environment.makeAuthenticationViewModel(),
             historyModel: environment.makeWatchHistoryViewModel(),
             playerContent: environment.makePlayerView(videoModel: videoModel),
+            commentAssetURLResolver: environment.commentAssetURLResolver,
+            commentVideoLinkResolver: environment.commentVideoLinkResolver,
+            commentLinkURLResolver: environment.commentLinkURLResolver,
             playbackPreferencesController: environment.playbackPreferencesController,
             openEnvironment: environment.open,
             closeEnvironment: environment.close
@@ -84,6 +90,9 @@ final class AppWindowOwner {
         authenticationModel: AuthenticationViewModel,
         historyModel: WatchHistoryViewModel,
         playerContent: AnyView,
+        commentAssetURLResolver: @escaping CommentAssetURLResolver = { _ in nil },
+        commentVideoLinkResolver: @escaping CommentVideoLinkResolver = { _ in nil },
+        commentLinkURLResolver: @escaping CommentLinkURLResolver = { _ in nil },
         playbackPreferencesController: PlaybackPreferencesController? = nil,
         openEnvironment: (@MainActor @Sendable () -> Void)? = nil,
         closeEnvironment: (@MainActor @Sendable () -> Void)? = nil
@@ -96,6 +105,9 @@ final class AppWindowOwner {
         self.authenticationModel = authenticationModel
         self.historyModel = historyModel
         self.playerContent = playerContent
+        self.commentAssetURLResolver = commentAssetURLResolver
+        self.commentVideoLinkResolver = commentVideoLinkResolver
+        self.commentLinkURLResolver = commentLinkURLResolver
         self.playbackPreferencesController = playbackPreferencesController
         self.openEnvironment = openEnvironment
         self.closeEnvironment = closeEnvironment

--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -6,11 +6,16 @@ import BiliAuthFeature
 import BiliBrowseFeature
 import BiliDanmaku
 import BiliLibraryFeature
+import BiliModels
 import BiliNetworking
 import BiliPlayback
 import CoreGraphics
 import Foundation
 import SwiftUI
+
+typealias CommentAssetURLResolver = @Sendable (CommentAssetReference) -> URL?
+typealias CommentVideoLinkResolver = @Sendable (CommentLinkTarget) -> String?
+typealias CommentLinkURLResolver = @Sendable (CommentLinkTarget) -> URL?
 
 @MainActor
 @Observable
@@ -62,6 +67,9 @@ struct AppEnvironment {
     private let relatedVideoRepository: any RelatedVideoRepository
     private let uploaderSignatureRepository: any UploaderSignatureRepository
     private let commentRepository: any CommentRepository
+    let commentAssetURLResolver: CommentAssetURLResolver
+    let commentVideoLinkResolver: CommentVideoLinkResolver
+    let commentLinkURLResolver: CommentLinkURLResolver
     private let historyRepository: any WatchHistoryRepository
     private let danmakuSession: DanmakuSession
     private let danmakuController: DanmakuPresentationController
@@ -77,6 +85,12 @@ struct AppEnvironment {
         relatedVideoRepository: any RelatedVideoRepository,
         uploaderSignatureRepository: any UploaderSignatureRepository,
         commentRepository: any CommentRepository,
+        commentAssetURLResolver: @escaping CommentAssetURLResolver = { _ in nil },
+        commentVideoLinkResolver: @escaping CommentVideoLinkResolver = { target in
+            guard case .video(let bvid) = target else { return nil }
+            return bvid
+        },
+        commentLinkURLResolver: @escaping CommentLinkURLResolver = { _ in nil },
         historyRepository: any WatchHistoryRepository,
         danmakuRepository: any DanmakuSegmentRepository,
         playerEngine: AVPlayerEngine,
@@ -96,6 +110,9 @@ struct AppEnvironment {
         self.relatedVideoRepository = relatedVideoRepository
         self.uploaderSignatureRepository = uploaderSignatureRepository
         self.commentRepository = commentRepository
+        self.commentAssetURLResolver = commentAssetURLResolver
+        self.commentVideoLinkResolver = commentVideoLinkResolver
+        self.commentLinkURLResolver = commentLinkURLResolver
         self.historyRepository = historyRepository
         self.playerEngine = playerEngine
         self.playbackPreferencesController = playbackPreferencesController
@@ -251,11 +268,19 @@ struct AppEnvironment {
             subtitleUseCase: SubtitleUseCase(repository: subtitleRepository)
         )
         let guestRepository = BiliGuestRepository(client: api)
+        let commentAssetResolver = BiliCommentAssetResolver()
+        let commentLinkResolver = BiliCommentLinkResolver()
         return AppEnvironment(
             guestContentRepository: guestRepository,
             relatedVideoRepository: guestRepository,
             uploaderSignatureRepository: guestRepository,
             commentRepository: BiliCommentRepository(client: api),
+            commentAssetURLResolver: { reference in
+                commentAssetResolver.imageURL(for: reference)
+            },
+            commentLinkURLResolver: { target in
+                commentLinkResolver.externalURL(for: target)
+            },
             historyRepository: BiliWatchHistoryRepository(client: api),
             danmakuRepository: BiliDanmakuRepository(client: api),
             playerEngine: playerEngine,

--- a/BiliKitMac/Platform/NativeVideoImagePipeline.swift
+++ b/BiliKitMac/Platform/NativeVideoImagePipeline.swift
@@ -18,6 +18,8 @@ struct NativeVideoImageLoadResult: @unchecked Sendable {
 enum NativeVideoImageVariant: Hashable, Sendable {
     case cover
     case avatar
+    case commentEmote
+    case commentPicture
 
     var maximumDecodedPixelSize: Int {
         switch self {
@@ -25,6 +27,10 @@ enum NativeVideoImageVariant: Hashable, Sendable {
             640
         case .avatar:
             96
+        case .commentEmote:
+            128
+        case .commentPicture:
+            1_024
         }
     }
 }

--- a/BiliKitMac/Platform/PlaybackSidebar/Comments/NativePlaybackCommentAvatarLoader.swift
+++ b/BiliKitMac/Platform/PlaybackSidebar/Comments/NativePlaybackCommentAvatarLoader.swift
@@ -1,0 +1,28 @@
+import BiliModels
+import CoreGraphics
+
+@MainActor
+final class NativePlaybackCommentAvatarLoader {
+    private let imagePipeline: NativeVideoImagePipeline
+    private let resolveURL: CommentAssetURLResolver
+
+    init(
+        imagePipeline: NativeVideoImagePipeline,
+        resolveURL: @escaping CommentAssetURLResolver
+    ) {
+        self.imagePipeline = imagePipeline
+        self.resolveURL = resolveURL
+    }
+
+    func cachedImage(for reference: CommentAssetReference) -> CGImage? {
+        guard let url = resolveURL(reference) else { return nil }
+        return imagePipeline.cachedImage(for: url, variant: .avatar)
+    }
+
+    func image(
+        for reference: CommentAssetReference
+    ) async -> NativeVideoImageLoadResult? {
+        guard let url = resolveURL(reference) else { return nil }
+        return await imagePipeline.image(for: url, variant: .avatar)
+    }
+}

--- a/BiliKitMac/Platform/PlaybackSidebar/Comments/NativePlaybackCommentPictureLoader.swift
+++ b/BiliKitMac/Platform/PlaybackSidebar/Comments/NativePlaybackCommentPictureLoader.swift
@@ -1,0 +1,28 @@
+import BiliModels
+import CoreGraphics
+
+@MainActor
+final class NativePlaybackCommentPictureLoader {
+    private let imagePipeline: NativeVideoImagePipeline
+    private let resolveURL: CommentAssetURLResolver
+
+    init(
+        imagePipeline: NativeVideoImagePipeline,
+        resolveURL: @escaping CommentAssetURLResolver
+    ) {
+        self.imagePipeline = imagePipeline
+        self.resolveURL = resolveURL
+    }
+
+    func cachedImage(for reference: CommentAssetReference) -> CGImage? {
+        guard let url = resolveURL(reference) else { return nil }
+        return imagePipeline.cachedImage(for: url, variant: .commentPicture)
+    }
+
+    func image(
+        for reference: CommentAssetReference
+    ) async -> NativeVideoImageLoadResult? {
+        guard let url = resolveURL(reference) else { return nil }
+        return await imagePipeline.image(for: url, variant: .commentPicture)
+    }
+}

--- a/BiliKitMac/Platform/PlaybackSidebar/Comments/NativePlaybackCommentTextRenderer.swift
+++ b/BiliKitMac/Platform/PlaybackSidebar/Comments/NativePlaybackCommentTextRenderer.swift
@@ -1,0 +1,251 @@
+import AppKit
+import BiliModels
+
+struct NativePlaybackCommentTextScope: Hashable {
+    let subject: CommentSubjectIdentity
+    let rootID: CommentID
+    let revision: Int
+}
+
+@MainActor
+final class NativePlaybackCommentTextRenderer {
+    struct PendingAsset: Hashable {
+        let reference: CommentAssetReference
+        let url: URL
+    }
+
+    struct RenderedText {
+        let attributedString: NSAttributedString
+        let attachments: [CommentAssetReference: [NSTextAttachment]]
+        let pendingAssets: [PendingAsset]
+        let linkTargets: [CommentLinkTarget]
+    }
+
+    private let imagePipeline: NativeVideoImagePipeline
+    private let resolveURL: CommentAssetURLResolver
+    private struct UnavailableAssetKey: Hashable {
+        let scope: NativePlaybackCommentTextScope
+        let reference: CommentAssetReference
+    }
+
+    private static let maximumUnavailableAssetCount = 512
+    private var activeScopes: Set<NativePlaybackCommentTextScope> = []
+    private var unavailableAssets: Set<UnavailableAssetKey> = []
+    private var unavailableAssetOrder: [UnavailableAssetKey] = []
+    private var unavailableAssetOrderHead = 0
+    private static let standardPlaceholder = placeholderImage(side: 18)
+    private static let largePlaceholder = placeholderImage(side: 36)
+
+    init(
+        imagePipeline: NativeVideoImagePipeline,
+        resolveURL: @escaping CommentAssetURLResolver
+    ) {
+        self.imagePipeline = imagePipeline
+        self.resolveURL = resolveURL
+    }
+
+    func render(
+        _ content: CommentContent,
+        scope: NativePlaybackCommentTextScope
+    ) -> RenderedText {
+        let font = NSFont.preferredFont(forTextStyle: .body)
+        let attributed = NSMutableAttributedString(
+            string: content.message,
+            attributes: [
+                .font: font,
+                .foregroundColor: NSColor.labelColor,
+                .paragraphStyle: NativePlaybackSidebarTextLayout.paragraphStyle,
+            ]
+        )
+        let linkTargets = applyLinks(content.links, to: attributed)
+
+        var attachments: [CommentAssetReference: [NSTextAttachment]] = [:]
+        var pendingByReference: [CommentAssetReference: PendingAsset] = [:]
+        for emote in content.emotes.sorted(by: Self.reverseRangeOrder) {
+            guard
+                !unavailableAssets.contains(
+                    UnavailableAssetKey(scope: scope, reference: emote.asset)
+                ),
+                emote.size != .unknown,
+                let url = resolveURL(emote.asset)
+            else { continue }
+            let range = NSRange(
+                location: emote.range.location,
+                length: emote.range.length
+            )
+            guard range.location >= 0, range.length > 0,
+                NSMaxRange(range) <= attributed.length
+            else { continue }
+
+            let image = imagePipeline.cachedImage(for: url, variant: .commentEmote)
+            let attachment = makeAttachment(
+                image: image,
+                size: emote.size,
+                font: font
+            )
+            attributed.replaceCharacters(
+                in: range,
+                with: NSAttributedString(attachment: attachment)
+            )
+            attachments[emote.asset, default: []].append(attachment)
+            if image == nil {
+                pendingByReference[emote.asset] = PendingAsset(
+                    reference: emote.asset,
+                    url: url
+                )
+            }
+        }
+
+        return RenderedText(
+            attributedString: attributed,
+            attachments: attachments,
+            pendingAssets: pendingByReference.values.sorted {
+                $0.url.absoluteString < $1.url.absoluteString
+            },
+            linkTargets: linkTargets
+        )
+    }
+
+    func load(_ pending: PendingAsset) async -> NativeVideoImageLoadResult? {
+        await imagePipeline.image(for: pending.url, variant: .commentEmote)
+    }
+
+    func markUnavailable(
+        _ reference: CommentAssetReference,
+        in scope: NativePlaybackCommentTextScope
+    ) -> Bool {
+        guard activeScopes.contains(scope) else { return false }
+        let key = UnavailableAssetKey(scope: scope, reference: reference)
+        if unavailableAssets.insert(key).inserted {
+            unavailableAssetOrder.append(key)
+            trimUnavailableAssetsIfNeeded()
+        }
+        return true
+    }
+
+    func retainFailureScopes(_ scopes: Set<NativePlaybackCommentTextScope>) {
+        activeScopes = scopes
+        unavailableAssets = unavailableAssets.filter { scopes.contains($0.scope) }
+        unavailableAssetOrder = unavailableAssetOrder[
+            unavailableAssetOrderHead...
+        ].filter { unavailableAssets.contains($0) }
+        unavailableAssetOrderHead = 0
+    }
+
+    func removeAllFailures() {
+        activeScopes.removeAll(keepingCapacity: false)
+        unavailableAssets.removeAll(keepingCapacity: false)
+        unavailableAssetOrder.removeAll(keepingCapacity: false)
+        unavailableAssetOrderHead = 0
+    }
+
+    func apply(
+        _ result: NativeVideoImageLoadResult,
+        to attachments: [NSTextAttachment]
+    ) {
+        for attachment in attachments {
+            attachment.image = NSImage(
+                cgImage: result.image,
+                size: attachment.bounds.size
+            )
+        }
+    }
+
+    func height(
+        _ content: CommentContent,
+        width: CGFloat,
+        scope: NativePlaybackCommentTextScope
+    ) -> CGFloat {
+        NativePlaybackSidebarTextLayout.height(
+            render(content, scope: scope).attributedString,
+            width: width
+        )
+    }
+
+    private func trimUnavailableAssetsIfNeeded() {
+        while unavailableAssets.count > Self.maximumUnavailableAssetCount,
+            unavailableAssetOrderHead < unavailableAssetOrder.count
+        {
+            unavailableAssets.remove(unavailableAssetOrder[unavailableAssetOrderHead])
+            unavailableAssetOrderHead += 1
+        }
+        if unavailableAssetOrderHead >= Self.maximumUnavailableAssetCount,
+            unavailableAssetOrderHead * 2 >= unavailableAssetOrder.count
+        {
+            unavailableAssetOrder.removeFirst(unavailableAssetOrderHead)
+            unavailableAssetOrderHead = 0
+        }
+    }
+
+    private func makeAttachment(
+        image: CGImage?,
+        size: CommentEmoteSize,
+        font: NSFont
+    ) -> NSTextAttachment {
+        let side = Self.sideLength(for: size)
+        let attachment = NSTextAttachment()
+        attachment.allowsTextAttachmentView = false
+        attachment.bounds = NSRect(
+            x: 0,
+            y: font.descender,
+            width: side,
+            height: side
+        )
+        attachment.image =
+            image.map {
+                NSImage(cgImage: $0, size: NSSize(width: side, height: side))
+            } ?? Self.placeholder(for: size)
+        return attachment
+    }
+
+    private func applyLinks(
+        _ links: [CommentLink],
+        to attributed: NSMutableAttributedString
+    ) -> [CommentLinkTarget] {
+        var targets: [CommentLinkTarget] = []
+        for link in links {
+            let range = NSRange(
+                location: link.range.location,
+                length: link.range.length
+            )
+            guard range.location >= 0, range.length > 0,
+                NSMaxRange(range) <= attributed.length
+            else { continue }
+            let value = "bilikit-comment-link-\(targets.count)"
+            targets.append(link.target)
+            attributed.addAttribute(.link, value: value, range: range)
+        }
+        return targets
+    }
+
+    private static func reverseRangeOrder(_ lhs: CommentEmote, _ rhs: CommentEmote) -> Bool {
+        if lhs.range.location != rhs.range.location {
+            return lhs.range.location > rhs.range.location
+        }
+        return lhs.range.length < rhs.range.length
+    }
+
+    private static func sideLength(for size: CommentEmoteSize) -> CGFloat {
+        switch size {
+        case .standard: 18
+        case .large: 36
+        case .unknown: 18
+        }
+    }
+
+    private static func placeholder(for size: CommentEmoteSize) -> NSImage {
+        size == .large ? largePlaceholder : standardPlaceholder
+    }
+
+    private static func placeholderImage(side: CGFloat) -> NSImage {
+        NSImage(size: NSSize(width: side, height: side), flipped: false) { rect in
+            NSColor.quaternaryLabelColor.withAlphaComponent(0.18).setFill()
+            NSBezierPath(
+                roundedRect: rect.insetBy(dx: 1, dy: 1),
+                xRadius: side / 4,
+                yRadius: side / 4
+            ).fill()
+            return true
+        }
+    }
+}

--- a/BiliKitMac/Platform/PlaybackSidebar/Comments/NativePlaybackCommentsItems.swift
+++ b/BiliKitMac/Platform/PlaybackSidebar/Comments/NativePlaybackCommentsItems.swift
@@ -34,18 +34,24 @@ enum NativePlaybackCommentsItemMeasurement {
 
     static func thread(
         _ presentation: NativePlaybackCommentThreadPresentation,
-        width: CGFloat
+        width: CGFloat,
+        textRenderer: NativePlaybackCommentTextRenderer? = nil
     ) -> CGFloat {
+        let textScope = presentation.textScope
         let rootHeight = comment(
             presentation.thread.root,
             width: width,
-            isReply: false
+            isReply: false,
+            textRenderer: textRenderer,
+            textScope: textScope
         )
         let panelWidth = max(80, width - replyPanelLeading)
         let panelHeight = repliesPanel(
             thread: presentation.thread,
             replyState: presentation.replyState,
-            width: panelWidth
+            width: panelWidth,
+            textRenderer: textRenderer,
+            textScope: textScope
         )
         return ceil(
             rootVerticalInset + rootHeight
@@ -57,7 +63,9 @@ enum NativePlaybackCommentsItemMeasurement {
     static func comment(
         _ comment: BiliModels.Comment,
         width: CGFloat,
-        isReply: Bool
+        isReply: Bool,
+        textRenderer: NativePlaybackCommentTextRenderer? = nil,
+        textScope: NativePlaybackCommentTextScope? = nil
     ) -> CGFloat {
         switch comment.payload {
         case .unavailable:
@@ -67,11 +75,20 @@ enum NativePlaybackCommentsItemMeasurement {
             let contentWidth = max(60, width - avatar - contentGap)
             let bodyHeight = max(
                 18,
-                NativePlaybackSidebarTextLayout.height(
-                    details.content.message,
-                    width: contentWidth,
-                    font: .preferredFont(forTextStyle: .body)
-                )
+                textRenderer.flatMap { renderer in
+                    textScope.map {
+                        renderer.height(
+                            details.content,
+                            width: contentWidth,
+                            scope: $0
+                        )
+                    }
+                }
+                    ?? NativePlaybackSidebarTextLayout.height(
+                        details.content.message,
+                        width: contentWidth,
+                        font: .preferredFont(forTextStyle: .body)
+                    )
             )
             let authorHeight = authorLineHeight(
                 details.author,
@@ -80,12 +97,14 @@ enum NativePlaybackCommentsItemMeasurement {
             )
             var contentHeight: CGFloat = authorHeight + 6 + bodyHeight
             if details.content.pictureCount > 0 {
+                let pictureLayout = NativePlaybackCommentPictureLayout.make(
+                    images: details.content.pictures,
+                    count: details.content.pictureCount,
+                    availableWidth: contentWidth
+                )
                 contentHeight +=
                     8
-                    + pictureGridHeight(
-                        count: details.content.pictureCount,
-                        width: contentWidth
-                    )
+                    + pictureLayout.size.height
             }
             contentHeight += 6 + 18
             if hasVisibleProvenance(details.provenance) {
@@ -98,7 +117,9 @@ enum NativePlaybackCommentsItemMeasurement {
     static func repliesPanel(
         thread: CommentThread,
         replyState: PlaybackCommentReplyState?,
-        width: CGFloat
+        width: CGFloat,
+        textRenderer: NativePlaybackCommentTextRenderer? = nil,
+        textScope: NativePlaybackCommentTextScope? = nil
     ) -> CGFloat {
         guard case .available(let details) = thread.root.payload,
             details.replyCount > 0
@@ -108,7 +129,13 @@ enum NativePlaybackCommentsItemMeasurement {
         if let replyState, replyState.isExpanded {
             height += 20 + 10
             for (index, reply) in replyState.replies.enumerated() {
-                height += comment(reply, width: innerWidth, isReply: true)
+                height += comment(
+                    reply,
+                    width: innerWidth,
+                    isReply: true,
+                    textRenderer: textRenderer,
+                    textScope: textScope
+                )
                 if index < replyState.replies.count - 1 { height += 8 }
             }
             if replyState.isLoading || replyState.error != nil {
@@ -120,7 +147,13 @@ enum NativePlaybackCommentsItemMeasurement {
         } else {
             let replies = Array(thread.replyPreview.prefix(2))
             for (index, reply) in replies.enumerated() {
-                height += comment(reply, width: innerWidth, isReply: true)
+                height += comment(
+                    reply,
+                    width: innerWidth,
+                    isReply: true,
+                    textRenderer: textRenderer,
+                    textScope: textScope
+                )
                 if index < replies.count - 1 { height += 8 }
             }
             if replies.count < details.replyCount {
@@ -129,21 +162,6 @@ enum NativePlaybackCommentsItemMeasurement {
             }
         }
         return ceil(height + replyPanelPadding)
-    }
-
-    static func pictureGridHeight(count: Int, width: CGFloat) -> CGFloat {
-        let displayedCount = min(max(count, 0), 9)
-        guard displayedCount > 0 else { return 0 }
-        if displayedCount == 1 {
-            return min(168, floor(width * 0.75))
-        }
-        let columns = displayedCount >= 5 ? 3 : 2
-        let gap: CGFloat = 4
-        let tile = floor(
-            (width - CGFloat(columns - 1) * gap) / CGFloat(columns)
-        )
-        let rows = (displayedCount + columns - 1) / columns
-        return CGFloat(rows) * tile + CGFloat(rows - 1) * gap
     }
 
     static func hasVisibleProvenance(_ values: [CommentProvenance]) -> Bool {
@@ -651,22 +669,30 @@ final class NativePlaybackCommentThreadItem: NSCollectionViewItem {
 
     func configure(
         presentation: NativePlaybackCommentThreadPresentation,
+        textRenderer: NativePlaybackCommentTextRenderer,
+        avatarLoader: NativePlaybackCommentAvatarLoader,
+        pictureLoader: NativePlaybackCommentPictureLoader,
+        onTextLayoutChange: @escaping () -> Void,
         onExpand: @escaping () -> Void,
         onCollapse: @escaping () -> Void,
         onPrevious: @escaping () -> Void,
         onNext: @escaping () -> Void,
         onRetry: @escaping () -> Void,
-        onOpenVideo: @escaping (String) -> Void
+        onOpenLink: @escaping (CommentLinkTarget) -> Void
     ) {
         representedObject = presentation
         contentView.configure(
             presentation: presentation,
+            textRenderer: textRenderer,
+            avatarLoader: avatarLoader,
+            pictureLoader: pictureLoader,
+            onTextLayoutChange: onTextLayoutChange,
             onExpand: onExpand,
             onCollapse: onCollapse,
             onPrevious: onPrevious,
             onNext: onNext,
             onRetry: onRetry,
-            onOpenVideo: onOpenVideo
+            onOpenLink: onOpenLink
         )
     }
 
@@ -688,6 +714,7 @@ private final class NativePlaybackCommentThreadView: NSView {
     private let repliesPanel = NativePlaybackCommentRepliesPanelView()
     private let separator = NSBox()
     private var presentation: NativePlaybackCommentThreadPresentation?
+    private var textRenderer: NativePlaybackCommentTextRenderer?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -703,28 +730,44 @@ private final class NativePlaybackCommentThreadView: NSView {
 
     func configure(
         presentation: NativePlaybackCommentThreadPresentation,
+        textRenderer: NativePlaybackCommentTextRenderer,
+        avatarLoader: NativePlaybackCommentAvatarLoader,
+        pictureLoader: NativePlaybackCommentPictureLoader,
+        onTextLayoutChange: @escaping () -> Void,
         onExpand: @escaping () -> Void,
         onCollapse: @escaping () -> Void,
         onPrevious: @escaping () -> Void,
         onNext: @escaping () -> Void,
         onRetry: @escaping () -> Void,
-        onOpenVideo: @escaping (String) -> Void
+        onOpenLink: @escaping (CommentLinkTarget) -> Void
     ) {
         self.presentation = presentation
+        self.textRenderer = textRenderer
+        let textScope = presentation.textScope
         rootRow.configure(
             comment: presentation.thread.root,
             isReply: false,
-            onOpenVideo: onOpenVideo
+            textRenderer: textRenderer,
+            avatarLoader: avatarLoader,
+            pictureLoader: pictureLoader,
+            textScope: textScope,
+            onTextLayoutChange: onTextLayoutChange,
+            onOpenLink: onOpenLink
         )
         repliesPanel.configure(
             thread: presentation.thread,
             replyState: presentation.replyState,
+            textRenderer: textRenderer,
+            avatarLoader: avatarLoader,
+            pictureLoader: pictureLoader,
+            textScope: textScope,
+            onTextLayoutChange: onTextLayoutChange,
             onExpand: onExpand,
             onCollapse: onCollapse,
             onPrevious: onPrevious,
             onNext: onNext,
             onRetry: onRetry,
-            onOpenVideo: onOpenVideo
+            onOpenLink: onOpenLink
         )
         needsLayout = true
     }
@@ -735,7 +778,9 @@ private final class NativePlaybackCommentThreadView: NSView {
         let rootHeight = NativePlaybackCommentsItemMeasurement.comment(
             presentation.thread.root,
             width: bounds.width,
-            isReply: false
+            isReply: false,
+            textRenderer: textRenderer,
+            textScope: presentation.textScope
         )
         rootRow.frame = NSRect(
             x: 0,
@@ -750,7 +795,9 @@ private final class NativePlaybackCommentThreadView: NSView {
         let panelHeight = NativePlaybackCommentsItemMeasurement.repliesPanel(
             thread: presentation.thread,
             replyState: presentation.replyState,
-            width: panelWidth
+            width: panelWidth,
+            textRenderer: textRenderer,
+            textScope: presentation.textScope
         )
         repliesPanel.isHidden = panelHeight <= 0
         repliesPanel.frame = NSRect(
@@ -768,12 +815,13 @@ private final class NativePlaybackCommentThreadView: NSView {
     }
 
     func releaseOffscreenResources() {
-        rootRow.releaseTextStorage()
-        repliesPanel.releaseTextStorage()
+        rootRow.releaseOffscreenResources()
+        repliesPanel.releaseOffscreenResources()
     }
 
     func reset() {
         presentation = nil
+        textRenderer = nil
         rootRow.reset()
         repliesPanel.reset()
     }
@@ -794,6 +842,8 @@ private final class NativePlaybackCommentRowView: NSView {
     private let unavailableLabel = NSTextField(labelWithString: "")
     private var comment: BiliModels.Comment?
     private var isReply = false
+    private var textRenderer: NativePlaybackCommentTextRenderer?
+    private var textScope: NativePlaybackCommentTextScope?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -846,13 +896,22 @@ private final class NativePlaybackCommentRowView: NSView {
     func configure(
         comment: BiliModels.Comment,
         isReply: Bool,
-        onOpenVideo: @escaping (String) -> Void
+        textRenderer: NativePlaybackCommentTextRenderer,
+        avatarLoader: NativePlaybackCommentAvatarLoader,
+        pictureLoader: NativePlaybackCommentPictureLoader,
+        textScope: NativePlaybackCommentTextScope,
+        onTextLayoutChange: @escaping () -> Void,
+        onOpenLink: @escaping (CommentLinkTarget) -> Void
     ) {
         self.comment = comment
         self.isReply = isReply
-        bodyText.onOpenVideo = onOpenVideo
+        self.textRenderer = textRenderer
+        self.textScope = textScope
+        bodyText.onOpenLink = onOpenLink
         switch comment.payload {
         case .unavailable(let reason):
+            avatar.releaseImage()
+            pictures.releaseImages()
             avatar.isHidden = true
             authorLabel.isHidden = true
             authorBadges.isHidden = true
@@ -874,15 +933,28 @@ private final class NativePlaybackCommentRowView: NSView {
             likeImage.isHidden = false
             likeLabel.isHidden = false
             unavailableLabel.isHidden = true
-            avatar.configure(author: details.author, isReply: isReply)
+            avatar.configure(
+                author: details.author,
+                isReply: isReply,
+                loader: avatarLoader
+            )
             authorLabel.stringValue = details.author.name
             authorLabel.textColor = Self.authorColor(details.author)
             authorLabel.setAccessibilityLabel(
                 Self.authorAccessibility(details.author)
             )
             authorBadges.configure(author: details.author, isReply: isReply)
-            bodyText.setContent(details.content)
-            pictures.count = details.content.pictureCount
+            bodyText.setContent(
+                details.content,
+                renderer: textRenderer,
+                scope: textScope,
+                onLayoutChange: onTextLayoutChange
+            )
+            pictures.configure(
+                images: details.content.pictures,
+                count: details.content.pictureCount,
+                loader: pictureLoader
+            )
             pictures.isHidden = details.content.pictureCount == 0
             metadataLabel.stringValue = Self.metadataLeading(details)
             metadataLabel.setAccessibilityLabel(Self.metadataAccessibility(details))
@@ -948,27 +1020,37 @@ private final class NativePlaybackCommentRowView: NSView {
                 ) + 6
             let bodyHeight = max(
                 18,
-                NativePlaybackSidebarTextLayout.height(
-                    details.content.message,
-                    width: contentWidth,
-                    font: .preferredFont(forTextStyle: .body)
-                )
+                textRenderer.flatMap { renderer in
+                    textScope.map {
+                        renderer.height(
+                            details.content,
+                            width: contentWidth,
+                            scope: $0
+                        )
+                    }
+                }
+                    ?? NativePlaybackSidebarTextLayout.height(
+                        details.content.message,
+                        width: contentWidth,
+                        font: .preferredFont(forTextStyle: .body)
+                    )
             )
             bodyText.frame = NSRect(x: contentX, y: y, width: contentWidth, height: bodyHeight)
             y += bodyHeight
             if details.content.pictureCount > 0 {
                 y += 8
-                let picturesHeight = NativePlaybackCommentsItemMeasurement.pictureGridHeight(
+                let pictureLayout = NativePlaybackCommentPictureLayout.make(
+                    images: details.content.pictures,
                     count: details.content.pictureCount,
-                    width: contentWidth
+                    availableWidth: contentWidth
                 )
                 pictures.frame = NSRect(
                     x: contentX,
                     y: y,
-                    width: contentWidth,
-                    height: picturesHeight
+                    width: pictureLayout.size.width,
+                    height: pictureLayout.size.height
                 )
-                y += picturesHeight
+                y += pictureLayout.size.height
             } else {
                 pictures.frame = .zero
             }
@@ -1010,12 +1092,17 @@ private final class NativePlaybackCommentRowView: NSView {
         }
     }
 
-    func releaseTextStorage() {
+    func releaseOffscreenResources() {
         bodyText.releaseTextStorage()
+        avatar.releaseImage()
+        pictures.releaseImages()
     }
 
     func reset() {
         comment = nil
+        textRenderer = nil
+        textScope = nil
+        avatar.reset()
         bodyText.reset()
         unavailableLabel.stringValue = ""
         authorLabel.stringValue = ""
@@ -1023,7 +1110,7 @@ private final class NativePlaybackCommentRowView: NSView {
         metadataLabel.stringValue = ""
         likeLabel.stringValue = ""
         provenanceBadges.reset()
-        pictures.count = 0
+        pictures.reset()
     }
 
     private static func authorColor(_ author: CommentAuthor) -> NSColor {
@@ -1388,7 +1475,14 @@ final class NativePlaybackCommentProvenanceBadgesView: NSView {
 
 @MainActor
 private final class NativePlaybackCommentTextView: NSTextView, NSTextViewDelegate {
-    var onOpenVideo: ((String) -> Void)?
+    var onOpenLink: ((CommentLinkTarget) -> Void)?
+    private var content: CommentContent?
+    private var renderer: NativePlaybackCommentTextRenderer?
+    private var scope: NativePlaybackCommentTextScope?
+    private var onLayoutChange: (() -> Void)?
+    private var renderGeneration: UInt64 = 0
+    private var renderTask: Task<Void, Never>?
+    private var linkTargets: [CommentLinkTarget] = []
 
     init() {
         let storage = NSTextStorage()
@@ -1409,8 +1503,7 @@ private final class NativePlaybackCommentTextView: NSTextView, NSTextViewDelegat
         isVerticallyResizable = false
         textContainerInset = .zero
         linkTextAttributes = [
-            .foregroundColor: NSColor.linkColor,
-            .underlineStyle: NSUnderlineStyle.single.rawValue,
+            .foregroundColor: NSColor.linkColor
         ]
         setAccessibilityRole(.staticText)
     }
@@ -1426,44 +1519,115 @@ private final class NativePlaybackCommentTextView: NSTextView, NSTextViewDelegat
         super.layout()
     }
 
-    func setContent(_ content: CommentContent) {
+    func setContent(
+        _ content: CommentContent,
+        renderer: NativePlaybackCommentTextRenderer,
+        scope: NativePlaybackCommentTextScope,
+        onLayoutChange: @escaping () -> Void
+    ) {
+        renderGeneration &+= 1
+        renderTask?.cancel()
+        self.content = content
+        self.renderer = renderer
+        self.scope = scope
+        self.onLayoutChange = onLayoutChange
+        applyContent()
+    }
+
+    private func applyContent() {
+        guard let content, let renderer, let scope else { return }
         let previousSelections = selectedRanges
-        let attributed = NSMutableAttributedString(
-            string: content.message,
-            attributes: [
-                .font: NSFont.preferredFont(forTextStyle: .body),
-                .foregroundColor: NSColor.labelColor,
-                .paragraphStyle: NativePlaybackSidebarTextLayout.paragraphStyle,
-            ]
-        )
-        let fullLength = attributed.length
-        for link in content.links {
-            let range = NSRange(location: link.range.location, length: link.range.length)
-            guard range.location >= 0, range.length >= 0,
-                NSMaxRange(range) <= fullLength
-            else { continue }
-            guard case .video(let bvid) = link.target,
-                let escaped = bvid.addingPercentEncoding(
-                    withAllowedCharacters: .urlPathAllowed
-                ),
-                let url = URL(string: "bilikit-comment://video/\(escaped)")
-            else { continue }
-            attributed.addAttribute(.link, value: url, range: range)
-        }
-        textStorage?.setAttributedString(attributed)
+        let rendered = renderer.render(content, scope: scope)
+        textStorage?.setAttributedString(rendered.attributedString)
+        linkTargets = rendered.linkTargets
         selectedRanges = NativePlaybackSidebarReadOnlyTextView.clampedSelections(
             previousSelections,
-            textLength: fullLength
+            textLength: rendered.attributedString.length
         )
         setAccessibilityLabel(content.message)
+        scheduleLoads(rendered)
+    }
+
+    private func scheduleLoads(
+        _ rendered: NativePlaybackCommentTextRenderer.RenderedText
+    ) {
+        renderTask?.cancel()
+        guard let renderer, let scheduledScope = scope,
+            !rendered.pendingAssets.isEmpty
+        else {
+            renderTask = nil
+            return
+        }
+        let generation = renderGeneration
+        renderTask = Task { [weak self] in
+            let results = await withTaskGroup(
+                of: (
+                    NativePlaybackCommentTextRenderer.PendingAsset,
+                    NativeVideoImageLoadResult?
+                ).self
+            ) { group in
+                for pending in rendered.pendingAssets {
+                    group.addTask {
+                        (pending, await renderer.load(pending))
+                    }
+                }
+                var values:
+                    [(
+                        NativePlaybackCommentTextRenderer.PendingAsset,
+                        NativeVideoImageLoadResult?
+                    )] = []
+                for await value in group { values.append(value) }
+                return values
+            }
+            guard !Task.isCancelled,
+                let self,
+                generation == self.renderGeneration,
+                self.scope == scheduledScope
+            else { return }
+
+            var hasFailure = false
+            for (pending, result) in results {
+                if let result {
+                    renderer.apply(
+                        result,
+                        to: rendered.attachments[pending.reference] ?? []
+                    )
+                } else if renderer.markUnavailable(
+                    pending.reference,
+                    in: scheduledScope
+                ) {
+                    hasFailure = true
+                }
+            }
+            if hasFailure {
+                applyContent()
+                onLayoutChange?()
+            } else {
+                layoutManager?.invalidateDisplay(
+                    forCharacterRange: NSRange(
+                        location: 0,
+                        length: textStorage?.length ?? 0
+                    )
+                )
+                needsDisplay = true
+            }
+        }
     }
 
     func releaseTextStorage() {
+        renderGeneration &+= 1
+        renderTask?.cancel()
+        renderTask = nil
+        content = nil
+        renderer = nil
+        scope = nil
+        onLayoutChange = nil
+        linkTargets.removeAll(keepingCapacity: false)
         textStorage?.setAttributedString(NSAttributedString(string: ""))
     }
 
     func reset() {
-        onOpenVideo = nil
+        onOpenLink = nil
         releaseTextStorage()
     }
 
@@ -1472,33 +1636,47 @@ private final class NativePlaybackCommentTextView: NSTextView, NSTextViewDelegat
         clickedOnLink link: Any,
         at charIndex: Int
     ) -> Bool {
-        guard let url = link as? URL,
-            url.scheme == "bilikit-comment",
-            url.host == "video"
-        else { return false }
-        let bvid = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        guard !bvid.isEmpty else { return false }
-        onOpenVideo?(bvid)
+        guard let value = link as? String,
+            value.hasPrefix("bilikit-comment-link-"),
+            let index = Int(value.dropFirst("bilikit-comment-link-".count)),
+            linkTargets.indices.contains(index)
+        else { return true }
+        onOpenLink?(linkTargets[index])
         return true
+    }
+}
+
+enum NativePlaybackCommentImageTransition {
+    static let duration: CFTimeInterval = 0.15
+
+    static func shouldAnimate(loadOrigin: NativeVideoImageLoadOrigin) -> Bool {
+        loadOrigin.shouldAnimate
     }
 }
 
 @MainActor
 private final class NativePlaybackCommentAvatarView: NSView {
     override var isFlipped: Bool { true }
+    private let avatarImage = NSImageView()
     private let initialLabel = NSTextField(labelWithString: "")
     private let badgeImage = NSImageView()
     private var author: CommentAuthor?
     private var isReply = false
+    private var imageGeneration: UInt64 = 0
+    private var imageTask: Task<Void, Never>?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
+        avatarImage.wantsLayer = true
+        avatarImage.imageScaling = .scaleAxesIndependently
+        avatarImage.setAccessibilityElement(false)
         initialLabel.alignment = .center
         initialLabel.textColor = .white
         badgeImage.contentTintColor = .white
         badgeImage.imageScaling = .scaleProportionallyDown
         badgeImage.setAccessibilityElement(false)
+        addSubview(avatarImage)
         addSubview(initialLabel)
         addSubview(badgeImage)
         setAccessibilityElement(false)
@@ -1507,9 +1685,17 @@ private final class NativePlaybackCommentAvatarView: NSView {
     @available(*, unavailable)
     required init?(coder: NSCoder) { nil }
 
-    func configure(author: CommentAuthor, isReply: Bool) {
+    func configure(
+        author: CommentAuthor,
+        isReply: Bool,
+        loader: NativePlaybackCommentAvatarLoader
+    ) {
+        cancelImageRequest()
         self.author = author
         self.isReply = isReply
+        avatarImage.image = nil
+        avatarImage.isHidden = true
+        initialLabel.isHidden = false
         initialLabel.stringValue = author.name.first.map(String.init) ?? "•"
         initialLabel.font = .systemFont(ofSize: isReply ? 9 : 12, weight: .bold)
         let symbolName: String? =
@@ -1522,12 +1708,38 @@ private final class NativePlaybackCommentAvatarView: NSView {
             NSImage(systemSymbolName: $0, accessibilityDescription: nil)
         }
         badgeImage.isHidden = badgeImage.image == nil
+        if let reference = author.avatar {
+            if let cached = loader.cachedImage(for: reference) {
+                apply(cached, animated: false)
+            } else {
+                let generation = imageGeneration
+                imageTask = Task { [weak self] in
+                    let result = await loader.image(for: reference)
+                    guard let self, !Task.isCancelled,
+                        self.imageGeneration == generation,
+                        self.author?.avatar == reference
+                    else { return }
+                    self.imageTask = nil
+                    guard let result else { return }
+                    self.apply(
+                        result.image,
+                        animated: NativePlaybackCommentImageTransition.shouldAnimate(
+                            loadOrigin: result.origin
+                        )
+                    )
+                }
+            }
+        }
         needsLayout = true
         needsDisplay = true
     }
 
     override func layout() {
         super.layout()
+        avatarImage.frame = bounds
+        avatarImage.wantsLayer = true
+        avatarImage.layer?.cornerRadius = bounds.width / 2
+        avatarImage.layer?.masksToBounds = true
         initialLabel.frame = bounds
         let badgeSize: CGFloat = isReply ? 10 : 13
         badgeImage.frame = NSRect(
@@ -1547,6 +1759,7 @@ private final class NativePlaybackCommentAvatarView: NSView {
 
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
+        guard !initialLabel.isHidden else { return }
         let path = NSBezierPath(ovalIn: bounds)
         path.addClip()
         NSGradient(
@@ -1554,63 +1767,416 @@ private final class NativePlaybackCommentAvatarView: NSView {
             ending: .systemBlue
         )?.draw(in: bounds, angle: -45)
     }
+
+    func releaseImage() {
+        cancelImageRequest()
+        avatarImage.image = nil
+        avatarImage.isHidden = true
+        initialLabel.isHidden = false
+        needsDisplay = true
+    }
+
+    func reset() {
+        releaseImage()
+        author = nil
+        initialLabel.stringValue = ""
+        badgeImage.image = nil
+        badgeImage.isHidden = true
+    }
+
+    private func cancelImageRequest() {
+        imageGeneration &+= 1
+        imageTask?.cancel()
+        imageTask = nil
+        avatarImage.layer?.removeAnimation(
+            forKey: "native-playback-comment-avatar.fade"
+        )
+        avatarImage.layer?.opacity = 1
+    }
+
+    private func apply(_ image: CGImage, animated: Bool) {
+        let generation = imageGeneration
+        avatarImage.image = NSImage(
+            cgImage: image,
+            size: NSSize(width: image.width, height: image.height)
+        )
+        avatarImage.isHidden = false
+        guard animated,
+            !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion,
+            let imageLayer = avatarImage.layer
+        else {
+            initialLabel.isHidden = true
+            needsDisplay = true
+            return
+        }
+        imageLayer.removeAnimation(
+            forKey: "native-playback-comment-avatar.fade"
+        )
+        imageLayer.opacity = 1
+        let animation = CABasicAnimation(keyPath: "opacity")
+        animation.fromValue = 0
+        animation.toValue = 1
+        animation.duration = NativePlaybackCommentImageTransition.duration
+        animation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+        CATransaction.begin()
+        CATransaction.setCompletionBlock { [weak self] in
+            guard let self, self.imageGeneration == generation else { return }
+            self.initialLabel.isHidden = true
+            self.needsDisplay = true
+        }
+        imageLayer.add(
+            animation,
+            forKey: "native-playback-comment-avatar.fade"
+        )
+        CATransaction.commit()
+        needsDisplay = true
+    }
+}
+
+struct NativePlaybackCommentPictureSlot: Equatable {
+    let reference: CommentAssetReference?
+    let pixelWidth: Int?
+    let pixelHeight: Int?
+}
+
+struct NativePlaybackCommentPictureSlots {
+    static func slots(
+        images: [CommentImage],
+        count: Int
+    ) -> [NativePlaybackCommentPictureSlot] {
+        let displayedCount = min(max(count, 0), 9)
+        var result = [NativePlaybackCommentPictureSlot](
+            repeating: NativePlaybackCommentPictureSlot(
+                reference: nil,
+                pixelWidth: nil,
+                pixelHeight: nil
+            ),
+            count: displayedCount
+        )
+        for (fallbackPosition, image) in images.enumerated() {
+            let position = image.position ?? fallbackPosition
+            guard result.indices.contains(position),
+                result[position].reference == nil
+            else { continue }
+            result[position] = NativePlaybackCommentPictureSlot(
+                reference: image.asset,
+                pixelWidth: image.pixelWidth,
+                pixelHeight: image.pixelHeight
+            )
+        }
+        return result
+    }
+}
+
+struct NativePlaybackCommentPictureLayout: Equatable {
+    static let maximumContentWidth: CGFloat = 364
+    static let maximumImageHeight: CGFloat = 180
+    static let gap: CGFloat = 4
+    static let fallbackExtent: CGFloat = 120
+    static let sourcePixelScale: CGFloat = 2
+
+    let frames: [CGRect]
+    let size: CGSize
+
+    static func make(
+        images: [CommentImage],
+        count: Int,
+        availableWidth: CGFloat
+    ) -> Self {
+        make(
+            slots: NativePlaybackCommentPictureSlots.slots(
+                images: images,
+                count: count
+            ),
+            availableWidth: availableWidth
+        )
+    }
+
+    static func make(
+        slots: [NativePlaybackCommentPictureSlot],
+        availableWidth: CGFloat
+    ) -> Self {
+        let contentWidth = floor(
+            min(max(0, availableWidth), maximumContentWidth)
+        )
+        guard !slots.isEmpty, contentWidth >= 1 else {
+            return Self(frames: [], size: .zero)
+        }
+
+        var frames: [CGRect] = []
+        frames.reserveCapacity(slots.count)
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+
+        for slot in slots {
+            let itemSize = displaySize(
+                for: slot,
+                availableWidth: contentWidth
+            )
+            if x > 0, x + itemSize.width > contentWidth {
+                y += rowHeight + gap
+                x = 0
+                rowHeight = 0
+            }
+            let frame = CGRect(origin: CGPoint(x: x, y: y), size: itemSize)
+            frames.append(frame)
+            x = frame.maxX + gap
+            rowHeight = max(rowHeight, itemSize.height)
+        }
+
+        return Self(
+            frames: frames,
+            size: CGSize(width: contentWidth, height: ceil(y + rowHeight))
+        )
+    }
+
+    private static func displaySize(
+        for slot: NativePlaybackCommentPictureSlot,
+        availableWidth: CGFloat
+    ) -> CGSize {
+        guard let pixelWidth = slot.pixelWidth,
+            let pixelHeight = slot.pixelHeight,
+            pixelWidth > 0,
+            pixelHeight > 0
+        else {
+            let extent = min(fallbackExtent, availableWidth)
+            return CGSize(width: extent, height: extent)
+        }
+
+        let sourceWidth = CGFloat(pixelWidth) / sourcePixelScale
+        let sourceHeight = CGFloat(pixelHeight) / sourcePixelScale
+        let scale = min(
+            1,
+            min(
+                availableWidth / sourceWidth,
+                maximumImageHeight / sourceHeight
+            )
+        )
+        return CGSize(
+            width: max(1, floor(sourceWidth * scale)),
+            height: max(1, floor(sourceHeight * scale))
+        )
+    }
 }
 
 @MainActor
 private final class NativePlaybackCommentPicturesView: NSView {
     override var isFlipped: Bool { true }
-    private static let placeholderText = NSAttributedString(
-        string: "暂不可用",
-        attributes: [
-            .font: NSFont.preferredFont(forTextStyle: .caption2),
-            .foregroundColor: NSColor.secondaryLabelColor,
-        ]
-    )
-    private static let placeholderSize = placeholderText.size()
-    private static let tileBackground = NSColor.secondaryLabelColor.withAlphaComponent(0.10)
-    var count = 0 {
-        didSet {
-            guard count != oldValue else { return }
-            setAccessibilityElement(count > 0)
-            setAccessibilityLabel("图片内容暂不可用，共 \(count) 张")
-            needsDisplay = true
+    private let tiles = (0..<9).map { _ in NativePlaybackCommentPictureTileView() }
+    private var slots: [NativePlaybackCommentPictureSlot] = []
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        for tile in tiles {
+            tile.isHidden = true
+            addSubview(tile)
+        }
+        setAccessibilityElement(false)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { nil }
+
+    func configure(
+        images: [CommentImage],
+        count: Int,
+        loader: NativePlaybackCommentPictureLoader
+    ) {
+        slots = NativePlaybackCommentPictureSlots.slots(
+            images: images,
+            count: count
+        )
+        for (index, tile) in tiles.enumerated() {
+            guard slots.indices.contains(index) else {
+                tile.isHidden = true
+                tile.reset()
+                continue
+            }
+            tile.isHidden = false
+            tile.configure(
+                reference: slots[index].reference,
+                loader: loader
+            )
+        }
+        setAccessibilityElement(!slots.isEmpty)
+        setAccessibilityRole(.group)
+        setAccessibilityLabel("评论图片，共 \(slots.count) 张")
+        needsLayout = true
+    }
+
+    override func layout() {
+        super.layout()
+        let pictureLayout = NativePlaybackCommentPictureLayout.make(
+            slots: slots,
+            availableWidth: bounds.width
+        )
+        for (index, frame) in pictureLayout.frames.enumerated() {
+            tiles[index].frame = frame
         }
     }
 
-    override func draw(_ dirtyRect: NSRect) {
-        super.draw(dirtyRect)
-        let displayedCount = min(max(count, 0), 9)
-        guard displayedCount > 0 else { return }
-        let columns = displayedCount == 1 ? 1 : (displayedCount >= 5 ? 3 : 2)
-        let gap: CGFloat = 4
-        let tileWidth =
-            displayedCount == 1
-            ? bounds.width
-            : floor((bounds.width - CGFloat(columns - 1) * gap) / CGFloat(columns))
-        let tileHeight =
-            displayedCount == 1
-            ? bounds.height
-            : tileWidth
-        for index in 0..<displayedCount {
-            let column = index % columns
-            let row = index / columns
-            let rect = NSRect(
-                x: CGFloat(column) * (tileWidth + gap),
-                y: CGFloat(row) * (tileHeight + gap),
-                width: tileWidth,
-                height: tileHeight
-            )
-            Self.tileBackground.setFill()
-            NSBezierPath(roundedRect: rect, xRadius: 7, yRadius: 7).fill()
-            NSColor.separatorColor.setStroke()
-            NSBezierPath(roundedRect: rect, xRadius: 7, yRadius: 7).stroke()
-            Self.placeholderText.draw(
-                at: NSPoint(
-                    x: rect.midX - Self.placeholderSize.width / 2,
-                    y: rect.midY - Self.placeholderSize.height / 2
+    func releaseImages() {
+        for tile in tiles { tile.releaseImage() }
+    }
+
+    func reset() {
+        slots = []
+        for tile in tiles {
+            tile.isHidden = true
+            tile.reset()
+        }
+        setAccessibilityElement(false)
+        setAccessibilityLabel(nil)
+    }
+}
+
+@MainActor
+private final class NativePlaybackCommentPictureTileView: NSView {
+    override var isFlipped: Bool { true }
+    private let imageView = NSImageView()
+    private let placeholderLabel = NSTextField(labelWithString: "图片")
+    private var reference: CommentAssetReference?
+    private var imageGeneration: UInt64 = 0
+    private var imageTask: Task<Void, Never>?
+    private var isShowingPlaceholder = true
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.cornerRadius = 6
+        layer?.masksToBounds = true
+        imageView.wantsLayer = true
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.imageAlignment = .alignCenter
+        imageView.setAccessibilityElement(false)
+        placeholderLabel.font = .preferredFont(forTextStyle: .caption2)
+        placeholderLabel.textColor = .secondaryLabelColor
+        placeholderLabel.alignment = .center
+        placeholderLabel.setAccessibilityElement(false)
+        addSubview(imageView)
+        addSubview(placeholderLabel)
+        setAccessibilityElement(false)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { nil }
+
+    override func updateLayer() {
+        super.updateLayer()
+        layer?.backgroundColor =
+            isShowingPlaceholder
+            ? NSColor.secondaryLabelColor.withAlphaComponent(0.06).cgColor
+            : NSColor.clear.cgColor
+        layer?.borderWidth = 0
+    }
+
+    override func layout() {
+        super.layout()
+        imageView.frame = bounds
+        placeholderLabel.frame = NSRect(
+            x: 4,
+            y: max(0, bounds.midY - 9),
+            width: max(0, bounds.width - 8),
+            height: 18
+        )
+    }
+
+    func configure(
+        reference: CommentAssetReference?,
+        loader: NativePlaybackCommentPictureLoader
+    ) {
+        cancelImageRequest()
+        self.reference = reference
+        imageView.image = nil
+        imageView.isHidden = true
+        placeholderLabel.isHidden = false
+        isShowingPlaceholder = true
+        needsDisplay = true
+        guard let reference else { return }
+        if let cached = loader.cachedImage(for: reference) {
+            apply(cached, animated: false)
+            return
+        }
+        let generation = imageGeneration
+        imageTask = Task { [weak self] in
+            let result = await loader.image(for: reference)
+            guard let self, !Task.isCancelled,
+                self.imageGeneration == generation,
+                self.reference == reference
+            else { return }
+            self.imageTask = nil
+            guard let result else { return }
+            self.apply(
+                result.image,
+                animated: NativePlaybackCommentImageTransition.shouldAnimate(
+                    loadOrigin: result.origin
                 )
             )
         }
+    }
+
+    func releaseImage() {
+        cancelImageRequest()
+        imageView.image = nil
+        imageView.isHidden = true
+        placeholderLabel.isHidden = false
+        isShowingPlaceholder = true
+        needsDisplay = true
+    }
+
+    func reset() {
+        releaseImage()
+        reference = nil
+    }
+
+    private func cancelImageRequest() {
+        imageGeneration &+= 1
+        imageTask?.cancel()
+        imageTask = nil
+        imageView.layer?.removeAnimation(
+            forKey: "native-playback-comment-picture.fade"
+        )
+        imageView.layer?.opacity = 1
+    }
+
+    private func apply(_ image: CGImage, animated: Bool) {
+        let generation = imageGeneration
+        imageView.image = NSImage(
+            cgImage: image,
+            size: NSSize(width: image.width, height: image.height)
+        )
+        imageView.isHidden = false
+        placeholderLabel.isHidden = true
+        guard animated,
+            !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion,
+            let imageLayer = imageView.layer
+        else {
+            isShowingPlaceholder = false
+            needsDisplay = true
+            return
+        }
+        imageLayer.removeAnimation(
+            forKey: "native-playback-comment-picture.fade"
+        )
+        imageLayer.opacity = 1
+        let animation = CABasicAnimation(keyPath: "opacity")
+        animation.fromValue = 0
+        animation.toValue = 1
+        animation.duration = NativePlaybackCommentImageTransition.duration
+        animation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+        CATransaction.begin()
+        CATransaction.setCompletionBlock { [weak self] in
+            guard let self, self.imageGeneration == generation else { return }
+            self.isShowingPlaceholder = false
+            self.needsDisplay = true
+        }
+        imageLayer.add(
+            animation,
+            forKey: "native-playback-comment-picture.fade"
+        )
+        CATransaction.commit()
+        needsDisplay = true
     }
 }
 
@@ -1628,6 +2194,8 @@ private final class NativePlaybackCommentRepliesPanelView: NSView {
     private var replyRows: [NativePlaybackCommentRowView] = []
     private var thread: CommentThread?
     private var replyState: PlaybackCommentReplyState?
+    private var textRenderer: NativePlaybackCommentTextRenderer?
+    private var textScope: NativePlaybackCommentTextScope?
     private var onExpand: (() -> Void)?
     private var onCollapse: (() -> Void)?
     private var onPrevious: (() -> Void)?
@@ -1707,16 +2275,23 @@ private final class NativePlaybackCommentRepliesPanelView: NSView {
     func configure(
         thread: CommentThread,
         replyState: PlaybackCommentReplyState?,
+        textRenderer: NativePlaybackCommentTextRenderer,
+        avatarLoader: NativePlaybackCommentAvatarLoader,
+        pictureLoader: NativePlaybackCommentPictureLoader,
+        textScope: NativePlaybackCommentTextScope,
+        onTextLayoutChange: @escaping () -> Void,
         onExpand: @escaping () -> Void,
         onCollapse: @escaping () -> Void,
         onPrevious: @escaping () -> Void,
         onNext: @escaping () -> Void,
         onRetry: @escaping () -> Void,
-        onOpenVideo: @escaping (String) -> Void
+        onOpenLink: @escaping (CommentLinkTarget) -> Void
     ) {
         resetRows()
         self.thread = thread
         self.replyState = replyState
+        self.textRenderer = textRenderer
+        self.textScope = textScope
         self.onExpand = onExpand
         self.onCollapse = onCollapse
         self.onPrevious = onPrevious
@@ -1739,7 +2314,12 @@ private final class NativePlaybackCommentRepliesPanelView: NSView {
             row.configure(
                 comment: reply,
                 isReply: true,
-                onOpenVideo: onOpenVideo
+                textRenderer: textRenderer,
+                avatarLoader: avatarLoader,
+                pictureLoader: pictureLoader,
+                textScope: textScope,
+                onTextLayoutChange: onTextLayoutChange,
+                onOpenLink: onOpenLink
             )
             addSubview(row)
             replyRows.append(row)
@@ -1820,7 +2400,9 @@ private final class NativePlaybackCommentRepliesPanelView: NSView {
             let height = NativePlaybackCommentsItemMeasurement.comment(
                 reply,
                 width: width,
-                isReply: true
+                isReply: true,
+                textRenderer: textRenderer,
+                textScope: textScope
             )
             row.frame = NSRect(x: padding, y: y, width: width, height: height)
             y += height + 8
@@ -1865,14 +2447,16 @@ private final class NativePlaybackCommentRepliesPanelView: NSView {
         _ = details
     }
 
-    func releaseTextStorage() {
-        for row in replyRows { row.releaseTextStorage() }
+    func releaseOffscreenResources() {
+        for row in replyRows { row.releaseOffscreenResources() }
     }
 
     func reset() {
         resetRows()
         thread = nil
         replyState = nil
+        textRenderer = nil
+        textScope = nil
         onExpand = nil
         onCollapse = nil
         onPrevious = nil
@@ -1884,7 +2468,7 @@ private final class NativePlaybackCommentRepliesPanelView: NSView {
 
     private func resetRows() {
         for row in replyRows {
-            row.releaseTextStorage()
+            row.releaseOffscreenResources()
             row.removeFromSuperview()
         }
         replyRows.removeAll(keepingCapacity: true)

--- a/BiliKitMac/Platform/PlaybackSidebar/Comments/NativePlaybackCommentsPresentation.swift
+++ b/BiliKitMac/Platform/PlaybackSidebar/Comments/NativePlaybackCommentsPresentation.swift
@@ -9,6 +9,14 @@ struct NativePlaybackCommentThreadPresentation: Equatable {
     let replyState: PlaybackCommentReplyState?
     let revision: Int
 
+    var textScope: NativePlaybackCommentTextScope {
+        NativePlaybackCommentTextScope(
+            subject: subject,
+            rootID: thread.id,
+            revision: revision
+        )
+    }
+
     init(
         subject: CommentSubjectIdentity,
         thread: CommentThread,
@@ -43,6 +51,7 @@ struct NativePlaybackCommentThreadPresentation: Equatable {
         case .available(let details):
             hasher.combine(details.author.id)
             hasher.combine(details.author.name)
+            hasher.combine(details.author.avatar)
             hasher.combine(details.author.sex)
             hasher.combine(details.author.level)
             hasher.combine(details.author.isHardcoreMember)
@@ -50,7 +59,9 @@ struct NativePlaybackCommentThreadPresentation: Equatable {
             hasher.combine(details.author.verification)
             hasher.combine(details.author.isUploader)
             hasher.combine(details.content.message)
+            hasher.combine(details.content.emotes)
             hasher.combine(details.content.links)
+            hasher.combine(details.content.pictures)
             hasher.combine(details.content.pictureCount)
             hasher.combine(details.createdAt)
             hasher.combine(details.location)

--- a/BiliKitMac/Platform/PlaybackSidebar/NativePlaybackSidebarLayout.swift
+++ b/BiliKitMac/Platform/PlaybackSidebar/NativePlaybackSidebarLayout.swift
@@ -443,6 +443,13 @@ enum NativePlaybackSidebarTextLayout {
         )
     }
 
+    static func height(
+        _ attributedText: NSAttributedString,
+        width: CGFloat
+    ) -> CGFloat {
+        measurer.height(attributedText, width: width)
+    }
+
     static func singleLineWidth(_ text: String, font: NSFont) -> CGFloat {
         ceil((text as NSString).size(withAttributes: [.font: font]).width)
     }
@@ -494,6 +501,22 @@ private final class NativePlaybackSidebarTextMeasurer {
                 ]
             )
         )
+        manager.ensureLayout(for: container)
+        return ceil(manager.usedRect(for: container).height)
+    }
+
+    func height(
+        _ attributedText: NSAttributedString,
+        width: CGFloat
+    ) -> CGFloat {
+        guard attributedText.length > 0 else { return 0 }
+        container.containerSize = NSSize(
+            width: max(1, width),
+            height: .greatestFiniteMagnitude
+        )
+        container.maximumNumberOfLines = 0
+        container.lineBreakMode = .byCharWrapping
+        storage.setAttributedString(attributedText)
         manager.ensureLayout(for: container)
         return ceil(manager.usedRect(for: container).height)
     }

--- a/BiliKitMac/Platform/PlaybackSidebar/NativePlaybackSidebarView.swift
+++ b/BiliKitMac/Platform/PlaybackSidebar/NativePlaybackSidebarView.swift
@@ -7,13 +7,15 @@ import SwiftUI
 struct NativePlaybackSidebarView: View {
     let model: GuestVideoViewModel
     let commentsModel: PlaybackCommentsViewModel?
+    let commentAssetURLResolver: CommentAssetURLResolver
     let onRetry: () -> Void
     let onSelectPlayback: (String, Int64?) -> Void
-    let onSelectCommentVideo: (String) -> Void
+    let onOpenCommentLink: (CommentLinkTarget) -> Void
 
     var body: some View {
         NativePlaybackSidebarRepresentable(
             presentation: presentation,
+            commentAssetURLResolver: commentAssetURLResolver,
             actions: NativePlaybackSidebarActions(
                 retry: retry,
                 selectEpisode: selectEpisode,
@@ -29,7 +31,7 @@ struct NativePlaybackSidebarView: View {
                 },
                 nextReplyPage: { commentsModel?.showNextReplyPage(for: $0) },
                 retryReplies: { commentsModel?.retryReplies(for: $0) },
-                openCommentVideo: onSelectCommentVideo
+                openCommentLink: onOpenCommentLink
             )
         )
         .navigationTitle("观看辅助")
@@ -136,15 +138,18 @@ struct NativePlaybackSidebarActions {
     let previousReplyPage: (CommentID) -> Void
     let nextReplyPage: (CommentID) -> Void
     let retryReplies: (CommentID) -> Void
-    let openCommentVideo: (String) -> Void
+    let openCommentLink: (CommentLinkTarget) -> Void
 }
 
 private struct NativePlaybackSidebarRepresentable: NSViewRepresentable {
     let presentation: NativePlaybackSidebarPresentation
+    let commentAssetURLResolver: CommentAssetURLResolver
     let actions: NativePlaybackSidebarActions
 
     func makeCoordinator() -> NativePlaybackSidebarController {
-        NativePlaybackSidebarController()
+        NativePlaybackSidebarController(
+            commentAssetURLResolver: commentAssetURLResolver
+        )
     }
 
     func makeNSView(context: Context) -> NativePlaybackSidebarRootView {
@@ -330,6 +335,19 @@ final class NativePlaybackSidebarController: NSObject, NSCollectionViewDelegate 
     private let layout = NativePlaybackSidebarLayout()
     private let heightCache = NativePlaybackSidebarHeightCache(capacity: 2_048)
     private let imageOwner = NativeVideoImagePipelineOwner()
+    private let commentAssetURLResolver: CommentAssetURLResolver
+    private lazy var commentTextRenderer = NativePlaybackCommentTextRenderer(
+        imagePipeline: imageOwner.pipeline,
+        resolveURL: commentAssetURLResolver
+    )
+    private lazy var commentAvatarLoader = NativePlaybackCommentAvatarLoader(
+        imagePipeline: imageOwner.pipeline,
+        resolveURL: commentAssetURLResolver
+    )
+    private lazy var commentPictureLoader = NativePlaybackCommentPictureLoader(
+        imagePipeline: imageOwner.pipeline,
+        resolveURL: commentAssetURLResolver
+    )
     private var dataSource:
         NSCollectionViewDiffableDataSource<
             NativePlaybackSidebarSectionID,
@@ -352,11 +370,12 @@ final class NativePlaybackSidebarController: NSObject, NSCollectionViewDelegate 
         previousReplyPage: { _ in },
         nextReplyPage: { _ in },
         retryReplies: { _ in },
-        openCommentVideo: { _ in }
+        openCommentLink: { _ in }
     )
     private var itemIDs: [NativePlaybackSidebarItemID] = []
     private var commentThreadsByItemID:
         [NativePlaybackSidebarItemID: NativePlaybackCommentThreadPresentation] = [:]
+    private var commentRenderRevisions: [NativePlaybackSidebarItemID: UInt64] = [:]
     private var summaryExpanded = false
     private var signatureExpanded = false
     private var browsedSectionID: VideoCollectionSectionIdentity?
@@ -378,7 +397,8 @@ final class NativePlaybackSidebarController: NSObject, NSCollectionViewDelegate 
     private var liveScrollEndObservation: NSObjectProtocol?
     private var isTornDown = false
 
-    override init() {
+    init(commentAssetURLResolver: @escaping CommentAssetURLResolver = { _ in nil }) {
+        self.commentAssetURLResolver = commentAssetURLResolver
         super.init()
         configureCollectionView()
         rootView.commentsTopButton.target = self
@@ -476,6 +496,12 @@ final class NativePlaybackSidebarController: NSObject, NSCollectionViewDelegate 
                 )
             } ?? []
         )
+        commentTextRenderer.retainFailureScopes(
+            Set(commentThreadsByItemID.values.map(\.textScope))
+        )
+        commentRenderRevisions = commentRenderRevisions.filter {
+            commentThreadsByItemID[$0.key] != nil
+        }
         updateOverlay()
         applySnapshot(
             resetToTop: changesIdentity,
@@ -519,6 +545,8 @@ final class NativePlaybackSidebarController: NSObject, NSCollectionViewDelegate 
         dataSource = nil
         itemIDs.removeAll()
         commentThreadsByItemID.removeAll(keepingCapacity: false)
+        commentRenderRevisions.removeAll(keepingCapacity: false)
+        commentTextRenderer.removeAllFailures()
         heightCache.removeAll()
         collectionView.delegate = nil
         rootView.scrollView.documentView = nil
@@ -664,12 +692,18 @@ final class NativePlaybackSidebarController: NSObject, NSCollectionViewDelegate 
             else { return nil }
             item.configure(
                 presentation: thread,
+                textRenderer: commentTextRenderer,
+                avatarLoader: commentAvatarLoader,
+                pictureLoader: commentPictureLoader,
+                onTextLayoutChange: { [weak self] in
+                    self?.commentTextLayoutDidChange(for: itemID)
+                },
                 onExpand: { [weak self] in self?.actions.expandReplies(rootID) },
                 onCollapse: { [weak self] in self?.actions.collapseReplies(rootID) },
                 onPrevious: { [weak self] in self?.actions.previousReplyPage(rootID) },
                 onNext: { [weak self] in self?.actions.nextReplyPage(rootID) },
                 onRetry: { [weak self] in self?.actions.retryReplies(rootID) },
-                onOpenVideo: { [weak self] in self?.actions.openCommentVideo($0) }
+                onOpenLink: { [weak self] in self?.actions.openCommentLink($0) }
             )
             return item
         case .commentsFooter:
@@ -898,6 +932,7 @@ final class NativePlaybackSidebarController: NSObject, NSCollectionViewDelegate 
             hasher.combine(kind)
         case .commentThread:
             hasher.combine(commentThreadsByItemID[itemID]?.revision ?? 0)
+            hasher.combine(commentRenderRevisions[itemID] ?? 0)
         case .commentsFooter:
             hasher.combine(content.comments.footer)
         }
@@ -934,7 +969,11 @@ final class NativePlaybackSidebarController: NSObject, NSCollectionViewDelegate 
             return NativePlaybackCommentsItemMeasurement.state(kind, width: width)
         case .commentThread:
             guard let thread = commentThreadsByItemID[itemID] else { return 1 }
-            return NativePlaybackCommentsItemMeasurement.thread(thread, width: width)
+            return NativePlaybackCommentsItemMeasurement.thread(
+                thread,
+                width: width,
+                textRenderer: commentTextRenderer
+            )
         case .commentsFooter:
             return NativePlaybackCommentsItemMeasurement.footer(content.comments.footer)
         }
@@ -1032,6 +1071,27 @@ final class NativePlaybackSidebarController: NSObject, NSCollectionViewDelegate 
             self.scheduleRefinement()
             self.scheduleNextCommentsPageIfNeeded()
         }
+    }
+
+    private func commentTextLayoutDidChange(
+        for itemID: NativePlaybackSidebarItemID
+    ) {
+        guard !isTornDown, itemIDs.contains(itemID) else { return }
+        cancelRefinement()
+        paginationTask?.cancel()
+        paginationTask = nil
+        let anchor = captureAnchor()
+        commentRenderRevisions[itemID, default: 0] &+= 1
+        updateLayoutEntries(invalidating: [itemID])
+        if let indexPath = dataSource?.indexPath(for: itemID) {
+            collectionView.item(at: indexPath)?.view.needsLayout = true
+        }
+        collectionView.layoutSubtreeIfNeeded()
+        synchronizeDocumentFrame()
+        if let anchor { restore(anchor) }
+        scheduleRefinement()
+        updateCommentsTopButton()
+        scheduleNextCommentsPageIfNeeded()
     }
 
     private struct Anchor {

--- a/BiliKitMacTests/NativePlaybackSidebarTests.swift
+++ b/BiliKitMacTests/NativePlaybackSidebarTests.swift
@@ -594,7 +594,7 @@ struct NativePlaybackSidebarTests {
 
     @Test
     @MainActor
-    func commentRevisionTracksRenderedVerificationAndLinks() {
+    func commentRevisionTracksRenderedVerificationLinksAndPictures() {
         let subject = CommentSubjectIdentity.video(aid: 700_001)
         let message = "查看视频"
         let range = CommentTextRange(location: 0, length: 4)
@@ -607,6 +607,11 @@ struct NativePlaybackSidebarTests {
             name: "评论者",
             verification: .personal(description: "认证")
         )
+        let avatarAuthor = CommentAuthor(
+            id: CommentAuthorID(rawValue: "author"),
+            name: "评论者",
+            avatar: CommentAssetReference()
+        )
         let plain = NativePlaybackCommentThreadPresentation(
             subject: subject,
             thread: commentThread(id: 1, message: message, author: plainAuthor),
@@ -615,6 +620,11 @@ struct NativePlaybackSidebarTests {
         let verified = NativePlaybackCommentThreadPresentation(
             subject: subject,
             thread: commentThread(id: 1, message: message, author: verifiedAuthor),
+            replyState: nil
+        )
+        let avatar = NativePlaybackCommentThreadPresentation(
+            subject: subject,
+            thread: commentThread(id: 1, message: message, author: avatarAuthor),
             replyState: nil
         )
         let linked = NativePlaybackCommentThreadPresentation(
@@ -632,9 +642,24 @@ struct NativePlaybackSidebarTests {
             ),
             replyState: nil
         )
+        let pictured = NativePlaybackCommentThreadPresentation(
+            subject: subject,
+            thread: commentThread(
+                id: 1,
+                message: message,
+                links: [
+                    CommentLink(range: range, target: .video(bvid: "BV1FixtureA1"))
+                ],
+                pictures: [CommentImage(asset: CommentAssetReference())],
+                author: verifiedAuthor
+            ),
+            replyState: nil
+        )
 
+        #expect(plain.revision != avatar.revision)
         #expect(plain.revision != verified.revision)
         #expect(verified.revision != linked.revision)
+        #expect(linked.revision != pictured.revision)
     }
 
     @Test
@@ -1040,12 +1065,16 @@ struct NativePlaybackSidebarTests {
             )
             item.configure(
                 presentation: row,
+                textRenderer: makeCommentTextRenderer(),
+                avatarLoader: makeCommentAvatarLoader(),
+                pictureLoader: makeCommentPictureLoader(),
+                onTextLayoutChange: {},
                 onExpand: {},
                 onCollapse: {},
                 onPrevious: {},
                 onNext: {},
                 onRetry: {},
-                onOpenVideo: { _ in }
+                onOpenLink: { _ in }
             )
             item.view.layoutSubtreeIfNeeded()
 
@@ -1151,8 +1180,9 @@ struct NativePlaybackSidebarTests {
     @MainActor
     func commentThreadUsesSelectableNonScrollingTextKitAndNativeLinkAttributes() throws {
         let subject = CommentSubjectIdentity.video(aid: 700_001)
-        let message = "跳转 BV1FixtureA1 查看视频"
+        let message = "跳转 BV1FixtureA1 查看视频 @回复用户"
         let linkRange = (message as NSString).range(of: "BV1FixtureA1")
+        let memberRange = (message as NSString).range(of: "@回复用户")
         let thread = commentThread(
             id: 1,
             message: message,
@@ -1163,12 +1193,20 @@ struct NativePlaybackSidebarTests {
                         length: linkRange.length
                     ),
                     target: .video(bvid: "BV1FixtureA1")
-                )
+                ),
+                CommentLink(
+                    range: CommentTextRange(
+                        location: memberRange.location,
+                        length: memberRange.length
+                    ),
+                    target: .member(CommentAuthorID(rawValue: "301"))
+                ),
             ],
             replyCount: 1,
             preview: [comment(id: 11, rootID: 1, message: "楼中楼正文")]
         )
         let item = NativePlaybackCommentThreadItem()
+        var openedTargets: [CommentLinkTarget] = []
         let row = NativePlaybackCommentThreadPresentation(
             subject: subject,
             thread: thread,
@@ -1182,12 +1220,16 @@ struct NativePlaybackSidebarTests {
         )
         item.configure(
             presentation: row,
+            textRenderer: makeCommentTextRenderer(),
+            avatarLoader: makeCommentAvatarLoader(),
+            pictureLoader: makeCommentPictureLoader(),
+            onTextLayoutChange: {},
             onExpand: {},
             onCollapse: {},
             onPrevious: {},
             onNext: {},
             onRetry: {},
-            onOpenVideo: { _ in }
+            onOpenLink: { openedTargets.append($0) }
         )
         item.view.layoutSubtreeIfNeeded()
 
@@ -1196,12 +1238,30 @@ struct NativePlaybackSidebarTests {
         let rootBody = try #require(
             textViews.first { $0.string == message }
         )
-        let link =
+        let link = try #require(
             rootBody.textStorage?.attribute(
                 .link,
                 at: linkRange.location,
                 effectiveRange: nil
-            ) as? URL
+            )
+        )
+        let handled = rootBody.delegate?.textView?(
+            rootBody,
+            clickedOnLink: link,
+            at: linkRange.location
+        )
+        let memberLink = try #require(
+            rootBody.textStorage?.attribute(
+                .link,
+                at: memberRange.location,
+                effectiveRange: nil
+            )
+        )
+        let handledMember = rootBody.delegate?.textView?(
+            rootBody,
+            clickedOnLink: memberLink,
+            at: memberRange.location
+        )
 
         #expect(textViews.count >= 2)
         #expect(textViews.allSatisfy { $0.isSelectable && !$0.isEditable })
@@ -1212,9 +1272,14 @@ struct NativePlaybackSidebarTests {
                 !String(describing: type(of: $0)).contains("NSHostingView")
             }
         )
-        #expect(link?.scheme == "bilikit-comment")
-        #expect(link?.host == "video")
-        #expect(link?.path == "/BV1FixtureA1")
+        #expect(handled == true)
+        #expect(handledMember == true)
+        #expect(
+            openedTargets == [
+                .video(bvid: "BV1FixtureA1"),
+                .member(CommentAuthorID(rawValue: "301")),
+            ]
+        )
         let labels = views.compactMap { $0 as? NSTextField }
         #expect(labels.contains { $0.stringValue.contains("东京") })
         #expect(labels.allSatisfy { !$0.stringValue.contains("IP属地：") })
@@ -1231,6 +1296,333 @@ struct NativePlaybackSidebarTests {
                 $0.title != "共 1 条回复"
             }
         )
+    }
+
+    @Test
+    @MainActor
+    func commentImageTransitionOnlyAnimatesNetworkResults() {
+        #expect(
+            !NativePlaybackCommentImageTransition.shouldAnimate(
+                loadOrigin: .memoryCache
+            )
+        )
+        #expect(
+            NativePlaybackCommentImageTransition.shouldAnimate(
+                loadOrigin: .network
+            )
+        )
+        #expect(NativePlaybackCommentImageTransition.duration == 0.15)
+    }
+
+    @Test
+    @MainActor
+    func commentPictureLayoutMatchesTheBoundedOfficialWebFlow() {
+        let portrait = CommentImage(
+            asset: CommentAssetReference(),
+            position: 0,
+            pixelWidth: 270,
+            pixelHeight: 360
+        )
+        let landscape = CommentImage(
+            asset: CommentAssetReference(),
+            position: 1,
+            pixelWidth: 446,
+            pixelHeight: 270
+        )
+
+        let layout = NativePlaybackCommentPictureLayout.make(
+            images: [portrait, landscape],
+            count: 2,
+            availableWidth: 408
+        )
+
+        #expect(layout.size == CGSize(width: 364, height: 180))
+        #expect(
+            layout.frames == [
+                CGRect(x: 0, y: 0, width: 135, height: 180),
+                CGRect(x: 139, y: 0, width: 223, height: 135),
+            ]
+        )
+    }
+
+    @Test
+    @MainActor
+    func commentPicturesUseMetadataDrivenFlowWithoutNestedScrolling() throws {
+        let first = CommentAssetReference()
+        let third = CommentAssetReference()
+        let pictures = [
+            CommentImage(
+                asset: first,
+                position: 0,
+                pixelWidth: 270,
+                pixelHeight: 360
+            ),
+            CommentImage(
+                asset: third,
+                position: 2,
+                pixelWidth: 446,
+                pixelHeight: 270
+            ),
+        ]
+        let slots = NativePlaybackCommentPictureSlots.slots(
+            images: pictures,
+            count: 3
+        )
+        #expect(slots.map(\.reference) == [first, nil, third])
+        #expect(slots.map(\.pixelWidth) == [270, nil, 446])
+        #expect(slots.map(\.pixelHeight) == [360, nil, 270])
+
+        let layout = NativePlaybackCommentPictureLayout.make(
+            slots: slots,
+            availableWidth: 408
+        )
+        #expect(layout.size == CGSize(width: 364, height: 319))
+        #expect(layout.frames[0].size == CGSize(width: 135, height: 180))
+        #expect(layout.frames[1].size == CGSize(width: 120, height: 120))
+        #expect(layout.frames[2].origin == CGPoint(x: 0, y: 184))
+        #expect(layout.frames[2].size == CGSize(width: 223, height: 135))
+
+        let row = NativePlaybackCommentThreadPresentation(
+            subject: .video(aid: 700_001),
+            thread: commentThread(
+                id: 7,
+                message: "带图评论",
+                pictures: pictures,
+                pictureCount: 3
+            ),
+            replyState: nil
+        )
+        let item = NativePlaybackCommentThreadItem()
+        item.view.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: 408,
+            height: NativePlaybackCommentsItemMeasurement.thread(row, width: 408)
+        )
+        item.configure(
+            presentation: row,
+            textRenderer: makeCommentTextRenderer(),
+            avatarLoader: makeCommentAvatarLoader(),
+            pictureLoader: makeCommentPictureLoader(),
+            onTextLayoutChange: {},
+            onExpand: {},
+            onCollapse: {},
+            onPrevious: {},
+            onNext: {},
+            onRetry: {},
+            onOpenLink: { _ in }
+        )
+        item.view.layoutSubtreeIfNeeded()
+
+        let views = descendants(of: item.view)
+        let pictureGroup = try #require(
+            views.first { $0.accessibilityLabel() == "评论图片，共 3 张" }
+        )
+        let pictureImageViews = descendants(of: pictureGroup).compactMap {
+            $0 as? NSImageView
+        }
+        #expect(pictureGroup.accessibilityRole() == .group)
+        #expect(!pictureImageViews.isEmpty)
+        #expect(
+            pictureImageViews.allSatisfy {
+                $0.imageScaling == .scaleProportionallyUpOrDown
+            }
+        )
+        #expect(!views.contains { $0 is NSScrollView })
+        #expect(
+            !views.contains {
+                String(describing: type(of: $0)).contains("NSHostingView")
+            }
+        )
+
+        item.releaseOffscreenResources()
+        item.prepareForReuse()
+    }
+
+    @Test
+    @MainActor
+    func commentEmoteRendererUsesFixedTextKitAttachmentsAndLiteralFallback() throws {
+        let asset = CommentAssetReference()
+        let url = try #require(
+            URL(string: "https://i0.hdslb.com/bfs/emote/doge.png")
+        )
+        let renderer = makeCommentTextRenderer { reference in
+            reference == asset ? url : nil
+        }
+        let content = CommentContent(
+            message: "前[doge]后",
+            emotes: [
+                CommentEmote(
+                    text: "[doge]",
+                    range: CommentTextRange(location: 1, length: 6),
+                    asset: asset,
+                    size: .standard
+                )
+            ]
+        )
+        let scope = NativePlaybackCommentTextScope(
+            subject: .video(aid: 1),
+            rootID: CommentID(rawValue: 10),
+            revision: 1
+        )
+
+        let rendered = renderer.render(content, scope: scope)
+        let attachment = try #require(
+            rendered.attributedString.attribute(
+                .attachment,
+                at: 1,
+                effectiveRange: nil
+            ) as? NSTextAttachment
+        )
+
+        #expect(rendered.attributedString.string == "前\u{fffc}后")
+        #expect(attachment.bounds.size == NSSize(width: 18, height: 18))
+        #expect(attachment.bounds.origin.y == NSFont.preferredFont(forTextStyle: .body).descender)
+        #expect(!attachment.allowsTextAttachmentView)
+        #expect(rendered.pendingAssets.map(\.reference) == [asset])
+
+        renderer.retainFailureScopes([scope])
+        #expect(renderer.markUnavailable(asset, in: scope))
+        #expect(renderer.markUnavailable(asset, in: scope))
+        let fallback = renderer.render(content, scope: scope)
+        #expect(fallback.attributedString.string == content.message)
+        #expect(fallback.pendingAssets.isEmpty)
+
+        let otherScope = NativePlaybackCommentTextScope(
+            subject: .video(aid: 2),
+            rootID: CommentID(rawValue: 10),
+            revision: 1
+        )
+        #expect(renderer.render(content, scope: otherScope).pendingAssets.count == 1)
+        renderer.retainFailureScopes([otherScope])
+        #expect(renderer.render(content, scope: scope).pendingAssets.count == 1)
+    }
+
+    @Test
+    @MainActor
+    func commentEmoteFailureCacheIsBoundedByStableRenderScope() throws {
+        let asset = CommentAssetReference()
+        let url = try #require(
+            URL(string: "https://i0.hdslb.com/bfs/emote/doge.png")
+        )
+        let renderer = makeCommentTextRenderer { reference in
+            reference == asset ? url : nil
+        }
+        let content = CommentContent(
+            message: "[doge]",
+            emotes: [
+                CommentEmote(
+                    text: "[doge]",
+                    range: CommentTextRange(location: 0, length: 6),
+                    asset: asset,
+                    size: .standard
+                )
+            ]
+        )
+        let scopes = (0...512).map {
+            NativePlaybackCommentTextScope(
+                subject: .video(aid: 1),
+                rootID: CommentID(rawValue: 10),
+                revision: $0
+            )
+        }
+
+        renderer.retainFailureScopes(Set(scopes))
+        for scope in scopes {
+            renderer.markUnavailable(asset, in: scope)
+        }
+
+        #expect(renderer.render(content, scope: scopes[0]).pendingAssets.count == 1)
+        #expect(renderer.render(content, scope: scopes[512]).pendingAssets.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func lateCommentEmoteFailureCannotReenterAnInactiveScope() throws {
+        let asset = CommentAssetReference()
+        let url = try #require(
+            URL(string: "https://i0.hdslb.com/bfs/emote/doge.png")
+        )
+        let renderer = makeCommentTextRenderer { reference in
+            reference == asset ? url : nil
+        }
+        let content = CommentContent(
+            message: "[doge]",
+            emotes: [
+                CommentEmote(
+                    text: "[doge]",
+                    range: CommentTextRange(location: 0, length: 6),
+                    asset: asset,
+                    size: .standard
+                )
+            ]
+        )
+        let scopeA = NativePlaybackCommentTextScope(
+            subject: .video(aid: 1),
+            rootID: CommentID(rawValue: 10),
+            revision: 1
+        )
+        let scopeB = NativePlaybackCommentTextScope(
+            subject: .video(aid: 2),
+            rootID: CommentID(rawValue: 20),
+            revision: 1
+        )
+
+        renderer.retainFailureScopes([scopeA])
+        renderer.retainFailureScopes([scopeB])
+        #expect(!renderer.markUnavailable(asset, in: scopeA))
+        renderer.retainFailureScopes([scopeA])
+
+        #expect(renderer.render(content, scope: scopeA).pendingAssets.count == 1)
+    }
+
+    @Test
+    @MainActor
+    func largeAndUnknownCommentEmotesKeepExplicitMeasurementSemantics() throws {
+        let largeAsset = CommentAssetReference()
+        let unknownAsset = CommentAssetReference()
+        let url = try #require(
+            URL(string: "https://i0.hdslb.com/bfs/emote/large.png")
+        )
+        let renderer = makeCommentTextRenderer { reference in
+            reference == largeAsset ? url : nil
+        }
+        let content = CommentContent(
+            message: "[大][未知]",
+            emotes: [
+                CommentEmote(
+                    text: "[大]",
+                    range: CommentTextRange(location: 0, length: 3),
+                    asset: largeAsset,
+                    size: .large
+                ),
+                CommentEmote(
+                    text: "[未知]",
+                    range: CommentTextRange(location: 3, length: 4),
+                    asset: unknownAsset,
+                    size: .unknown
+                ),
+            ]
+        )
+        let scope = NativePlaybackCommentTextScope(
+            subject: .video(aid: 1),
+            rootID: CommentID(rawValue: 11),
+            revision: 1
+        )
+
+        let rendered = renderer.render(content, scope: scope)
+        let attachment = try #require(
+            rendered.attributedString.attribute(
+                .attachment,
+                at: 0,
+                effectiveRange: nil
+            ) as? NSTextAttachment
+        )
+
+        #expect(rendered.attributedString.string == "\u{fffc}[未知]")
+        #expect(attachment.bounds.size == NSSize(width: 36, height: 36))
+        #expect(attachment.bounds.origin.y == NSFont.preferredFont(forTextStyle: .body).descender)
+        #expect(renderer.height(content, width: 200, scope: scope) >= 36)
     }
 
     @Test
@@ -1261,12 +1653,16 @@ struct NativePlaybackSidebarTests {
             )
             item.configure(
                 presentation: row,
+                textRenderer: makeCommentTextRenderer(),
+                avatarLoader: makeCommentAvatarLoader(),
+                pictureLoader: makeCommentPictureLoader(),
+                onTextLayoutChange: {},
                 onExpand: {},
                 onCollapse: {},
                 onPrevious: {},
                 onNext: {},
                 onRetry: {},
-                onOpenVideo: { _ in }
+                onOpenLink: { _ in }
             )
             item.view.layoutSubtreeIfNeeded()
 
@@ -1308,12 +1704,16 @@ struct NativePlaybackSidebarTests {
             )
             item.configure(
                 presentation: row,
+                textRenderer: makeCommentTextRenderer(),
+                avatarLoader: makeCommentAvatarLoader(),
+                pictureLoader: makeCommentPictureLoader(),
+                onTextLayoutChange: {},
                 onExpand: {},
                 onCollapse: {},
                 onPrevious: {},
                 onNext: {},
                 onRetry: {},
-                onOpenVideo: { _ in }
+                onOpenLink: { _ in }
             )
             item.view.layoutSubtreeIfNeeded()
 
@@ -1356,12 +1756,16 @@ struct NativePlaybackSidebarTests {
         )
         item.configure(
             presentation: row,
+            textRenderer: makeCommentTextRenderer(),
+            avatarLoader: makeCommentAvatarLoader(),
+            pictureLoader: makeCommentPictureLoader(),
+            onTextLayoutChange: {},
             onExpand: {},
             onCollapse: {},
             onPrevious: {},
             onNext: {},
             onRetry: {},
-            onOpenVideo: { _ in }
+            onOpenLink: { _ in }
         )
         item.view.layoutSubtreeIfNeeded()
 
@@ -1412,12 +1816,16 @@ struct NativePlaybackSidebarTests {
         )
         item.configure(
             presentation: row,
+            textRenderer: makeCommentTextRenderer(),
+            avatarLoader: makeCommentAvatarLoader(),
+            pictureLoader: makeCommentPictureLoader(),
+            onTextLayoutChange: {},
             onExpand: {},
             onCollapse: {},
             onPrevious: {},
             onNext: {},
             onRetry: {},
-            onOpenVideo: { _ in }
+            onOpenLink: { _ in }
         )
         item.view.layoutSubtreeIfNeeded()
 
@@ -1771,7 +2179,7 @@ struct NativePlaybackSidebarTests {
             previousReplyPage: { _ in },
             nextReplyPage: { _ in },
             retryReplies: { _ in },
-            openCommentVideo: { _ in }
+            openCommentLink: { _ in }
         )
 
         controller.update(
@@ -1813,7 +2221,7 @@ struct NativePlaybackSidebarTests {
             previousReplyPage: { _ in },
             nextReplyPage: { _ in },
             retryReplies: { _ in },
-            openCommentVideo: { _ in }
+            openCommentLink: { _ in }
         )
     }
 
@@ -1901,6 +2309,8 @@ struct NativePlaybackSidebarTests {
         id: Int64,
         message: String,
         links: [CommentLink] = [],
+        pictures: [CommentImage] = [],
+        pictureCount: Int? = nil,
         replyCount: Int = 0,
         preview: [BiliModels.Comment] = [],
         author: CommentAuthor? = nil,
@@ -1911,6 +2321,8 @@ struct NativePlaybackSidebarTests {
                 id: id,
                 message: message,
                 links: links,
+                pictures: pictures,
+                pictureCount: pictureCount,
                 replyCount: replyCount,
                 author: author,
                 provenance: provenance
@@ -1924,6 +2336,8 @@ struct NativePlaybackSidebarTests {
         rootID: Int64? = nil,
         message: String,
         links: [CommentLink] = [],
+        pictures: [CommentImage] = [],
+        pictureCount: Int? = nil,
         replyCount: Int = 0,
         author: CommentAuthor? = nil,
         provenance: [CommentProvenance] = []
@@ -1940,7 +2354,12 @@ struct NativePlaybackSidebarTests {
                             level: 6,
                             isVIP: true
                         ),
-                    content: CommentContent(message: message, links: links),
+                    content: CommentContent(
+                        message: message,
+                        links: links,
+                        pictures: pictures,
+                        pictureCount: pictureCount
+                    ),
                     createdAt: Date(timeIntervalSince1970: 1_700_000_000),
                     location: "东京",
                     likeCount: 42,
@@ -2044,6 +2463,36 @@ struct NativePlaybackSidebarTests {
                     durationSeconds: 61
                 )
             ]
+        )
+    }
+
+    @MainActor
+    private func makeCommentTextRenderer(
+        resolveURL: @escaping CommentAssetURLResolver = { _ in nil }
+    ) -> NativePlaybackCommentTextRenderer {
+        NativePlaybackCommentTextRenderer(
+            imagePipeline: NativeVideoImagePipeline(),
+            resolveURL: resolveURL
+        )
+    }
+
+    @MainActor
+    private func makeCommentAvatarLoader(
+        resolveURL: @escaping CommentAssetURLResolver = { _ in nil }
+    ) -> NativePlaybackCommentAvatarLoader {
+        NativePlaybackCommentAvatarLoader(
+            imagePipeline: NativeVideoImagePipeline(),
+            resolveURL: resolveURL
+        )
+    }
+
+    @MainActor
+    private func makeCommentPictureLoader(
+        resolveURL: @escaping CommentAssetURLResolver = { _ in nil }
+    ) -> NativePlaybackCommentPictureLoader {
+        NativePlaybackCommentPictureLoader(
+            imagePipeline: NativeVideoImagePipeline(),
+            resolveURL: resolveURL
         )
     }
 

--- a/BiliKitMacTests/PopularNativeGridTests.swift
+++ b/BiliKitMacTests/PopularNativeGridTests.swift
@@ -436,6 +436,8 @@ struct PopularNativeGridTests {
     func imageVariantsUseDistinctDecodeBoundsAndCacheIdentities() throws {
         #expect(NativeVideoImageVariant.cover.maximumDecodedPixelSize == 640)
         #expect(NativeVideoImageVariant.avatar.maximumDecodedPixelSize == 96)
+        #expect(NativeVideoImageVariant.commentEmote.maximumDecodedPixelSize == 128)
+        #expect(NativeVideoImageVariant.commentPicture.maximumDecodedPixelSize == 1_024)
 
         let url = try #require(URL(string: "https://i.example/shared.webp"))
         let coverKey = NativeVideoImageKey(url: url, variant: .cover)

--- a/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliCommentAssetResolver.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliCommentAssetResolver.swift
@@ -1,0 +1,52 @@
+import BiliModels
+import Foundation
+
+public struct BiliCommentAssetResolver: Sendable {
+    private static let bfsPathPrefix = "/bfs/"
+    private static let allowedHosts: Set<String> = [
+        "i0.hdslb.com",
+        "i1.hdslb.com",
+        "i2.hdslb.com",
+    ]
+
+    public init() {}
+
+    public func imageURL(for reference: CommentAssetReference) -> URL? {
+        guard let url = reference.remoteURL else { return nil }
+        guard url.scheme?.lowercased() == "https",
+            let host = url.host?.lowercased(),
+            Self.allowedHosts.contains(host),
+            url.port == nil || url.port == 443,
+            url.user == nil,
+            url.password == nil,
+            url.query == nil,
+            url.fragment == nil,
+            Self.isSafeBFSPath(url)
+        else { return nil }
+        return url
+    }
+
+    private static func isSafeBFSPath(_ url: URL) -> Bool {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else { return false }
+        let encodedPath = components.percentEncodedPath
+        let lowercaseEncodedPath = encodedPath.lowercased()
+        guard encodedPath.hasPrefix(bfsPathPrefix),
+            encodedPath.count > bfsPathPrefix.count,
+            !lowercaseEncodedPath.contains("%25"),
+            !lowercaseEncodedPath.contains("%2f"),
+            !lowercaseEncodedPath.contains("%5c")
+        else { return false }
+
+        let decodedPath = url.path
+        guard !decodedPath.contains("\\"),
+            !decodedPath.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains)
+        else { return false }
+        let resourceComponents =
+            decodedPath
+            .dropFirst(bfsPathPrefix.count)
+            .split(separator: "/", omittingEmptySubsequences: false)
+        return !resourceComponents.isEmpty
+            && resourceComponents.allSatisfy { !$0.isEmpty && $0 != "." && $0 != ".." }
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliCommentLinkResolver.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliCommentLinkResolver.swift
@@ -1,0 +1,40 @@
+import BiliModels
+import BiliNetworking
+import Foundation
+
+public struct BiliCommentLinkResolver: Sendable {
+    private let publicHTTPSPolicy = PublicHTTPSURLPolicy()
+
+    public init() {}
+
+    public func externalURL(for target: CommentLinkTarget) -> URL? {
+        switch target {
+        case .video:
+            return nil
+        case .member(let authorID):
+            let value = authorID.rawValue
+            guard !value.isEmpty,
+                value.utf8.allSatisfy({ $0 >= 48 && $0 <= 57 }),
+                let numericID = Int64(value), numericID > 0
+            else { return nil }
+            return URL(string: "https://space.bilibili.com/\(value)")
+        case .external(let reference):
+            guard let url = reference.remoteURL,
+                allowsUserInitiatedExternalURL(url)
+            else { return nil }
+            return url
+        }
+    }
+
+    private func allowsUserInitiatedExternalURL(_ url: URL) -> Bool {
+        guard
+            var components = URLComponents(
+                url: url,
+                resolvingAgainstBaseURL: false
+            )
+        else { return false }
+        components.fragment = nil
+        guard let validationURL = components.url else { return false }
+        return publicHTTPSPolicy.allows(validationURL)
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/CommentEndpointPayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/CommentEndpointPayloads.swift
@@ -411,10 +411,18 @@ struct CommentMemberPayload: Decodable, Sendable {
         case "女": authorSex = .female
         default: authorSex = .unspecified
         }
+        let avatarReference =
+            avatar
+            .flatMap(WebImageURL.parse)
+            .flatMap { url -> CommentAssetReference? in
+                guard url.user == nil, url.password == nil else { return nil }
+                return CommentAssetReference(remoteURL: url)
+            }
+
         return CommentAuthor(
             id: CommentAuthorID(rawValue: mid),
             name: name,
-            avatar: nil,
+            avatar: avatarReference,
             sex: authorSex,
             level: level.flatMap {
                 (0...6).contains($0.currentLevel) ? $0.currentLevel : nil
@@ -461,7 +469,7 @@ struct CommentContentPayload: Decodable, Sendable {
     let message: String
     let emote: [String: CommentEmotePayload]
     let jumpURLs: [String: CommentJumpURLPayload]
-    let pictures: [CommentPicturePayload]
+    let pictures: [CommentPicturePayload?]
     let pictureCount: Int
     let members: [CommentMentionPayload]
 
@@ -491,7 +499,7 @@ struct CommentContentPayload: Decodable, Sendable {
                 [LossyCommentPicturePayload].self,
                 forKey: .pictures
             ) ?? []
-        pictures = lossyPictures.compactMap(\.value)
+        pictures = lossyPictures.map(\.value)
         pictureCount = lossyPictures.count
         members =
             container.decodeLossyIfPresent(
@@ -504,18 +512,112 @@ struct CommentContentPayload: Decodable, Sendable {
         guard pictureCount <= 9 else {
             throw BiliAPIError.decodingFailed
         }
-        let emotes: [CommentEmote] = []
-        let links = jumpURLs.flatMap { label, payload -> [CommentLink] in
+        let emotes = mappedEmotes()
+        let mappedPictures = mappedPictures()
+        let jumpLinks = jumpURLs.flatMap { label, payload -> [CommentLink] in
             guard let target = CommentRemoteURL.linkTarget(payload.url) else { return [] }
             return ranges(of: label).map { CommentLink(range: $0, target: target) }
         }
+        var mentionTargetsByToken: [String: Set<CommentAuthorID>] = [:]
+        for member in members where !member.mid.isEmpty && !member.name.isEmpty {
+            let token = member.name.hasPrefix("@") ? member.name : "@\(member.name)"
+            mentionTargetsByToken[token, default: []].insert(
+                CommentAuthorID(rawValue: member.mid)
+            )
+        }
+        let mentionLinks = mentionTargetsByToken.flatMap { token, targets -> [CommentLink] in
+            // 接口不给 mention 的正文位置；同名对应多个账号时不能安全猜测目标。
+            guard targets.count == 1, let target = targets.first else { return [] }
+            return ranges(of: token).map {
+                CommentLink(range: $0, target: .member(target))
+            }
+        }
+        let links = Self.nonoverlappingLinks(jumpLinks + mentionLinks)
         return CommentContent(
             message: message,
             emotes: emotes,
             links: links,
-            pictures: [],
+            pictures: mappedPictures,
             pictureCount: pictureCount
         )
+    }
+
+    private func mappedPictures() -> [CommentImage] {
+        var assetByURL: [URL: CommentAssetReference] = [:]
+        return pictures.enumerated().compactMap { position, payload in
+            guard let payload else { return nil }
+            guard let url = WebImageURL.parse(payload.url),
+                url.user == nil,
+                url.password == nil
+            else { return nil }
+            let asset = assetByURL[url] ?? CommentAssetReference(remoteURL: url)
+            assetByURL[url] = asset
+            return CommentImage(
+                asset: asset,
+                position: position,
+                pixelWidth: Self.positiveDimension(payload.width),
+                pixelHeight: Self.positiveDimension(payload.height)
+            )
+        }
+    }
+
+    private static func positiveDimension(_ value: Int?) -> Int? {
+        guard let value, value > 0 else { return nil }
+        return value
+    }
+
+    private func mappedEmotes() -> [CommentEmote] {
+        var assetByURL: [URL: CommentAssetReference] = [:]
+        var result: [CommentEmote] = []
+
+        for (token, payload) in emote {
+            guard !token.isEmpty,
+                payload.text == nil || payload.text == token,
+                let url = WebImageURL.parse(payload.url),
+                url.user == nil,
+                url.password == nil
+            else { continue }
+
+            let asset = assetByURL[url] ?? CommentAssetReference(remoteURL: url)
+            assetByURL[url] = asset
+            let size: CommentEmoteSize =
+                switch payload.meta?.size {
+                case 1: .standard
+                case 2: .large
+                default: .unknown
+                }
+            result.append(
+                contentsOf: ranges(of: token).map {
+                    CommentEmote(
+                        text: token,
+                        range: $0,
+                        asset: asset,
+                        size: size
+                    )
+                }
+            )
+        }
+
+        let sorted = result.sorted {
+            if $0.range.location != $1.range.location {
+                return $0.range.location < $1.range.location
+            }
+            if $0.range.length != $1.range.length {
+                return $0.range.length > $1.range.length
+            }
+            return $0.text < $1.text
+        }
+        var nonoverlapping: [CommentEmote] = []
+        for candidate in sorted {
+            guard let previous = nonoverlapping.last else {
+                nonoverlapping.append(candidate)
+                continue
+            }
+            guard candidate.range.location >= previous.range.location + previous.range.length
+            else { continue }
+            nonoverlapping.append(candidate)
+        }
+        return nonoverlapping
     }
 
     private func ranges(of token: String) -> [CommentTextRange] {
@@ -532,10 +634,63 @@ struct CommentContentPayload: Decodable, Sendable {
         }
         return result
     }
+
+    private static func nonoverlappingLinks(_ links: [CommentLink]) -> [CommentLink] {
+        let sorted = links.sorted {
+            if $0.range.location != $1.range.location {
+                return $0.range.location < $1.range.location
+            }
+            if $0.range.length != $1.range.length {
+                return $0.range.length > $1.range.length
+            }
+            return linkOrderKey($0.target) < linkOrderKey($1.target)
+        }
+        var result: [CommentLink] = []
+        for link in sorted {
+            guard let previous = result.last else {
+                result.append(link)
+                continue
+            }
+            guard link.range.location >= previous.range.location + previous.range.length
+            else { continue }
+            result.append(link)
+        }
+        return result
+    }
+
+    private static func linkOrderKey(_ target: CommentLinkTarget) -> String {
+        switch target {
+        case .video(let bvid):
+            "0:\(bvid)"
+        case .member(let authorID):
+            "1:\(authorID.rawValue)"
+        case .external(let reference):
+            "2:\(reference.remoteURL?.absoluteString ?? "")"
+        }
+    }
 }
 
 struct CommentEmotePayload: Decodable, Sendable {
     let url: String
+    let text: String?
+    let meta: CommentEmoteMetaPayload?
+
+    private enum CodingKeys: String, CodingKey {
+        case url
+        case text
+        case meta
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        url = try container.decode(String.self, forKey: .url)
+        text = container.decodeLossyIfPresent(String.self, forKey: .text)
+        meta = container.decodeLossyIfPresent(CommentEmoteMetaPayload.self, forKey: .meta)
+    }
+}
+
+struct CommentEmoteMetaPayload: Decodable, Sendable {
+    let size: Int?
 }
 
 struct CommentJumpURLPayload: Decodable, Sendable {
@@ -569,6 +724,16 @@ struct CommentMentionPayload: Decodable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case mid
         case name = "uname"
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let value = try? container.decode(String.self, forKey: .mid) {
+            mid = value
+        } else {
+            mid = String(try container.decode(Int64.self, forKey: .mid))
+        }
+        name = try container.decode(String.self, forKey: .name)
     }
 }
 
@@ -608,7 +773,8 @@ private enum CommentRemoteURL {
         {
             return .video(bvid: String(parts[1]))
         }
-        return nil
+        guard let url = components.url else { return nil }
+        return .external(CommentExternalLinkReference(remoteURL: url))
     }
 
     private static func components(_ value: String?) -> URLComponents? {

--- a/Packages/BiliKitCore/Sources/BiliModels/Comment/CommentModels.swift
+++ b/Packages/BiliKitCore/Sources/BiliModels/Comment/CommentModels.swift
@@ -37,19 +37,47 @@ public struct CommentAuthorID: Sendable, Equatable, Hashable {
 
 /// 资源的进程内不透明引用；远端 URL 只由具体 adapter 解析和消费。
 public struct CommentAssetReference: Sendable, Equatable, Hashable {
-    private let token: UUID
+    private enum Storage: Sendable, Equatable, Hashable {
+        case opaque(UUID)
+        case remote(URL)
+    }
 
-    package init() {
-        token = UUID()
+    private let storage: Storage
+
+    package var remoteURL: URL? {
+        guard case .remote(let url) = storage else { return nil }
+        return url
+    }
+
+    public init() {
+        storage = .opaque(UUID())
+    }
+
+    package init(remoteURL: URL) {
+        storage = .remote(remoteURL)
     }
 }
 
 /// 外部 HTTPS 链接的进程内不透明引用。
 public struct CommentExternalLinkReference: Sendable, Equatable, Hashable {
-    private let token: UUID
+    private enum Storage: Sendable, Equatable, Hashable {
+        case opaque(UUID)
+        case remote(URL)
+    }
 
-    package init() {
-        token = UUID()
+    private let storage: Storage
+
+    package var remoteURL: URL? {
+        guard case .remote(let url) = storage else { return nil }
+        return url
+    }
+
+    public init() {
+        storage = .opaque(UUID())
+    }
+
+    package init(remoteURL: URL) {
+        storage = .remote(remoteURL)
     }
 }
 
@@ -113,16 +141,25 @@ public struct CommentEmote: Sendable, Equatable, Hashable {
     public let text: String
     public let range: CommentTextRange
     public let asset: CommentAssetReference
+    public let size: CommentEmoteSize
 
     public init(
         text: String,
         range: CommentTextRange,
-        asset: CommentAssetReference
+        asset: CommentAssetReference,
+        size: CommentEmoteSize = .unknown
     ) {
         self.text = text
         self.range = range
         self.asset = asset
+        self.size = size
     }
+}
+
+public enum CommentEmoteSize: Sendable, Equatable, Hashable {
+    case standard
+    case large
+    case unknown
 }
 
 public enum CommentLinkTarget: Sendable, Equatable, Hashable {
@@ -141,19 +178,20 @@ public struct CommentLink: Sendable, Equatable, Hashable {
     }
 }
 
-public struct CommentImage: Sendable, Equatable, Hashable, Identifiable {
-    public var id: CommentAssetReference { asset }
-
+public struct CommentImage: Sendable, Equatable, Hashable {
     public let asset: CommentAssetReference
+    public let position: Int?
     public let pixelWidth: Int?
     public let pixelHeight: Int?
 
     public init(
         asset: CommentAssetReference,
+        position: Int? = nil,
         pixelWidth: Int? = nil,
         pixelHeight: Int? = nil
     ) {
         self.asset = asset
+        self.position = position
         self.pixelWidth = pixelWidth
         self.pixelHeight = pixelHeight
     }

--- a/Packages/BiliKitCore/Sources/BiliNetworking/Transport/PublicHTTPSURLPolicy.swift
+++ b/Packages/BiliKitCore/Sources/BiliNetworking/Transport/PublicHTTPSURLPolicy.swift
@@ -22,6 +22,7 @@ public struct PublicHTTPSURLPolicy: Sendable {
 
         let host = rawHost.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
         guard !host.isEmpty,
+            !host.hasSuffix("."),
             host != "localhost",
             !host.hasSuffix(".localhost"),
             !host.hasSuffix(".local"),

--- a/Packages/BiliKitCore/Tests/BiliAPITests/CommentAPIClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/CommentAPIClientTests.swift
@@ -39,7 +39,14 @@ struct CommentAPIClientTests {
         #expect(first.provenance == [.adminPinned, .uploaderLiked])
         let second = try #require(available(page.threads[1].root))
         #expect(second.author.isUploader)
-        #expect(second.content.links.isEmpty)
+        #expect(
+            second.content.links == [
+                CommentLink(
+                    range: CommentTextRange(location: 5, length: 5),
+                    target: .member(CommentAuthorID(rawValue: "301"))
+                )
+            ]
+        )
         #expect(second.content.pictureCount == 0)
         #expect(page.threads[1].replyPreview.count == 1)
         guard case .unavailable(.unknown(rawValue: 7)) = page.threads[2].root.payload else {
@@ -335,6 +342,102 @@ struct CommentAPIClientTests {
         #expect(!details.author.isHardcoreMember)
     }
 
+    @Test(
+        arguments: [
+            "//i0.hdslb.com/bfs/face/protocol-relative.jpg",
+            "http://i1.hdslb.com/bfs/face/legacy-http.jpg",
+            "https://i2.hdslb.com/bfs/face/secure.jpg",
+        ]
+    )
+    func commentAvatarMapsToNormalizedOpaqueAssetReference(_ value: String) throws {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "mid": "42",
+            "uname": "评论者",
+            "avatar": value,
+        ])
+        let payload = try JSONDecoder().decode(CommentMemberPayload.self, from: data)
+
+        let avatar = try #require(payload.model(uploaderID: nil).avatar?.remoteURL)
+
+        #expect(avatar.scheme == "https")
+        #expect(avatar.user == nil)
+        #expect(avatar.password == nil)
+    }
+
+    @Test
+    func commentAvatarWithUserInfoDegradesWithoutDiscardingAuthor() throws {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "mid": "42",
+            "uname": "评论者",
+            "avatar": "https://user@i0.hdslb.com/bfs/face/avatar.jpg",
+        ])
+        let payload = try JSONDecoder().decode(CommentMemberPayload.self, from: data)
+
+        let author = try payload.model(uploaderID: nil)
+
+        #expect(author.name == "评论者")
+        #expect(author.avatar == nil)
+    }
+
+    @Test
+    func commentLinksMapVideoExternalAndMemberTargetsWithUTF16Ranges() throws {
+        let body = Data(
+            #"""
+            {
+              "message": "看视频 访问活动 @回复用户",
+              "jump_url": {
+                "看视频": {
+                  "pc_url": "https://www.bilibili.com/video/BV1FixtureA1?p=1"
+                },
+                "访问活动": {
+                  "pc_url": "https://www.bilibili.com/opus/42#reply"
+                }
+              },
+              "members": [
+                { "mid": 301, "uname": "回复用户" }
+              ],
+              "pictures": []
+            }
+            """#.utf8
+        )
+        let payload = try JSONDecoder().decode(CommentContentPayload.self, from: body)
+
+        let links = try payload.model().links
+
+        #expect(links.count == 3)
+        #expect(
+            links.map(\.range) == [
+                CommentTextRange(location: 0, length: 3),
+                CommentTextRange(location: 4, length: 4),
+                CommentTextRange(location: 9, length: 5),
+            ]
+        )
+        #expect(links[0].target == .video(bvid: "BV1FixtureA1"))
+        guard case .external(let externalReference) = links[1].target else {
+            Issue.record("Expected an external comment link")
+            return
+        }
+        #expect(
+            externalReference.remoteURL?.absoluteString
+                == "https://www.bilibili.com/opus/42#reply"
+        )
+        #expect(
+            links[2].target
+                == .member(CommentAuthorID(rawValue: "301"))
+        )
+    }
+
+    @Test
+    func ambiguousDuplicateMentionNamesRemainLiteralText() throws {
+        let body = Data(
+            #"{"message":"@同名用户","members":[{"mid":301,"uname":"同名用户"},{"mid":302,"uname":"同名用户"}]}"#
+                .utf8
+        )
+        let payload = try JSONDecoder().decode(CommentContentPayload.self, from: body)
+
+        #expect(try payload.model().links.isEmpty)
+    }
+
     @Test
     func malformedPageEnhancementsAndReplyPreviewDegradeLocally() async throws {
         let response = try mutatedFixture("comment-main") { data in
@@ -567,23 +670,49 @@ struct CommentAPIClientTests {
     }
 
     @Test
-    func commentVideoLinksRequireAValidHTTPSBVID() throws {
-        let validJSON =
+    func commentJumpLinksDistinguishInternalVideosFromExternalHTTPS() throws {
+        let internalVideoJSON =
             #"{"message":"视频","jump_url":{"视频":{"pc_url":"https://www.bilibili.com/video/BV1FixtureA1"}}}"#
-        let valid = try JSONDecoder().decode(
+        let internalVideo = try JSONDecoder().decode(
             CommentContentPayload.self,
-            from: Data(validJSON.utf8)
+            from: Data(internalVideoJSON.utf8)
         )
-        #expect(try valid.model().links.count == 1)
+        #expect(
+            try internalVideo.model().links == [
+                CommentLink(
+                    range: CommentTextRange(location: 0, length: 2),
+                    target: .video(bvid: "BV1FixtureA1")
+                )
+            ]
+        )
 
-        let invalidValues = [
-            "http://www.bilibili.com/video/BV1FixtureA1",
-            "https://user@example.com/video/BV1FixtureA1",
+        let externalValues = [
             "https://www.bilibili.com/video/BV😈",
             "https://example.com/video/BV1FixtureA1",
             "https://www.bilibili.com/video/BV",
         ]
-        for value in invalidValues {
+        for value in externalValues {
+            let data = try JSONSerialization.data(
+                withJSONObject: [
+                    "message": "视频",
+                    "jump_url": ["视频": ["pc_url": value]],
+                ]
+            )
+            let payload = try JSONDecoder().decode(CommentContentPayload.self, from: data)
+            let links = try payload.model().links
+            #expect(links.count == 1)
+            guard case .external(let reference) = try #require(links.first).target else {
+                Issue.record("合法但非内部视频的 HTTPS jump_url 应保持为外部链接")
+                continue
+            }
+            #expect(reference.remoteURL == URL(string: value))
+        }
+
+        let rejectedValues = [
+            "http://www.bilibili.com/video/BV1FixtureA1",
+            "https://user@example.com/video/BV1FixtureA1",
+        ]
+        for value in rejectedValues {
             let data = try JSONSerialization.data(
                 withJSONObject: [
                     "message": "视频",
@@ -596,8 +725,142 @@ struct CommentAPIClientTests {
     }
 
     @Test
-    func moreThanNinePicturesRejectsOnlyThatContent() throws {
-        let picture = #"{"img_src":"https://i0.hdslb.com/fixture.jpg"}"#
+    func commentEmotesUsePerCommentAnnotationsAndUTF16Ranges() throws {
+        let body = Data(
+            #"""
+            {
+              "message": "前😺[doge]中[doge][大表情]",
+              "emote": {
+                "[doge]": {
+                  "text": "[doge]",
+                  "url": "http://i0.hdslb.com/bfs/emote/doge.png",
+                  "meta": { "size": 1 }
+                },
+                "[大表情]": {
+                  "text": "[大表情]",
+                  "url": "https://i0.hdslb.com/bfs/emote/large.png",
+                  "meta": { "size": 2 }
+                },
+                "[未使用]": {
+                  "text": "[未使用]",
+                  "url": "https://i0.hdslb.com/bfs/emote/unused.png",
+                  "meta": { "size": 1 }
+                }
+              }
+            }
+            """#.utf8
+        )
+        let payload = try JSONDecoder().decode(CommentContentPayload.self, from: body)
+
+        let emotes = try payload.model().emotes
+
+        #expect(emotes.count == 3)
+        #expect(emotes.map(\.text) == ["[doge]", "[doge]", "[大表情]"])
+        #expect(
+            emotes.map(\.range) == [
+                CommentTextRange(location: 3, length: 6),
+                CommentTextRange(location: 10, length: 6),
+                CommentTextRange(location: 16, length: 5),
+            ]
+        )
+        #expect(emotes.map(\.size) == [.standard, .standard, .large])
+        #expect(emotes[0].asset == emotes[1].asset)
+        #expect(emotes[1].asset != emotes[2].asset)
+        #expect(emotes[0].asset.remoteURL?.scheme == "https")
+    }
+
+    @Test
+    func malformedOrUnmatchedCommentEmotesDegradeToLiteralText() throws {
+        let body = Data(
+            #"""
+            {
+              "message": "[有效][错名][坏地址][未知尺寸]",
+              "emote": {
+                "[有效]": {
+                  "url": "//i0.hdslb.com/bfs/emote/valid.png",
+                  "meta": { "size": "unexpected" }
+                },
+                "[错名]": {
+                  "text": "[另一个名字]",
+                  "url": "https://i0.hdslb.com/bfs/emote/mismatch.png"
+                },
+                "[坏地址]": {
+                  "url": "https://user@example.invalid/emote.png"
+                },
+                "[未知尺寸]": {
+                  "url": "https://i0.hdslb.com/bfs/emote/unknown.png",
+                  "meta": { "size": 99 }
+                },
+                "[未出现]": {
+                  "url": "https://i0.hdslb.com/bfs/emote/absent.png"
+                }
+              }
+            }
+            """#.utf8
+        )
+        let payload = try JSONDecoder().decode(CommentContentPayload.self, from: body)
+
+        let content = try payload.model()
+
+        #expect(content.message == "[有效][错名][坏地址][未知尺寸]")
+        #expect(content.emotes.map(\.text) == ["[有效]", "[未知尺寸]"])
+        #expect(content.emotes.map(\.size) == [.unknown, .unknown])
+    }
+
+    @Test
+    func overlappingCommentEmotesPreferLeftmostThenLongestAtTheSameLocation() throws {
+        let body = Data(
+            #"""
+            {
+              "message": "[doge]",
+              "emote": {
+                "[doge]": {
+                  "url": "https://i0.hdslb.com/bfs/emote/doge.png"
+                },
+                "doge": {
+                  "url": "https://i0.hdslb.com/bfs/emote/overlap.png"
+                }
+              }
+            }
+            """#.utf8
+        )
+        let payload = try JSONDecoder().decode(CommentContentPayload.self, from: body)
+
+        let emotes = try payload.model().emotes
+
+        #expect(emotes.map(\.text) == ["[doge]"])
+        #expect(emotes.map(\.range) == [CommentTextRange(location: 0, length: 6)])
+    }
+
+    @Test
+    func differentCommentEmoteTokensShareTheSameAssetIdentity() throws {
+        let body = Data(
+            #"""
+            {
+              "message": "[甲][乙]",
+              "emote": {
+                "[甲]": {
+                  "url": "https://i0.hdslb.com/bfs/emote/shared.png"
+                },
+                "[乙]": {
+                  "url": "https://i0.hdslb.com/bfs/emote/shared.png"
+                }
+              }
+            }
+            """#.utf8
+        )
+        let payload = try JSONDecoder().decode(CommentContentPayload.self, from: body)
+
+        let emotes = try payload.model().emotes
+
+        #expect(emotes.count == 2)
+        #expect(emotes[0].asset == emotes[1].asset)
+    }
+
+    @Test
+    func commentPicturesMapWithinNineAndRejectOverflow() throws {
+        let picture =
+            #"{"img_src":"http://i0.hdslb.com/bfs/new_dyn/fixture.jpg","img_width":1920,"img_height":1080}"#
         let onePicturePayload = try JSONDecoder().decode(
             CommentContentPayload.self,
             from: Data(
@@ -606,7 +869,11 @@ struct CommentAPIClientTests {
         )
         let onePictureContent = try onePicturePayload.model()
         #expect(onePictureContent.pictureCount == 1)
-        #expect(onePictureContent.pictures.isEmpty)
+        let mapped = try #require(onePictureContent.pictures.first)
+        #expect(mapped.asset.remoteURL?.scheme == "https")
+        #expect(mapped.position == 0)
+        #expect(mapped.pixelWidth == 1920)
+        #expect(mapped.pixelHeight == 1080)
 
         let pictures = Array(repeating: picture, count: 10).joined(separator: ",")
         let body = Data(
@@ -620,6 +887,23 @@ struct CommentAPIClientTests {
         #expect(throws: BiliAPIError.self) {
             try payload.model()
         }
+    }
+
+    @Test
+    func malformedCommentPicturesKeepStableSlotsAndDegradeLocally() throws {
+        let body = Data(
+            #"{"message":"fixture","pictures":[42,{"img_src":"https://user@i0.hdslb.com/bfs/new_dyn/rejected.webp"},{"img_src":"//i1.hdslb.com/bfs/new_dyn/valid.webp","img_width":-1,"img_height":0}]}"#
+                .utf8
+        )
+        let payload = try JSONDecoder().decode(CommentContentPayload.self, from: body)
+
+        let content = try payload.model()
+
+        #expect(content.pictureCount == 3)
+        #expect(content.pictures.count == 1)
+        #expect(content.pictures[0].position == 2)
+        #expect(content.pictures[0].pixelWidth == nil)
+        #expect(content.pictures[0].pixelHeight == nil)
     }
 
     @Test

--- a/Packages/BiliKitCore/Tests/BiliAPITests/CommentAssetResolverTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/CommentAssetResolverTests.swift
@@ -1,0 +1,64 @@
+import BiliModels
+import Foundation
+import Testing
+
+@testable import BiliAPI
+
+@Suite("Comment asset resolver")
+struct CommentAssetResolverTests {
+    private let resolver = BiliCommentAssetResolver()
+
+    @Test
+    func acceptsTrustedHTTPSHostsAcrossTheBFSNamespace() throws {
+        for host in ["i0.hdslb.com", "i1.hdslb.com", "i2.hdslb.com"] {
+            for path in [
+                "bfs/emote/fixture.png",
+                "bfs/face/fixture.jpg",
+                "bfs/new_dyn/fixture.webp",
+                "bfs/garb/item/fixture.png",
+                "bfs/garb/fixture.webp",
+                "bfs/activity-plat/static/20231013/bucket/fixture.png",
+                "bfs/future-package/nested/fixture.gif@128w.webp",
+            ] {
+                let url = try #require(URL(string: "https://\(host)/\(path)"))
+                let reference = CommentAssetReference(remoteURL: url)
+
+                #expect(resolver.imageURL(for: reference) == url)
+            }
+        }
+    }
+
+    @Test(
+        arguments: [
+            "http://i0.hdslb.com/bfs/emote/fixture.png",
+            "https://example.invalid/bfs/emote/fixture.png",
+            "https://localhost/bfs/emote/fixture.png",
+            "https://user@i0.hdslb.com/bfs/emote/fixture.png",
+            "https://i0.hdslb.com:444/bfs/emote/fixture.png",
+            "https://i0.hdslb.com/not-bfs/emote/fixture.png",
+            "https://i0.hdslb.com/bfs",
+            "https://i0.hdslb.com/bfs/",
+            "https://i0.hdslb.com/bfs//fixture.png",
+            "https://i0.hdslb.com/bfs/../fixture.png",
+            "https://i0.hdslb.com/bfs/%2E%2E/fixture.png",
+            "https://i0.hdslb.com/bfs/emote%2F..%2Ffixture.png",
+            "https://i0.hdslb.com/bfs/emote%5Cfixture.png",
+            "https://i0.hdslb.com/bfs/emote%252F..%252Ffixture.png",
+            "https://i0.hdslb.com/bfs/emote%255Cfixture.png",
+            "https://i0.hdslb.com/bfs/%252E%252E/fixture.png",
+            "https://i0.hdslb.com/bfs/emote/fixture.png?token=value",
+            "https://i0.hdslb.com/bfs/emote/fixture.png#fragment",
+        ]
+    )
+    func rejectsUntrustedOrAmbiguousSources(_ value: String) throws {
+        let url = try #require(URL(string: value))
+        let reference = CommentAssetReference(remoteURL: url)
+
+        #expect(resolver.imageURL(for: reference) == nil)
+    }
+
+    @Test
+    func rejectsOpaqueReferencesWithoutInventingASource() {
+        #expect(resolver.imageURL(for: CommentAssetReference()) == nil)
+    }
+}

--- a/Packages/BiliKitCore/Tests/BiliAPITests/CommentLinkResolverTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/CommentLinkResolverTests.swift
@@ -1,0 +1,68 @@
+import BiliModels
+import Foundation
+import Testing
+
+@testable import BiliAPI
+
+@Suite("Comment link resolver")
+struct CommentLinkResolverTests {
+    private let resolver = BiliCommentLinkResolver()
+
+    @Test
+    func resolvesPositiveMemberIDsToThePublicSpacePage() throws {
+        let url = try #require(
+            resolver.externalURL(
+                for: .member(CommentAuthorID(rawValue: "123456"))
+            )
+        )
+
+        #expect(url.absoluteString == "https://space.bilibili.com/123456")
+    }
+
+    @Test(arguments: ["", "0", "-1", "abc", "１２３", "999999999999999999999999"])
+    func rejectsInvalidMemberIDs(_ value: String) {
+        #expect(
+            resolver.externalURL(
+                for: .member(CommentAuthorID(rawValue: value))
+            ) == nil
+        )
+    }
+
+    @Test
+    func preservesAUserInitiatedPublicHTTPSExternalURL() throws {
+        let url = try #require(
+            URL(string: "https://www.bilibili.com/opus/42?from=comment#reply")
+        )
+        let reference = CommentExternalLinkReference(remoteURL: url)
+
+        #expect(resolver.externalURL(for: .external(reference)) == url)
+    }
+
+    @Test(
+        arguments: [
+            "http://www.bilibili.com/opus/42",
+            "https://user@www.bilibili.com/opus/42",
+            "https://localhost/opus/42",
+            "https://localhost./opus/42",
+            "https://host.local/opus/42",
+            "https://host.local./opus/42",
+            "https://home.arpa./opus/42",
+            "https://127.0.0.1/opus/42",
+            "https://[::1]/opus/42",
+            "https://www.bilibili.com:444/opus/42",
+        ]
+    )
+    func rejectsUnsafeExternalDestinations(_ value: String) throws {
+        let url = try #require(URL(string: value))
+        let reference = CommentExternalLinkReference(remoteURL: url)
+
+        #expect(resolver.externalURL(for: .external(reference)) == nil)
+    }
+
+    @Test
+    func leavesVideoLinksForInAppNavigation() {
+        #expect(
+            resolver.externalURL(for: .video(bvid: "BV1FixtureA1")) == nil
+        )
+    }
+}

--- a/docs/adr/0010-native-playback-sidebar-comments-renderer.md
+++ b/docs/adr/0010-native-playback-sidebar-comments-renderer.md
@@ -23,13 +23,20 @@ section 中嵌入 `NSHostingView`。
   由 subject／generation 隔离迟到结果。
 - diffable snapshot 使用稳定的 subject + root `CommentID`，不使用 index 身份。正文和回复正文使用
   可选择、不可编辑、不可独立滚动的 `NSTextView`／TextKit；已验证的视频链接由 text view delegate
-  回送现有播放导航。
+  回送现有播放导航。成员提及与其他 `jump_url` 也只回送不透明 target：成员页由正整数 MID 生成
+  B 站空间页，其他目标经公开 HTTPS 形状策略复核后才交给系统 `OpenURLAction`；App 不预取、不跟随
+  重定向，也不向浏览器目标附加 Cookie。
 - layout 高度缓存键为 item identity、宽度桶和内容 revision，容量上限为 2,048，使用 O(1) LRU。
   append 复用旧高度，只测新增或 revision 改变的 row；resize 先按宽度比例估算并恢复 RowID +
   relativeY，再以最多 32 行一批精测，新 resize 会取消旧批次。
 - 只有 viewport 真正贴底时，append 才继续贴底；其余更新、楼中楼展开和 resize 均恢复语义 anchor。
-- 评论图片和头像目前没有可消费的公开资源 URL，继续使用原生 fallback；不从不透明 asset reference
-  反推 URL，也不增加第二条图片网络链。
+- 评论头像消费当前评论 `member.avatar`，inline 自定义表情消费 `content.emote` 注解，正文图片消费
+  `content.pictures`；三者都先映射为
+  不透明资源引用，再由 `BiliAPI` adapter 在加载前验证精确 CDN 来源。渲染复用既有匿名、有界图片
+  管线，不从不透明引用反推 URL，也不增加第二条图片网络链。头像保持固定行内尺寸；正文图片根据
+  API 宽高元数据在最多 364 pt、4 pt 间距的有界流式布局中预先确定最多九张图片的 frame，图片本体
+  保持 6 pt 圆角且没有外围卡片。缺失或无效元数据使用稳定占位，加载成功或失败都不改变行高。
+  cell 离屏、复用和 teardown 时取消等待者。
 
 ## 不采用
 
@@ -44,5 +51,4 @@ section 中嵌入 `NSHostingView`。
 
 原生 sidebar controller 的 snapshot、layout、focus、teardown 和 accessibility 职责增加，需要用
 unit／renderer 契约与真人 VoiceOver、Full Keyboard Access、连续 resize 和真实网络分别验证。
-build、AX tree 或合成性能数字不能替代这些证据。评论写入、真实评论图片、成员页／任意外链导航均不在
-本决策范围。
+build、AX tree 或合成性能数字不能替代这些证据。评论写入仍不在本决策范围。

--- a/docs/security/M4-data-privacy.md
+++ b/docs/security/M4-data-privacy.md
@@ -49,6 +49,20 @@ Cookie、token、二维码 key 和 refresh token 继续只由 `BiliAuth` 管理�
 - 账户读取 Cookie 必须在各 API 响应前终止；映射后的 playback manifest 与媒体 headers
   不保留 Cookie。DASH SIDX/媒体 Range、图片与 loopback 请求继续使用
   各自无认证 transport，不能从播放信息请求继承授权状态。
+- 评论头像、自定义表情与正文图片只消费当前评论 `member.avatar`／`content.emote`／
+  `content.pictures` 返回的资源，不下载或维护全量头像、表情包或图片索引。
+  映射层把接口历史遗留的 HTTP／协议相对地址升级为 HTTPS；实际加载前由具体 adapter 再次限制
+  精确 `i0.hdslb.com`／`i1.hdslb.com`／`i2.hdslb.com`、默认或 443 端口，以及
+  非空且无歧义的 `/bfs/` 资源路径；不把其下 `emote`、`garb`、`activity-plat` 等服务端内部
+  子目录当作稳定 API 契约，并拒绝 userinfo、query、fragment、点段、编码分隔符与全部
+  redirect。加载复用无 Cookie、无 credential、无磁盘 cache 的图片会话，响应必须是图片且不超过
+  8 MiB；表情解码最长边不超过 128 px、头像不超过 96 px、正文图片不超过 1,024 px；cell 离屏、
+  复用和窗口 teardown 必须取消等待者，
+  内存 cache 继续服从既有有界上限。
+- 评论链接只在用户明确点击后行动。视频 `jump_url` 仅把合法 BVID 回送现有 App 内播放导航；成员提及
+  仅允许正整数 MID 并交给 `https://space.bilibili.com/<mid>`；其他目标必须保持不透明，直到 App
+  composition 复核 HTTPS、无 userinfo、默认／443 端口、非本地域名且非 IP literal 后才交给系统
+  `OpenURLAction`。App 不预取、不解析 DNS、不跟随目标重定向，也不为该导航附加 Cookie 或 credential。
 - 登录态 playurl 可把同一响应中的服务端分 P 与毫秒位置映射为一次性的首次定位候选；匿名
   响应不消费该账户字段。播放器在首次 `play` 前完成受 identity、load intent、item generation
   与用户交互 revision 保护的 seek，切视频、切 P、暂停、拖动或 teardown 都能否决迟到提交。


### PR DESCRIPTION
## 变化

- 映射评论表情、@ 提及、站内视频链接、外部链接、正文图片及作者展示元数据。
- 建立匿名、有界的评论资源加载链：禁用 Cookie 与凭据、拒绝重定向、限制响应字节、解码尺寸和内存缓存。
- 在现有纯 AppKit 评论 renderer 中渲染可选择正文链接、TextKit 表情附件、头像、会员与作者徽章、IP 属地、点赞信息和自适应图片流式布局。
- 保持单一 `NSScrollView + NSCollectionView` 滚动所有权、稳定 RowID、原有 ViewModel 分页和 generation/cancellation 语义。

## 原因

原生评论侧栏此前只有基础文本语义，无法还原真实评论中的表情、链接、作者状态和图片。此次在既有 API/domain/ViewModel 边界上补齐富内容，不引入第二套评论状态机或认证图片请求。

## 用户影响

评论区能够显示 B 站表情、作者徽章、IP 属地、链接和正文图片；图片按原始比例自适应布局，头像与图片采用克制淡入，正文仍可选择。

## 验证

- 重放到最新 `origin/main`（`e48aab4`）后执行完整 App Gate。
- Static Gate 通过。
- Package Gate：535 tests / 56 suites 通过。
- App build-for-testing 与 App tests 通过。
- 已在真实评论数据中人工检查表情、链接、图片布局、徽章、IP 属地及连续滚动。

## 未覆盖边界

- 真人 VoiceOver / Full Keyboard Access 的完整遍历。
- 真实 CDN 异常 MIME、动画图片及网络失败的长时间压力。
- 不包含评论图片全屏预览；该能力位于后续 stacked PR。
