### PR TITLE
feat(playback): 接入系统播放信息与远程控制

### DIFF
--- a/BiliKitMac/App/AppRootView.swift
+++ b/BiliKitMac/App/AppRootView.swift
@@ -27,14 +27,18 @@ struct AppRootView: View {
     @State private var submittedSearchQuery: String?
     init(
         environment: AppEnvironment? = nil,
-        accountSessionCoordinator: AccountSessionCoordinator = AccountSessionCoordinator()
+        accountSessionCoordinator: AccountSessionCoordinator = AccountSessionCoordinator(),
+        systemNowPlayingController: SystemNowPlayingController? = nil
     ) {
         self.accountSessionCoordinator = accountSessionCoordinator
         let environment =
             environment
             ?? .live(accountSessionCoordinator: accountSessionCoordinator)
         _windowOwner = State(
-            initialValue: AppWindowOwner(environment: environment)
+            initialValue: AppWindowOwner(
+                environment: environment,
+                systemNowPlayingController: systemNowPlayingController
+            )
         )
     }
 
@@ -96,7 +100,9 @@ struct AppRootView: View {
         }
         .onAppear {
             windowOwner.open()
+            windowOwner.markWindowActive()
         }
+        .background(AppWindowActivationObserver(onBecomeKey: windowOwner.markWindowActive))
         .task {
             authenticationModel.restoreIfNeeded()
             await authenticationModel.waitForCurrentTask()
@@ -299,6 +305,74 @@ struct AppRootView: View {
         browseModel.synchronizeAuthenticationSession(
             generation: processGeneration
         )
+    }
+}
+
+private struct AppWindowActivationObserver: NSViewRepresentable {
+    let onBecomeKey: @MainActor () -> Void
+
+    func makeNSView(context: Context) -> AppWindowActivationNSView {
+        AppWindowActivationNSView(onBecomeKey: onBecomeKey)
+    }
+
+    func updateNSView(
+        _ nsView: AppWindowActivationNSView,
+        context: Context
+    ) {
+        nsView.onBecomeKey = onBecomeKey
+    }
+}
+
+@MainActor
+private final class AppWindowActivationNSView: NSView {
+    var onBecomeKey: @MainActor () -> Void
+    private let observerOwner = AppWindowActivationObserverOwner()
+
+    init(onBecomeKey: @escaping @MainActor () -> Void) {
+        self.onBecomeKey = onBecomeKey
+        super.init(frame: .zero)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        observerOwner.remove()
+        guard let window else { return }
+        observerOwner.store(
+            NotificationCenter.default.addObserver(
+                forName: NSWindow.didBecomeKeyNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in self?.onBecomeKey() }
+            }
+        )
+        if window.isKeyWindow {
+            onBecomeKey()
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+}
+
+private final class AppWindowActivationObserverOwner: @unchecked Sendable {
+    private var observer: NSObjectProtocol?
+
+    func store(_ observer: NSObjectProtocol) {
+        remove()
+        self.observer = observer
+    }
+
+    func remove() {
+        guard let observer else { return }
+        NotificationCenter.default.removeObserver(observer)
+        self.observer = nil
+    }
+
+    deinit {
+        remove()
     }
 }
 

--- a/BiliKitMac/App/AppWindowOwner.swift
+++ b/BiliKitMac/App/AppWindowOwner.swift
@@ -23,12 +23,16 @@ final class AppWindowOwner {
     let commentImagePipeline: NativeVideoImagePipeline
     private let commentImagePipelineOwner: NativeVideoImagePipelineOwner
     private let playbackPreferencesController: PlaybackPreferencesController?
+    private let systemNowPlayingCoordinator: SystemNowPlayingWindowCoordinator?
     private let openEnvironment: (@MainActor @Sendable () -> Void)?
     private let closeEnvironment: (@MainActor @Sendable () -> Void)?
     private var isOpen = false
     private var isClosed = false
 
-    convenience init(environment: AppEnvironment) {
+    convenience init(
+        environment: AppEnvironment,
+        systemNowPlayingController: SystemNowPlayingController? = nil
+    ) {
         let browseModel = environment.makeBrowseViewModel()
         let videoModel = environment.makeVideoViewModel()
         let commentsModel = environment.makeCommentsViewModel()
@@ -58,6 +62,9 @@ final class AppWindowOwner {
             commentVideoLinkResolver: environment.commentVideoLinkResolver,
             commentLinkURLResolver: environment.commentLinkURLResolver,
             playbackPreferencesController: environment.playbackPreferencesController,
+            systemNowPlayingController: systemNowPlayingController,
+            systemNowPlayingConnection:
+                environment.makeSystemNowPlayingPlaybackConnection(),
             openEnvironment: environment.open,
             closeEnvironment: environment.close
         )
@@ -98,6 +105,8 @@ final class AppWindowOwner {
         commentImagePipelineOwner: NativeVideoImagePipelineOwner =
             NativeVideoImagePipelineOwner(),
         playbackPreferencesController: PlaybackPreferencesController? = nil,
+        systemNowPlayingController: SystemNowPlayingController? = nil,
+        systemNowPlayingConnection: SystemNowPlayingPlaybackConnection? = nil,
         openEnvironment: (@MainActor @Sendable () -> Void)? = nil,
         closeEnvironment: (@MainActor @Sendable () -> Void)? = nil
     ) {
@@ -115,6 +124,15 @@ final class AppWindowOwner {
         self.commentImagePipelineOwner = commentImagePipelineOwner
         commentImagePipeline = commentImagePipelineOwner.pipeline
         self.playbackPreferencesController = playbackPreferencesController
+        if let systemNowPlayingController, let systemNowPlayingConnection {
+            systemNowPlayingCoordinator = SystemNowPlayingWindowCoordinator(
+                controller: systemNowPlayingController,
+                connection: systemNowPlayingConnection,
+                videoModel: videoModel
+            )
+        } else {
+            systemNowPlayingCoordinator = nil
+        }
         self.openEnvironment = openEnvironment
         self.closeEnvironment = closeEnvironment
     }
@@ -123,14 +141,20 @@ final class AppWindowOwner {
         guard !isOpen, !isClosed else { return }
         isOpen = true
         openEnvironment?()
+        systemNowPlayingCoordinator?.start()
     }
 
     func close() {
         guard !isClosed else { return }
         isClosed = true
+        systemNowPlayingCoordinator?.close()
         commentImagePipelineOwner.shutdown()
         if isOpen {
             closeEnvironment?()
         }
+    }
+
+    func markWindowActive() {
+        systemNowPlayingCoordinator?.markWindowActive()
     }
 }

--- a/BiliKitMac/App/BiliKitMacApp.swift
+++ b/BiliKitMac/App/BiliKitMacApp.swift
@@ -10,13 +10,17 @@ import SwiftUI
 @main
 struct BiliKitMacApp: App {
     @State private var accountSessionCoordinator = AccountSessionCoordinator()
+    @State private var systemNowPlayingController = SystemNowPlayingController()
 
     var body: some Scene {
         WindowGroup {
-            AppRootView(accountSessionCoordinator: accountSessionCoordinator)
-                .typesettingLanguage(
-                    .explicit(Locale.Language(identifier: "zh-Hans"))
-                )
+            AppRootView(
+                accountSessionCoordinator: accountSessionCoordinator,
+                systemNowPlayingController: systemNowPlayingController
+            )
+            .typesettingLanguage(
+                .explicit(Locale.Language(identifier: "zh-Hans"))
+            )
         }
         .defaultSize(width: 1_320, height: 820)
     }

--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -17,6 +17,22 @@ typealias CommentAssetURLResolver = @Sendable (CommentAssetReference) -> URL?
 typealias CommentVideoLinkResolver = @Sendable (CommentLinkTarget) -> String?
 typealias CommentLinkURLResolver = @Sendable (CommentLinkTarget) -> URL?
 
+enum SystemNowPlayingSeekTarget {
+    static func relative(
+        positionSeconds: Double,
+        durationSeconds: Double,
+        offsetSeconds: Double
+    ) -> Double? {
+        guard positionSeconds.isFinite,
+            durationSeconds.isFinite,
+            durationSeconds > 0,
+            offsetSeconds.isFinite,
+            offsetSeconds != 0
+        else { return nil }
+        return min(max(positionSeconds + offsetSeconds, 0), durationSeconds)
+    }
+}
+
 @MainActor
 @Observable
 final class AccountSessionCoordinator: AuthenticatedSessionInvalidating {
@@ -137,6 +153,101 @@ struct AppEnvironment {
 
     var nativeSubtitlesEnabled: Bool {
         playerEngine.nativeSubtitlesEnabled
+    }
+
+    func makeSystemNowPlayingPlaybackConnection()
+        -> SystemNowPlayingPlaybackConnection
+    {
+        SystemNowPlayingPlaybackConnection(
+            currentSnapshot: { [playerEngine] in
+                playerEngine.currentTimelineSnapshot
+            },
+            timelineUpdates: { [playerEngine] in
+                playerEngine.timelineUpdates()
+            },
+            currentItemIdentifier: { [playerEngine] in
+                playerEngine.player.currentItem.map(ObjectIdentifier.init)
+            },
+            currentDefaultPlaybackRate: { [playerEngine] in
+                Double(playerEngine.player.defaultRate)
+            },
+            observeDefaultPlaybackRate: { [playerEngine] notify in
+                let observation = playerEngine.player.observe(
+                    \.defaultRate,
+                    options: [.new]
+                ) { player, change in
+                    let rate = Double(change.newValue ?? player.defaultRate)
+                    Task { @MainActor in notify(rate) }
+                }
+                return SystemNowPlayingDefaultRateObservation {
+                    observation.invalidate()
+                }
+            },
+            perform: { [playerEngine] command, identity, itemIdentifier in
+                guard playerEngine.currentTimelineSnapshot.identity == identity,
+                    let item = playerEngine.player.currentItem,
+                    ObjectIdentifier(item) == itemIdentifier
+                else { return false }
+                switch command {
+                case .play:
+                    playerEngine.play()
+                    return true
+                case .pause:
+                    playerEngine.pause()
+                    return true
+                case .togglePlayPause:
+                    if playerEngine.currentTimelineSnapshot.state == .playing
+                        || playerEngine.currentTimelineSnapshot.state == .buffering
+                    {
+                        playerEngine.pause()
+                    } else {
+                        playerEngine.play()
+                    }
+                    return true
+                case .seek(let positionSeconds):
+                    return Self.requestSystemSeek(
+                        positionSeconds,
+                        engine: playerEngine,
+                        identity: identity,
+                        itemIdentifier: itemIdentifier
+                    )
+                case .skip(let offsetSeconds):
+                    let snapshot = playerEngine.currentTimelineSnapshot
+                    guard let duration = snapshot.durationSeconds,
+                        let target = SystemNowPlayingSeekTarget.relative(
+                            positionSeconds: snapshot.positionSeconds,
+                            durationSeconds: duration,
+                            offsetSeconds: offsetSeconds
+                        )
+                    else {
+                        return false
+                    }
+                    return Self.requestSystemSeek(
+                        target,
+                        engine: playerEngine,
+                        identity: identity,
+                        itemIdentifier: itemIdentifier
+                    )
+                }
+            }
+        )
+    }
+
+    private static func requestSystemSeek(
+        _ positionSeconds: Double,
+        engine: AVPlayerEngine,
+        identity: PlaybackItemIdentity,
+        itemIdentifier: ObjectIdentifier
+    ) -> Bool {
+        guard positionSeconds.isFinite, positionSeconds >= 0,
+            let duration = engine.currentTimelineSnapshot.durationSeconds,
+            positionSeconds <= duration
+        else { return false }
+        guard engine.currentTimelineSnapshot.identity == identity,
+            let item = engine.player.currentItem,
+            ObjectIdentifier(item) == itemIdentifier
+        else { return false }
+        return engine.requestSeek(to: .seconds(positionSeconds))
     }
 
     func makeBrowseViewModel() -> GuestBrowseViewModel {

--- a/BiliKitMac/Composition/SystemNowPlayingWindowCoordinator.swift
+++ b/BiliKitMac/Composition/SystemNowPlayingWindowCoordinator.swift
@@ -1,0 +1,158 @@
+import BiliApplication
+import BiliBrowseFeature
+import BiliModels
+import Foundation
+
+@MainActor
+final class SystemNowPlayingDefaultRateObservation {
+    private var cancellation: (() -> Void)?
+
+    init(cancellation: @escaping () -> Void) {
+        self.cancellation = cancellation
+    }
+
+    isolated deinit {
+        cancellation?()
+    }
+
+    func cancel() {
+        cancellation?()
+        cancellation = nil
+    }
+}
+
+@MainActor
+struct SystemNowPlayingPlaybackConnection {
+    let currentSnapshot: () -> PlaybackTimelineSnapshot
+    let timelineUpdates: () -> AsyncStream<PlaybackTimelineSnapshot>
+    let currentItemIdentifier: () -> ObjectIdentifier?
+    let currentDefaultPlaybackRate: () -> Double
+    let observeDefaultPlaybackRate:
+        (@escaping @MainActor @Sendable (Double) -> Void) ->
+            SystemNowPlayingDefaultRateObservation
+    let perform:
+        (
+            SystemNowPlayingCommand,
+            PlaybackItemIdentity,
+            ObjectIdentifier
+        ) -> Bool
+}
+
+@MainActor
+final class SystemNowPlayingWindowCoordinator {
+    private let controller: SystemNowPlayingController
+    private let connection: SystemNowPlayingPlaybackConnection
+    private let videoModel: GuestVideoViewModel
+    private let windowID: UUID
+    private var observationTask: Task<Void, Never>?
+    private var defaultRateObservation: SystemNowPlayingDefaultRateObservation?
+    private var generation: UInt64 = 0
+    private var sourceIdentity: SystemNowPlayingSourceIdentity?
+    private var isClosed = false
+
+    init(
+        controller: SystemNowPlayingController,
+        connection: SystemNowPlayingPlaybackConnection,
+        videoModel: GuestVideoViewModel
+    ) {
+        self.controller = controller
+        self.connection = connection
+        self.videoModel = videoModel
+        windowID = controller.registerWindow()
+    }
+
+    isolated deinit {
+        observationTask?.cancel()
+        defaultRateObservation?.cancel()
+        controller.removeWindow(windowID)
+    }
+
+    func start() {
+        guard observationTask == nil, !isClosed else { return }
+        synchronize(with: connection.currentSnapshot())
+        observationTask = Task { [weak self, connection] in
+            for await snapshot in connection.timelineUpdates() {
+                guard !Task.isCancelled else { return }
+                self?.synchronize(with: snapshot)
+            }
+        }
+        defaultRateObservation = connection.observeDefaultPlaybackRate {
+            [weak self] _ in
+            guard let self, !self.isClosed else { return }
+            self.synchronize(with: self.connection.currentSnapshot())
+        }
+        observePresentation()
+    }
+
+    func close() {
+        guard !isClosed else { return }
+        isClosed = true
+        observationTask?.cancel()
+        observationTask = nil
+        defaultRateObservation?.cancel()
+        defaultRateObservation = nil
+        controller.removeWindow(windowID)
+    }
+
+    func markWindowActive() {
+        controller.markWindowActive(windowID)
+    }
+
+    private func observePresentation() {
+        guard !isClosed else { return }
+        withObservationTracking {
+            _ = videoModel.presentedContext
+            _ = videoModel.presentedPlaybackIdentity
+            _ = videoModel.state
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self, !self.isClosed else { return }
+                self.synchronize(with: self.connection.currentSnapshot())
+                self.observePresentation()
+            }
+        }
+    }
+
+    private func synchronize(with timeline: PlaybackTimelineSnapshot) {
+        guard let context = videoModel.presentedContext,
+            let identity = videoModel.presentedPlaybackIdentity,
+            timeline.identity == identity,
+            context.detail.bvid == identity.bvid,
+            context.selectedPage.cid == identity.cid,
+            let itemIdentifier = connection.currentItemIdentifier()
+        else {
+            controller.removeWindow(windowID)
+            sourceIdentity = nil
+            return
+        }
+        let nextSourceIdentity = SystemNowPlayingSourceIdentity(
+            playbackIdentity: identity,
+            playerItemIdentifier: itemIdentifier
+        )
+        if nextSourceIdentity != sourceIdentity {
+            generation &+= 1
+            sourceIdentity = nextSourceIdentity
+        }
+        controller.update(
+            windowID: windowID,
+            generation: generation,
+            playbackIdentity: identity,
+            playerItemIdentifier: itemIdentifier,
+            presentation: SystemNowPlayingPresentation(
+                totalTitle: context.detail.title,
+                artist: context.detail.owner.name,
+                partTitle: context.selectedPage.title,
+                partCount: context.pages.count,
+                coverURL: context.detail.coverURL
+            ),
+            timeline: timeline,
+            defaultPlaybackRate: connection.currentDefaultPlaybackRate(),
+            perform: connection.perform
+        )
+    }
+}
+
+private struct SystemNowPlayingSourceIdentity: Equatable {
+    let playbackIdentity: PlaybackItemIdentity
+    let playerItemIdentifier: ObjectIdentifier
+}

--- a/BiliKitMac/Platform/PlayerHostView.swift
+++ b/BiliKitMac/Platform/PlayerHostView.swift
@@ -302,6 +302,7 @@ final class DanmakuPlayerView: AVPlayerView {
         requestMomentaryPlaybackRate = beginMomentaryPlaybackRate
         finishMomentaryPlaybackRate = endMomentaryPlaybackRate
         super.init(frame: .zero)
+        updatesNowPlayingInfoCenter = false
         scrollWheelCaptureView.isMomentaryRateAvailable = { [weak self] in
             self?.canBeginMomentaryPlaybackRate == true
         }

--- a/BiliKitMac/Platform/SystemNowPlayingController.swift
+++ b/BiliKitMac/Platform/SystemNowPlayingController.swift
@@ -1,0 +1,600 @@
+@preconcurrency import AppKit
+import BiliApplication
+import Foundation
+@preconcurrency import MediaPlayer
+
+struct SystemNowPlayingPresentation: Equatable, Sendable {
+    let title: String
+    let artist: String?
+    let albumTitle: String?
+    let coverURL: URL?
+
+    init(
+        totalTitle: String,
+        artist: String,
+        partTitle: String?,
+        partCount: Int,
+        coverURL: URL?
+    ) {
+        let normalizedTotal = totalTitle.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        let normalizedPart = partTitle?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        if let normalizedPart,
+            partCount > 1,
+            !normalizedPart.isEmpty,
+            normalizedPart != normalizedTotal
+        {
+            title = normalizedPart
+            albumTitle = normalizedTotal
+        } else {
+            title = normalizedTotal
+            albumTitle = nil
+        }
+        let normalizedArtist = artist.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        self.artist = normalizedArtist.isEmpty ? nil : normalizedArtist
+        self.coverURL = coverURL
+    }
+}
+
+enum SystemNowPlayingCommand: Equatable, Sendable {
+    case play
+    case pause
+    case togglePlayPause
+    case seek(positionSeconds: Double)
+    case skip(offsetSeconds: Double)
+
+    static func skip(
+        interval: Double,
+        direction: SystemNowPlayingSkipDirection
+    ) -> SystemNowPlayingCommand? {
+        guard interval.isFinite, interval > 0 else { return nil }
+        return .skip(
+            offsetSeconds: direction == .forward ? interval : -interval
+        )
+    }
+}
+
+enum SystemNowPlayingSkipDirection: Sendable {
+    case forward
+    case backward
+}
+
+enum SystemNowPlayingCommandResult: Equatable, Sendable {
+    case success
+    case noSuchContent
+    case commandFailed
+}
+
+@MainActor
+private struct SystemNowPlayingSession {
+    let windowID: UUID
+    let generation: UInt64
+    let playbackIdentity: PlaybackItemIdentity
+    let playerItemIdentifier: ObjectIdentifier
+    let presentation: SystemNowPlayingPresentation
+    let timeline: PlaybackTimelineSnapshot
+    let defaultPlaybackRate: Double
+    let perform:
+        (
+            SystemNowPlayingCommand,
+            PlaybackItemIdentity,
+            ObjectIdentifier
+        ) -> Bool
+    var selectionOrder: UInt64
+
+    var isPlaying: Bool {
+        timeline.state == .playing || timeline.state == .buffering
+    }
+
+    var isValid: Bool {
+        timeline.identity == playbackIdentity
+            && timeline.durationSeconds.map { $0 > 0 } == true
+            && timeline.state != .idle
+            && timeline.state != .loading
+            && timeline.state != .failed
+    }
+}
+
+private struct SystemNowPlayingPublicationIdentity: Equatable {
+    let windowID: UUID
+    let generation: UInt64
+    let playbackIdentity: PlaybackItemIdentity
+    let playerItemIdentifier: ObjectIdentifier
+}
+
+private struct SystemNowPlayingTimelineFingerprint: Equatable {
+    let identity: PlaybackItemIdentity?
+    let durationSeconds: Double?
+    let rate: Double
+    let defaultPlaybackRate: Double
+    let state: PlaybackTimelineState
+    let discontinuityGeneration: UInt64
+}
+
+@MainActor
+protocol SystemNowPlayingCenterWriting: AnyObject {
+    func publish(info: [String: Any], state: MPNowPlayingPlaybackState)
+    func clear()
+}
+
+@MainActor
+private final class DefaultSystemNowPlayingCenter: SystemNowPlayingCenterWriting {
+    private let center: MPNowPlayingInfoCenter
+
+    init(center: MPNowPlayingInfoCenter = .default()) {
+        self.center = center
+    }
+
+    func publish(info: [String: Any], state: MPNowPlayingPlaybackState) {
+        center.nowPlayingInfo = info
+        center.playbackState = state
+    }
+
+    func clear() {
+        center.nowPlayingInfo = nil
+        center.playbackState = .stopped
+    }
+}
+
+@MainActor
+protocol SystemRemoteCommandManaging: AnyObject {
+    var installationCount: Int { get }
+    var removalCount: Int { get }
+    func install(
+        handler:
+            @escaping @Sendable (SystemNowPlayingCommand) ->
+            SystemNowPlayingCommandResult
+    )
+    func removeHandlers()
+}
+
+@MainActor
+private final class DefaultSystemRemoteCommandManager:
+    SystemRemoteCommandManaging
+{
+    private let center: MPRemoteCommandCenter
+    private var registrations: [(command: MPRemoteCommand, token: Any)] = []
+    private(set) var installationCount = 0
+    private(set) var removalCount = 0
+
+    init(center: MPRemoteCommandCenter = .shared()) {
+        self.center = center
+    }
+
+    func install(
+        handler:
+            @escaping @Sendable (SystemNowPlayingCommand) ->
+            SystemNowPlayingCommandResult
+    ) {
+        guard registrations.isEmpty else { return }
+        installationCount += 1
+
+        register(center.playCommand) { _ in handler(.play) }
+        register(center.pauseCommand) { _ in handler(.pause) }
+        register(center.togglePlayPauseCommand) { _ in
+            handler(.togglePlayPause)
+        }
+        register(center.changePlaybackPositionCommand) { event in
+            guard let event = event as? MPChangePlaybackPositionCommandEvent,
+                event.positionTime.isFinite,
+                event.positionTime >= 0
+            else { return .commandFailed }
+            return handler(.seek(positionSeconds: event.positionTime))
+        }
+        center.skipForwardCommand.preferredIntervals = [15]
+        register(center.skipForwardCommand) { event in
+            guard let event = event as? MPSkipIntervalCommandEvent,
+                let command = SystemNowPlayingCommand.skip(
+                    interval: event.interval,
+                    direction: .forward
+                )
+            else { return .commandFailed }
+            return handler(command)
+        }
+        center.skipBackwardCommand.preferredIntervals = [15]
+        register(center.skipBackwardCommand) { event in
+            guard let event = event as? MPSkipIntervalCommandEvent,
+                let command = SystemNowPlayingCommand.skip(
+                    interval: event.interval,
+                    direction: .backward
+                )
+            else { return .commandFailed }
+            return handler(command)
+        }
+
+        center.nextTrackCommand.isEnabled = false
+        center.previousTrackCommand.isEnabled = false
+    }
+
+    func removeHandlers() {
+        guard !registrations.isEmpty else { return }
+        removalCount += 1
+        for registration in registrations {
+            registration.command.removeTarget(registration.token)
+        }
+        registrations.removeAll()
+    }
+
+    private func register(
+        _ command: MPRemoteCommand,
+        handler:
+            @escaping (MPRemoteCommandEvent) ->
+            SystemNowPlayingCommandResult
+    ) {
+        command.isEnabled = true
+        let token = command.addTarget { event in
+            switch handler(event) {
+            case .success:
+                return .success
+            case .noSuchContent:
+                return .noSuchContent
+            case .commandFailed:
+                return .commandFailed
+            }
+        }
+        registrations.append((command, token))
+    }
+}
+
+private final class SystemNowPlayingArtworkImageBox: @unchecked Sendable {
+    let image: CGImage
+
+    init(_ image: CGImage) {
+        self.image = image
+    }
+}
+
+@MainActor
+final class SystemNowPlayingController {
+    private let center: any SystemNowPlayingCenterWriting
+    private let remoteCommands: any SystemRemoteCommandManaging
+    private let artworkLoader: (@Sendable (URL) async -> CGImage?)?
+    private var sessions: [UUID: SystemNowPlayingSession] = [:]
+    private var selectionClock: UInt64 = 0
+    private var publishedIdentity: SystemNowPlayingPublicationIdentity?
+    private var publishedFingerprint: SystemNowPlayingTimelineFingerprint?
+    private var publishedArtwork: MPMediaItemArtwork?
+    private var artworkTask: Task<Void, Never>?
+    private var artworkPipelineOwner: NativeVideoImagePipelineOwner?
+    private var isClosed = false
+
+    init(
+        center: (any SystemNowPlayingCenterWriting)? = nil,
+        remoteCommands: (any SystemRemoteCommandManaging)? = nil,
+        artworkLoader: (@Sendable (URL) async -> CGImage?)? = nil
+    ) {
+        self.center = center ?? DefaultSystemNowPlayingCenter()
+        self.remoteCommands =
+            remoteCommands ?? DefaultSystemRemoteCommandManager()
+        self.artworkLoader = artworkLoader
+        self.remoteCommands.install { [weak self] command in
+            guard let self else { return .noSuchContent }
+            return self.handleFromAnyThread(command)
+        }
+    }
+
+    isolated deinit {
+        artworkTask?.cancel()
+        artworkPipelineOwner?.shutdown()
+        remoteCommands.removeHandlers()
+        if publishedIdentity != nil {
+            center.clear()
+        }
+    }
+
+    func registerWindow() -> UUID {
+        UUID()
+    }
+
+    func update(
+        windowID: UUID,
+        generation: UInt64,
+        playbackIdentity: PlaybackItemIdentity,
+        playerItemIdentifier: ObjectIdentifier,
+        presentation: SystemNowPlayingPresentation,
+        timeline: PlaybackTimelineSnapshot,
+        defaultPlaybackRate: Double,
+        perform:
+            @escaping (
+                SystemNowPlayingCommand,
+                PlaybackItemIdentity,
+                ObjectIdentifier
+            ) -> Bool
+    ) {
+        guard !isClosed else { return }
+        let previous = sessions[windowID]
+        var selectionOrder = previous?.selectionOrder ?? 0
+        let beganPlaying =
+            (timeline.state == .playing || timeline.state == .buffering)
+            && previous?.isPlaying != true
+        if beganPlaying {
+            selectionClock &+= 1
+            selectionOrder = selectionClock
+        }
+        let session = SystemNowPlayingSession(
+            windowID: windowID,
+            generation: generation,
+            playbackIdentity: playbackIdentity,
+            playerItemIdentifier: playerItemIdentifier,
+            presentation: presentation,
+            timeline: timeline,
+            defaultPlaybackRate: Self.normalizedDefaultPlaybackRate(
+                defaultPlaybackRate
+            ),
+            perform: perform,
+            selectionOrder: selectionOrder
+        )
+        if session.isValid {
+            sessions[windowID] = session
+        } else {
+            sessions[windowID] = nil
+        }
+        reconcile()
+    }
+
+    func markWindowActive(_ windowID: UUID) {
+        guard var session = sessions[windowID], session.isValid else { return }
+        selectionClock &+= 1
+        session.selectionOrder = selectionClock
+        sessions[windowID] = session
+        reconcile()
+    }
+
+    func removeWindow(_ windowID: UUID) {
+        sessions[windowID] = nil
+        reconcile()
+    }
+
+    func close() {
+        guard !isClosed else { return }
+        isClosed = true
+        sessions.removeAll()
+        clearPublishedSession()
+        remoteCommands.removeHandlers()
+    }
+
+    nonisolated private func handleFromAnyThread(
+        _ command: SystemNowPlayingCommand
+    ) -> SystemNowPlayingCommandResult {
+        if Thread.isMainThread {
+            return MainActor.assumeIsolated { handle(command) }
+        }
+        return DispatchQueue.main.sync { handle(command) }
+    }
+
+    func handle(
+        _ command: SystemNowPlayingCommand
+    ) -> SystemNowPlayingCommandResult {
+        guard !isClosed, var winner = winningSession() else {
+            return .noSuchContent
+        }
+        guard commandIsValid(command, for: winner.timeline) else {
+            return .noSuchContent
+        }
+        guard
+            winner.perform(
+                command,
+                winner.playbackIdentity,
+                winner.playerItemIdentifier
+            )
+        else {
+            return .commandFailed
+        }
+        selectionClock &+= 1
+        winner.selectionOrder = selectionClock
+        sessions[winner.windowID] = winner
+        return .success
+    }
+
+    private func commandIsValid(
+        _ command: SystemNowPlayingCommand,
+        for timeline: PlaybackTimelineSnapshot
+    ) -> Bool {
+        guard timeline.identity != nil, timeline.state != .ended else {
+            return false
+        }
+        switch command {
+        case .play, .pause, .togglePlayPause:
+            return true
+        case .seek(let positionSeconds):
+            guard let duration = timeline.durationSeconds else { return false }
+            return positionSeconds.isFinite
+                && positionSeconds >= 0
+                && positionSeconds <= duration
+        case .skip(let offsetSeconds):
+            return offsetSeconds.isFinite
+                && offsetSeconds != 0
+                && timeline.durationSeconds.map { $0 > 0 } == true
+        }
+    }
+
+    private func winningSession() -> SystemNowPlayingSession? {
+        let valid = sessions.values.filter(\.isValid)
+        let playing = valid.filter(\.isPlaying)
+        let candidates = playing.isEmpty ? valid : playing
+        return candidates.max { lhs, rhs in
+            let lhsRank = (lhs.selectionOrder, lhs.generation)
+            let rhsRank = (rhs.selectionOrder, rhs.generation)
+            return lhsRank < rhsRank
+        }
+    }
+
+    private func reconcile() {
+        guard let winner = winningSession() else {
+            clearPublishedSession()
+            return
+        }
+        let identity = SystemNowPlayingPublicationIdentity(
+            windowID: winner.windowID,
+            generation: winner.generation,
+            playbackIdentity: winner.playbackIdentity,
+            playerItemIdentifier: winner.playerItemIdentifier
+        )
+        let fingerprint = SystemNowPlayingTimelineFingerprint(
+            identity: winner.timeline.identity,
+            durationSeconds: winner.timeline.durationSeconds,
+            rate: Self.effectiveRate(for: winner.timeline),
+            defaultPlaybackRate: winner.defaultPlaybackRate,
+            state: winner.timeline.state,
+            discontinuityGeneration:
+                winner.timeline.discontinuityGeneration
+        )
+        let identityChanged = identity != publishedIdentity
+        guard identityChanged || fingerprint != publishedFingerprint else {
+            return
+        }
+        if identityChanged {
+            cancelArtworkLoad()
+            publishedArtwork = nil
+            publishedIdentity = identity
+        }
+        publishedFingerprint = fingerprint
+        publish(winner)
+        if identityChanged, let coverURL = winner.presentation.coverURL {
+            loadArtwork(from: coverURL, for: identity)
+        }
+    }
+
+    private func publish(_ session: SystemNowPlayingSession) {
+        var info = Self.info(
+            presentation: session.presentation,
+            timeline: session.timeline,
+            defaultPlaybackRate: session.defaultPlaybackRate
+        )
+        if let publishedArtwork {
+            info[MPMediaItemPropertyArtwork] = publishedArtwork
+        }
+        center.publish(info: info, state: playbackState(for: session.timeline))
+    }
+
+    static func info(
+        presentation: SystemNowPlayingPresentation,
+        timeline: PlaybackTimelineSnapshot,
+        defaultPlaybackRate: Double
+    ) -> [String: Any] {
+        var info: [String: Any] = [
+            MPMediaItemPropertyTitle: presentation.title,
+            MPNowPlayingInfoPropertyElapsedPlaybackTime:
+                timeline.positionSeconds,
+            MPNowPlayingInfoPropertyPlaybackRate: effectiveRate(for: timeline),
+            MPNowPlayingInfoPropertyDefaultPlaybackRate:
+                normalizedDefaultPlaybackRate(defaultPlaybackRate),
+            MPNowPlayingInfoPropertyMediaType:
+                MPNowPlayingInfoMediaType.video.rawValue,
+            MPNowPlayingInfoPropertyIsLiveStream: false,
+            MPNowPlayingInfoPropertyExcludeFromSuggestions: true,
+        ]
+        if let artist = presentation.artist {
+            info[MPMediaItemPropertyArtist] = artist
+        }
+        if let albumTitle = presentation.albumTitle {
+            info[MPMediaItemPropertyAlbumTitle] = albumTitle
+        }
+        if let duration = timeline.durationSeconds, duration > 0 {
+            info[MPMediaItemPropertyPlaybackDuration] = duration
+        }
+        return info
+    }
+
+    nonisolated private static func effectiveRate(
+        for timeline: PlaybackTimelineSnapshot
+    ) -> Double {
+        switch timeline.state {
+        case .playing:
+            return timeline.rate
+        case .idle, .loading, .ready, .paused, .buffering, .ended, .failed:
+            return 0
+        }
+    }
+
+    nonisolated private static func normalizedDefaultPlaybackRate(
+        _ rate: Double
+    ) -> Double {
+        rate.isFinite && rate > 0 ? rate : 1
+    }
+
+    private func playbackState(
+        for timeline: PlaybackTimelineSnapshot
+    ) -> MPNowPlayingPlaybackState {
+        switch timeline.state {
+        case .playing, .buffering:
+            return .playing
+        case .ready, .paused, .ended:
+            return .paused
+        case .idle, .loading, .failed:
+            return .stopped
+        }
+    }
+
+    private func loadArtwork(
+        from url: URL,
+        for identity: SystemNowPlayingPublicationIdentity
+    ) {
+        if let artworkLoader {
+            artworkTask = Task { [weak self] in
+                guard let image = await artworkLoader(url),
+                    !Task.isCancelled
+                else { return }
+                self?.acceptArtwork(image, for: identity)
+            }
+            return
+        }
+        let owner = NativeVideoImagePipelineOwner()
+        artworkPipelineOwner = owner
+        artworkTask = Task { [weak self, pipeline = owner.pipeline] in
+            guard let result = await pipeline.image(for: url, variant: .cover),
+                !Task.isCancelled
+            else { return }
+            self?.acceptArtwork(result.image, for: identity)
+        }
+    }
+
+    private func acceptArtwork(
+        _ image: CGImage,
+        for identity: SystemNowPlayingPublicationIdentity
+    ) {
+        guard publishedIdentity == identity else { return }
+        publishedArtwork = Self.makeArtwork(from: image)
+        guard let winner = winningSession(),
+            publishedIdentity
+                == SystemNowPlayingPublicationIdentity(
+                    windowID: winner.windowID,
+                    generation: winner.generation,
+                    playbackIdentity: winner.playbackIdentity,
+                    playerItemIdentifier: winner.playerItemIdentifier
+                )
+        else { return }
+        publish(winner)
+    }
+
+    nonisolated private static func makeArtwork(
+        from image: CGImage
+    ) -> MPMediaItemArtwork {
+        let box = SystemNowPlayingArtworkImageBox(image)
+        let size = NSSize(width: image.width, height: image.height)
+        return MPMediaItemArtwork(boundsSize: size) { _ in
+            NSImage(cgImage: box.image, size: size)
+        }
+    }
+
+    private func cancelArtworkLoad() {
+        artworkTask?.cancel()
+        artworkTask = nil
+        artworkPipelineOwner?.shutdown()
+        artworkPipelineOwner = nil
+    }
+
+    private func clearPublishedSession() {
+        guard publishedIdentity != nil else { return }
+        cancelArtworkLoad()
+        publishedArtwork = nil
+        publishedIdentity = nil
+        publishedFingerprint = nil
+        center.clear()
+    }
+}

--- a/BiliKitMacTests/PlayerHostViewIdentityTests.swift
+++ b/BiliKitMacTests/PlayerHostViewIdentityTests.swift
@@ -35,6 +35,24 @@ struct PlayerHostViewIdentityTests {
 
     @Test
     @MainActor
+    func nativePlayerViewLeavesNowPlayingOwnershipToProcessController() {
+        let renderer = CoreAnimationDanmakuRenderer()
+        let controller = DanmakuPresentationController(
+            backend: renderer,
+            configuration: Self.emptyDanmakuConfiguration
+        )
+        let view = DanmakuPlayerView(
+            renderer: renderer,
+            controller: controller,
+            beginMomentaryPlaybackRate: nil,
+            endMomentaryPlaybackRate: nil
+        )
+
+        #expect(!view.updatesNowPlayingInfoCenter)
+    }
+
+    @Test
+    @MainActor
     func playbackPreparationBlocksNativePlayerInputAndAccessibility() {
         let renderer = CoreAnimationDanmakuRenderer()
         let controller = DanmakuPresentationController(

--- a/BiliKitMacTests/SystemNowPlayingControllerTests.swift
+++ b/BiliKitMacTests/SystemNowPlayingControllerTests.swift
@@ -1,0 +1,580 @@
+@preconcurrency import AppKit
+import BiliApplication
+import MediaPlayer
+import Testing
+
+@testable import BiliKit
+
+@Suite(.serialized)
+@MainActor
+struct SystemNowPlayingControllerTests {
+    @Test
+    func singleAndMultiplePartMappingRemainMinimal() {
+        let single = SystemNowPlayingPresentation(
+            totalTitle: "总标题",
+            artist: "UP 主",
+            partTitle: "P1",
+            partCount: 1,
+            coverURL: URL(string: "https://example.invalid/cover")
+        )
+        #expect(single.title == "总标题")
+        #expect(single.artist == "UP 主")
+        #expect(single.albumTitle == nil)
+
+        let multiple = SystemNowPlayingPresentation(
+            totalTitle: "总标题",
+            artist: "UP 主",
+            partTitle: "第二章",
+            partCount: 2,
+            coverURL: nil
+        )
+        #expect(multiple.title == "第二章")
+        #expect(multiple.albumTitle == "总标题")
+
+        let duplicate = SystemNowPlayingPresentation(
+            totalTitle: "总标题",
+            artist: "  ",
+            partTitle: " 总标题 ",
+            partCount: 3,
+            coverURL: nil
+        )
+        #expect(duplicate.title == "总标题")
+        #expect(duplicate.albumTitle == nil)
+        #expect(duplicate.artist == nil)
+    }
+
+    @Test
+    func publishedDictionaryContainsNoContentIdentifiersOrURLs() {
+        let presentation = SystemNowPlayingPresentation(
+            totalTitle: "公开标题",
+            artist: "公开作者",
+            partTitle: nil,
+            partCount: 1,
+            coverURL: URL(string: "https://example.invalid/private-cover")
+        )
+        let info = SystemNowPlayingController.info(
+            presentation: presentation,
+            timeline: Self.timeline(position: 12, state: .playing),
+            defaultPlaybackRate: 1
+        )
+
+        #expect(info[MPMediaItemPropertyTitle] as? String == "公开标题")
+        #expect(info[MPMediaItemPropertyArtist] as? String == "公开作者")
+        #expect(
+            info[MPNowPlayingInfoPropertyMediaType] as? UInt
+                == MPNowPlayingInfoMediaType.video.rawValue
+        )
+        #expect(info[MPNowPlayingInfoPropertyExcludeFromSuggestions] as? Bool == true)
+        #expect(info[MPNowPlayingInfoPropertyAssetURL] == nil)
+        #expect(info[MPNowPlayingInfoPropertyExternalContentIdentifier] == nil)
+        #expect(info[MPNowPlayingInfoPropertyServiceIdentifier] == nil)
+        #expect(
+            !info.values.contains { value in
+                let text = String(describing: value)
+                return text.contains("BVSecret")
+                    || text.contains("900001")
+                    || text.contains("example.invalid")
+            }
+        )
+    }
+
+    @Test
+    func preferredRateIsDistinctFromMomentaryAndPausedRates() {
+        let presentation = SystemNowPlayingPresentation(
+            totalTitle: "倍速视频",
+            artist: "UP 主",
+            partTitle: nil,
+            partCount: 1,
+            coverURL: nil
+        )
+        let playing = SystemNowPlayingController.info(
+            presentation: presentation,
+            timeline: PlaybackTimelineSnapshot(
+                identity: PlaybackItemIdentity(bvid: "BVRate", cid: 1),
+                positionSeconds: 10,
+                durationSeconds: 120,
+                rate: 2,
+                state: .playing,
+                discontinuityGeneration: 1
+            ),
+            defaultPlaybackRate: 1.5
+        )
+        #expect(playing[MPNowPlayingInfoPropertyPlaybackRate] as? Double == 2)
+        #expect(
+            playing[MPNowPlayingInfoPropertyDefaultPlaybackRate] as? Double
+                == 1.5
+        )
+
+        let paused = SystemNowPlayingController.info(
+            presentation: presentation,
+            timeline: Self.timeline(state: .paused),
+            defaultPlaybackRate: 1.5
+        )
+        #expect(paused[MPNowPlayingInfoPropertyPlaybackRate] as? Double == 0)
+        #expect(
+            paused[MPNowPlayingInfoPropertyDefaultPlaybackRate] as? Double
+                == 1.5
+        )
+    }
+
+    @Test
+    func elapsedOnlyUpdatesDoNotRepublishEverySecond() {
+        let center = RecordingNowPlayingCenter()
+        let commands = RecordingRemoteCommands()
+        let controller = SystemNowPlayingController(
+            center: center,
+            remoteCommands: commands
+        )
+        let fixture = SessionFixture()
+        let windowID = controller.registerWindow()
+
+        fixture.update(controller, windowID: windowID, timeline: Self.timeline(position: 1))
+        fixture.update(controller, windowID: windowID, timeline: Self.timeline(position: 2))
+        fixture.update(controller, windowID: windowID, timeline: Self.timeline(position: 30))
+
+        #expect(center.publications.count == 1)
+        fixture.update(
+            controller,
+            windowID: windowID,
+            timeline: Self.timeline(position: 31, discontinuity: 2)
+        )
+        #expect(center.publications.count == 2)
+    }
+
+    @Test
+    func pausingCurrentSessionKeepsMetadataAndPublishesPausedState() {
+        let center = RecordingNowPlayingCenter()
+        let controller = SystemNowPlayingController(
+            center: center,
+            remoteCommands: RecordingRemoteCommands()
+        )
+        let fixture = SessionFixture(title: "Pause Fixture")
+        let windowID = controller.registerWindow()
+
+        fixture.update(controller, windowID: windowID, timeline: Self.timeline())
+        fixture.update(
+            controller,
+            windowID: windowID,
+            timeline: Self.timeline(position: 25, state: .paused)
+        )
+
+        #expect(center.clearCount == 0)
+        #expect(center.latestTitle == "Pause Fixture")
+        #expect(center.states.last == .paused)
+        #expect(
+            center.publications.last?[MPNowPlayingInfoPropertyPlaybackRate]
+                as? Double == 0
+        )
+
+        fixture.update(
+            controller,
+            windowID: windowID,
+            timeline: Self.timeline(position: 25, state: .paused),
+            defaultPlaybackRate: 1.5
+        )
+        #expect(
+            center.publications.last?[
+                MPNowPlayingInfoPropertyDefaultPlaybackRate
+            ] as? Double == 1.5
+        )
+        #expect(center.clearCount == 0)
+
+        fixture.update(
+            controller,
+            windowID: windowID,
+            timeline: Self.timeline(position: 25, state: .playing)
+        )
+        #expect(center.clearCount == 0)
+        #expect(center.latestTitle == "Pause Fixture")
+        #expect(center.states.last == .playing)
+    }
+
+    @Test
+    func staleArtworkCannotOverwriteReplacement() async {
+        let center = RecordingNowPlayingCenter()
+        let commands = RecordingRemoteCommands()
+        let loader = ControlledArtworkLoader()
+        let controller = SystemNowPlayingController(
+            center: center,
+            remoteCommands: commands,
+            artworkLoader: { url in await loader.load(url) }
+        )
+        let first = SessionFixture(
+            generation: 1,
+            title: "A",
+            coverURL: URL(string: "https://example.invalid/a")!
+        )
+        let second = SessionFixture(
+            generation: 2,
+            identity: PlaybackItemIdentity(bvid: "BVReplacement", cid: 2),
+            title: "B",
+            coverURL: URL(string: "https://example.invalid/b")!
+        )
+        let windowID = controller.registerWindow()
+        first.update(controller, windowID: windowID, timeline: Self.timeline())
+        second.update(
+            controller,
+            windowID: windowID,
+            timeline: Self.timeline(
+                identity: second.identity
+            )
+        )
+
+        await confirmation("only the current artwork is published") { confirmation in
+            center.onPublish = { info in
+                guard info[MPMediaItemPropertyArtwork] != nil else { return }
+                #expect(info[MPMediaItemPropertyTitle] as? String == "B")
+                confirmation()
+            }
+            await loader.complete(
+                URL(string: "https://example.invalid/a")!,
+                image: Self.image()
+            )
+            await loader.complete(
+                URL(string: "https://example.invalid/b")!,
+                image: Self.image()
+            )
+            await Task.yield()
+        }
+    }
+
+    @Test
+    func remoteCommandsValidateContentAndRouteStatus() {
+        let center = RecordingNowPlayingCenter()
+        let commands = RecordingRemoteCommands()
+        let controller = SystemNowPlayingController(
+            center: center,
+            remoteCommands: commands
+        )
+        let fixture = SessionFixture()
+
+        #expect(commands.invoke(.play) == .noSuchContent)
+        let windowID = controller.registerWindow()
+        fixture.update(controller, windowID: windowID, timeline: Self.timeline())
+        #expect(commands.invoke(.play) == .success)
+        #expect(fixture.performed == [.play])
+        #expect(commands.invoke(.skip(offsetSeconds: 17)) == .success)
+        #expect(commands.invoke(.skip(offsetSeconds: -23)) == .success)
+        #expect(fixture.performed == [.play, .skip(offsetSeconds: 17), .skip(offsetSeconds: -23)])
+        #expect(commands.invoke(.skip(offsetSeconds: 0)) == .noSuchContent)
+        #expect(commands.invoke(.seek(positionSeconds: 121)) == .noSuchContent)
+
+        fixture.update(
+            controller,
+            windowID: windowID,
+            timeline: Self.timeline(position: 120, state: .ended)
+        )
+        #expect(commands.invoke(.play) == .noSuchContent)
+        #expect(commands.invoke(.seek(positionSeconds: 60)) == .noSuchContent)
+        #expect(commands.invoke(.skip(offsetSeconds: -15)) == .noSuchContent)
+
+        fixture.acceptsCommands = false
+        fixture.update(controller, windowID: windowID, timeline: Self.timeline())
+        #expect(commands.invoke(.pause) == .commandFailed)
+        #expect(commands.installationCount == 1)
+        controller.close()
+        #expect(commands.removalCount == 1)
+        controller.close()
+        #expect(commands.removalCount == 1)
+    }
+
+    @Test
+    func skipEventsPreserveTheirIntervalAndDirection() {
+        #expect(
+            SystemNowPlayingCommand.skip(interval: 17, direction: .forward)
+                == .skip(offsetSeconds: 17)
+        )
+        #expect(
+            SystemNowPlayingCommand.skip(interval: 23, direction: .backward)
+                == .skip(offsetSeconds: -23)
+        )
+        #expect(
+            SystemNowPlayingCommand.skip(interval: 0, direction: .forward)
+                == nil
+        )
+        #expect(
+            SystemNowPlayingCommand.skip(
+                interval: .infinity,
+                direction: .backward
+            ) == nil
+        )
+    }
+
+    @Test
+    func relativeSkipTargetsClampToTheCurrentItem() {
+        #expect(
+            SystemNowPlayingSeekTarget.relative(
+                positionSeconds: 20,
+                durationSeconds: 120,
+                offsetSeconds: 17
+            ) == 37
+        )
+        #expect(
+            SystemNowPlayingSeekTarget.relative(
+                positionSeconds: 5,
+                durationSeconds: 120,
+                offsetSeconds: -23
+            ) == 0
+        )
+        #expect(
+            SystemNowPlayingSeekTarget.relative(
+                positionSeconds: 115,
+                durationSeconds: 120,
+                offsetSeconds: 17
+            ) == 120
+        )
+        #expect(
+            SystemNowPlayingSeekTarget.relative(
+                positionSeconds: 20,
+                durationSeconds: 120,
+                offsetSeconds: 0
+            ) == nil
+        )
+    }
+
+    @Test
+    func handlerInstallationIsRemovedWhenProcessOwnerIsReleased() {
+        let commands = RecordingRemoteCommands()
+        var controller: SystemNowPlayingController? = SystemNowPlayingController(
+            center: RecordingNowPlayingCenter(),
+            remoteCommands: commands
+        )
+        let weakController = WeakSystemNowPlayingControllerBox(controller)
+
+        #expect(commands.installationCount == 1)
+        controller = nil
+
+        #expect(weakController.value == nil)
+        #expect(commands.removalCount == 1)
+    }
+
+    @Test
+    func playingWindowWinsAndConditionalRemovalFallsBack() {
+        let center = RecordingNowPlayingCenter()
+        let controller = SystemNowPlayingController(
+            center: center,
+            remoteCommands: RecordingRemoteCommands()
+        )
+        let first = SessionFixture(title: "First")
+        let second = SessionFixture(
+            identity: PlaybackItemIdentity(bvid: "BVSecond", cid: 2),
+            title: "Second"
+        )
+        let firstWindow = controller.registerWindow()
+        let secondWindow = controller.registerWindow()
+
+        first.update(controller, windowID: firstWindow, timeline: Self.timeline())
+        second.update(
+            controller,
+            windowID: secondWindow,
+            timeline: Self.timeline(identity: second.identity, state: .paused)
+        )
+        #expect(center.latestTitle == "First")
+
+        second.update(
+            controller,
+            windowID: secondWindow,
+            timeline: Self.timeline(identity: second.identity)
+        )
+        #expect(center.latestTitle == "Second")
+        controller.markWindowActive(firstWindow)
+        #expect(center.latestTitle == "First")
+
+        let clearsBeforeNonWinnerRemoval = center.clearCount
+        controller.removeWindow(secondWindow)
+        #expect(center.latestTitle == "First")
+        #expect(center.clearCount == clearsBeforeNonWinnerRemoval)
+
+        second.update(
+            controller,
+            windowID: secondWindow,
+            timeline: Self.timeline(identity: second.identity)
+        )
+        #expect(center.latestTitle == "Second")
+        controller.removeWindow(secondWindow)
+        #expect(center.latestTitle == "First")
+        #expect(center.clearCount == clearsBeforeNonWinnerRemoval)
+
+        controller.removeWindow(firstWindow)
+        #expect(center.clearCount == clearsBeforeNonWinnerRemoval + 1)
+    }
+
+    private static func timeline(
+        identity: PlaybackItemIdentity = PlaybackItemIdentity(
+            bvid: "BVSecret",
+            cid: 900_001
+        ),
+        position: Double = 10,
+        state: PlaybackTimelineState = .playing,
+        discontinuity: UInt64 = 1
+    ) -> PlaybackTimelineSnapshot {
+        PlaybackTimelineSnapshot(
+            identity: identity,
+            positionSeconds: position,
+            durationSeconds: 120,
+            rate: state == .playing ? 1 : 0,
+            state: state,
+            discontinuityGeneration: discontinuity
+        )
+    }
+
+    private static func image() -> CGImage {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard
+            let context = CGContext(
+                data: nil,
+                width: 1,
+                height: 1,
+                bitsPerComponent: 8,
+                bytesPerRow: 4,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ), let image = context.makeImage()
+        else {
+            preconditionFailure("Unable to create the artwork test image")
+        }
+        return image
+    }
+}
+
+@MainActor
+private final class SessionFixture {
+    let generation: UInt64
+    let identity: PlaybackItemIdentity
+    let item = NSObject()
+    let title: String
+    let coverURL: URL?
+    var acceptsCommands = true
+    private(set) var performed: [SystemNowPlayingCommand] = []
+
+    init(
+        generation: UInt64 = 1,
+        identity: PlaybackItemIdentity = PlaybackItemIdentity(
+            bvid: "BVSecret",
+            cid: 900_001
+        ),
+        title: String = "Fixture",
+        coverURL: URL? = nil
+    ) {
+        self.generation = generation
+        self.identity = identity
+        self.title = title
+        self.coverURL = coverURL
+    }
+
+    func update(
+        _ controller: SystemNowPlayingController,
+        windowID: UUID,
+        timeline: PlaybackTimelineSnapshot,
+        defaultPlaybackRate: Double = 1
+    ) {
+        controller.update(
+            windowID: windowID,
+            generation: generation,
+            playbackIdentity: identity,
+            playerItemIdentifier: ObjectIdentifier(item),
+            presentation: SystemNowPlayingPresentation(
+                totalTitle: title,
+                artist: "UP",
+                partTitle: nil,
+                partCount: 1,
+                coverURL: coverURL
+            ),
+            timeline: timeline,
+            defaultPlaybackRate: defaultPlaybackRate
+        ) { [weak self] command, identity, itemIdentifier in
+            guard let self, self.acceptsCommands,
+                identity == self.identity,
+                itemIdentifier == ObjectIdentifier(self.item)
+            else { return false }
+            self.performed.append(command)
+            return true
+        }
+    }
+}
+
+@MainActor
+private final class WeakSystemNowPlayingControllerBox {
+    weak var value: SystemNowPlayingController?
+
+    init(_ value: SystemNowPlayingController?) {
+        self.value = value
+    }
+}
+
+@MainActor
+private final class RecordingNowPlayingCenter: SystemNowPlayingCenterWriting {
+    private(set) var publications: [[String: Any]] = []
+    private(set) var states: [MPNowPlayingPlaybackState] = []
+    private(set) var clearCount = 0
+    var onPublish: (([String: Any]) -> Void)?
+
+    var latestTitle: String? {
+        publications.last?[MPMediaItemPropertyTitle] as? String
+    }
+
+    func publish(info: [String: Any], state: MPNowPlayingPlaybackState) {
+        publications.append(info)
+        states.append(state)
+        onPublish?(info)
+    }
+
+    func clear() {
+        clearCount += 1
+    }
+}
+
+@MainActor
+private final class RecordingRemoteCommands: SystemRemoteCommandManaging {
+    private(set) var installationCount = 0
+    private(set) var removalCount = 0
+    private var handler:
+        (
+            @Sendable (SystemNowPlayingCommand) ->
+                SystemNowPlayingCommandResult
+        )?
+
+    func install(
+        handler:
+            @escaping @Sendable (SystemNowPlayingCommand) ->
+            SystemNowPlayingCommandResult
+    ) {
+        guard self.handler == nil else { return }
+        installationCount += 1
+        self.handler = handler
+    }
+
+    func removeHandlers() {
+        guard handler != nil else { return }
+        removalCount += 1
+        handler = nil
+    }
+
+    func invoke(
+        _ command: SystemNowPlayingCommand
+    ) -> SystemNowPlayingCommandResult {
+        handler?(command) ?? .noSuchContent
+    }
+}
+
+private actor ControlledArtworkLoader {
+    private var continuations: [URL: CheckedContinuation<CGImage?, Never>] = [:]
+    private var completed: [URL: CGImage] = [:]
+
+    func load(_ url: URL) async -> CGImage? {
+        if let image = completed.removeValue(forKey: url) {
+            return image
+        }
+        return await withCheckedContinuation { continuation in
+            continuations[url] = continuation
+        }
+    }
+
+    func complete(_ url: URL, image: CGImage) {
+        if let continuation = continuations.removeValue(forKey: url) {
+            continuation.resume(returning: image)
+        } else {
+            completed[url] = image
+        }
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
@@ -45,6 +45,7 @@ public final class AVPlayerEngine:
     private var loadIntent: PlaybackLoadIntent?
     private var activeResumeToken: PlaybackResumeToken?
     private var restartOperation: UUID?
+    private var explicitSeekOperation = UUID()
     private var preparedAsset: PreparedPlaybackAsset?
     private var subtitleIdentity: PlaybackItemIdentity?
     private var subtitleResetTask: Task<Void, Never>?
@@ -169,6 +170,7 @@ public final class AVPlayerEngine:
         try Task.checkCancellation()
 
         loadGeneration = generation
+        explicitSeekOperation = UUID()
         loadIntent = intent
         activeResumeToken = nil
         restartOperation = nil
@@ -234,6 +236,7 @@ public final class AVPlayerEngine:
             if loadGeneration == generation {
                 loadTask = nil
                 readinessTask = nil
+                explicitSeekOperation = UUID()
                 preparedAsset?.stop()
                 preparedAsset = nil
                 player.replaceCurrentItem(with: nil)
@@ -246,6 +249,7 @@ public final class AVPlayerEngine:
             if loadGeneration == generation {
                 loadTask = nil
                 readinessTask = nil
+                explicitSeekOperation = UUID()
                 preparedAsset?.stop()
                 preparedAsset = nil
                 player.replaceCurrentItem(with: nil)
@@ -264,6 +268,7 @@ public final class AVPlayerEngine:
     private func cancelLoad(generation: UUID) {
         guard loadGeneration == generation else { return }
         loadGeneration = UUID()
+        explicitSeekOperation = UUID()
         loadIntent = nil
         activeResumeToken = nil
         restartOperation = nil
@@ -376,6 +381,7 @@ public final class AVPlayerEngine:
             }
         }
         let currentGeneration = loadGeneration
+        explicitSeekOperation = UUID()
         timeline.prepareResumeRestart()
         let interactionRevision = timeline.playbackInteractionRevision
         let didSeek = await player.seek(
@@ -383,6 +389,9 @@ public final class AVPlayerEngine:
             toleranceBefore: .zero,
             toleranceAfter: .zero
         )
+        guard restartOperation == operation else {
+            return false
+        }
         guard didSeek else {
             timeline.resumeRestartFailed()
             return false
@@ -440,9 +449,13 @@ public final class AVPlayerEngine:
 
     /// 执行精确 seek，并只为一次用户 seek 发布一个 discontinuity generation。
     public func seek(to time: Duration) async throws {
-        guard player.currentItem != nil else {
+        guard let item = player.currentItem else {
             throw AVPlayerEngineError.seekFailed
         }
+        let generation = loadGeneration
+        let operation = UUID()
+        restartOperation = nil
+        explicitSeekOperation = operation
         let components = time.components
         let seconds =
             Double(components.seconds)
@@ -453,6 +466,12 @@ public final class AVPlayerEngine:
             toleranceBefore: .zero,
             toleranceAfter: .zero
         )
+        guard explicitSeekOperation == operation,
+            loadGeneration == generation,
+            player.currentItem === item
+        else {
+            throw CancellationError()
+        }
         guard didSeek else {
             timeline.explicitSeekFailed()
             throw AVPlayerEngineError.seekFailed
@@ -460,9 +479,53 @@ public final class AVPlayerEngine:
         timeline.explicitSeekCompleted(at: seconds)
     }
 
+    /// 同步接受当前 item 上的精确 seek，并在 engine 内完成 generation-safe 的异步收尾。
+    ///
+    /// 返回 `true` 表示 AVPlayer 已经收到请求；系统远程命令的同步 handler 无法等待完成回调。
+    @discardableResult
+    public func requestSeek(to time: Duration) -> Bool {
+        guard let item = player.currentItem,
+            let duration = currentTimelineSnapshot.durationSeconds
+        else { return false }
+        let components = time.components
+        let seconds =
+            Double(components.seconds)
+            + Double(components.attoseconds) / 1_000_000_000_000_000_000
+        guard seconds.isFinite, seconds >= 0, seconds <= duration else {
+            return false
+        }
+
+        let generation = loadGeneration
+        let operation = UUID()
+        restartOperation = nil
+        explicitSeekOperation = operation
+        timeline.prepareExplicitSeek(to: seconds)
+        player.seek(
+            to: CMTime(seconds: seconds, preferredTimescale: 600),
+            toleranceBefore: .zero,
+            toleranceAfter: .zero
+        ) { [weak self, weak item] didSeek in
+            Task { @MainActor in
+                guard let self, let item,
+                    self.explicitSeekOperation == operation,
+                    self.loadGeneration == generation,
+                    self.player.currentItem === item
+                else { return }
+                self.explicitSeekOperation = UUID()
+                if didSeek {
+                    self.timeline.explicitSeekCompleted(at: seconds)
+                } else {
+                    self.timeline.explicitSeekFailed()
+                }
+            }
+        }
+        return true
+    }
+
     /// 幂等终止当前及在途播放，将唯一时间线恢复为 `.idle` 状态。
     public func stop() {
         loadGeneration = UUID()
+        explicitSeekOperation = UUID()
         loadIntent = nil
         activeResumeToken = nil
         restartOperation = nil
@@ -590,6 +653,7 @@ public final class AVPlayerEngine:
             let intent = loadIntent
         else { return }
         loadGeneration = UUID()
+        explicitSeekOperation = UUID()
         loadIntent = nil
         loadTask?.cancel()
         loadTask = nil

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
@@ -3012,6 +3012,7 @@ struct LoopbackPlaybackServerTests {
             )
         )
 
+        #expect(!engine.requestSeek(to: .seconds(0.5)))
         try await engine.load(request, identity: identity)
         let firstItem = try #require(engine.player.currentItem)
         let loadGeneration = engine.currentTimelineSnapshot
@@ -3055,6 +3056,23 @@ struct LoopbackPlaybackServerTests {
         #expect(abs(engine.player.rate - 1.5) < 0.01)
         try engine.setRate(1.25)
 
+        engine.pause()
+        let requestedSeekGeneration = engine.currentTimelineSnapshot
+            .discontinuityGeneration
+        #expect(engine.requestSeek(to: .seconds(0.2)))
+        #expect(engine.requestSeek(to: .seconds(0.5)))
+        try await waitUntilAsync {
+            engine.currentTimelineSnapshot.discontinuityGeneration
+                > requestedSeekGeneration
+        }
+        #expect(
+            engine.currentTimelineSnapshot.discontinuityGeneration
+                == requestedSeekGeneration + 1
+        )
+        #expect(abs(engine.currentTimelineSnapshot.positionSeconds - 0.5) < 0.05)
+        #expect(!engine.requestSeek(to: .seconds(10)))
+        engine.play()
+
         try await engine.seek(to: .seconds(0.7))
         #expect(engine.currentTimelineSnapshot.positionSeconds >= 0.65)
         #expect(
@@ -3073,6 +3091,7 @@ struct LoopbackPlaybackServerTests {
         let staleMomentarySession = try #require(
             try engine.beginMomentaryPlaybackRate(2)
         )
+        #expect(engine.requestSeek(to: .seconds(0.2)))
         try await engine.load(request, identity: replacementIdentity)
         engine.endMomentaryPlaybackRate(sessionID: staleMomentarySession)
         #expect(engine.player.currentItem !== firstItem)
@@ -3091,8 +3110,10 @@ struct LoopbackPlaybackServerTests {
         let stoppedMomentarySession = try #require(
             try engine.beginMomentaryPlaybackRate(0.5)
         )
+        #expect(engine.requestSeek(to: .seconds(0.2)))
         engine.stop()
         engine.endMomentaryPlaybackRate(sessionID: stoppedMomentarySession)
+        await Task { @MainActor in }.value
         #expect(engine.player.currentItem == nil)
         #expect(engine.currentTimelineSnapshot.identity == nil)
         #expect(engine.currentTimelineSnapshot.state == .idle)


### PR DESCRIPTION
## 变化

- 新增进程级 `SystemNowPlayingController`，由 App 创建唯一实例，并由窗口 owner 组合视频展示事实与唯一 `AVPlayerEngine` 会话。
- 发布标题、UP 主、分 P、封面、时长、进度、播放状态与倍速；支持 play、pause、toggle、指定位置 seek 及按事件 interval 前进/后退。
- 关闭 `AVPlayerView` 的自动 Now Playing 写入，避免无标题系统条目覆盖产品 metadata。
- 增加多窗口仲裁、条件清理、封面 stale 防护，以及 engine-owned 的 generation-safe 精确 seek 受理。

## 原因

AVKit 默认会自动向系统写入不完整播放信息，并可能在暂停时覆盖或清除应用发布的 metadata。该切片把系统播放信息和远程命令收敛到一个明确的进程级 owner，同时继续复用现有唯一播放器、播放状态和 PiP 会话。

## 用户影响

- macOS 控制中心可稳定显示当前视频或分 P 的标题、UP 主、封面和时间线。
- 暂停时播放信息继续保留，播放状态和默认倍速保持正确。
- 系统播放控件可执行播放、暂停、切换、定位和前后跳转；无内容、结束态或失效会话不会误报成功。
- 正常播放、全屏和 PiP 继续共享同一个 `AVPlayer`。

## 实际验证

- 复数只读审核覆盖架构生命周期、MediaPlayer 语义、测试与安全；修复后复审无剩余 merge blocker。
- `sh Scripts/run-quality-gates.sh app` 通过：静态检查、541 个 package tests / 56 suites、App build-for-testing 与完整 App tests。
- 定向覆盖单/多 P mapping、敏感标识不泄漏、无逐秒发布、暂停保留、默认倍速、stale artwork、远程状态、±interval、多窗口回退、handler 生命周期，以及 seek supersede/换片/stop 竞态。
- 使用正式开发签名构建并运行，Bundle ID `com.shiinayane.BiliKit`，Team `2B3LZ256AG`。

## 未覆盖边界

- 未在 macOS 15 验证。
- 最终构建未逐项人工复验控制中心、全屏与 PiP；自动化契约和 macOS 26 签名构建已覆盖。
- 未验证安装版的系统来源 App 图标；公开 Now Playing API 也不提供设置该图标的能力。
- 快速连续相对 skip 当前可能合并到同一目标；后续方向键分支合入 engine-owned 累计 transport seek 后，可做小范围接线。
