### PR TITLE
feat(player): 实现详情页播放快捷键与统一反馈

### DIFF
--- a/BiliKitMac/App/AppWindowOwner.swift
+++ b/BiliKitMac/App/AppWindowOwner.swift
@@ -57,7 +57,10 @@ final class AppWindowOwner {
             danmakuModel: danmakuModel,
             authenticationModel: environment.makeAuthenticationViewModel(),
             historyModel: environment.makeWatchHistoryViewModel(),
-            playerContent: environment.makePlayerView(videoModel: videoModel),
+            playerContent: environment.makePlayerView(
+                videoModel: videoModel,
+                danmakuModel: danmakuModel
+            ),
             commentAssetURLResolver: environment.commentAssetURLResolver,
             commentVideoLinkResolver: environment.commentVideoLinkResolver,
             commentLinkURLResolver: environment.commentLinkURLResolver,

--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -298,7 +298,10 @@ struct AppEnvironment {
         )
     }
 
-    func makePlayerView(videoModel: GuestVideoViewModel) -> AnyView {
+    func makePlayerView(
+        videoModel: GuestVideoViewModel,
+        danmakuModel: DanmakuControlsViewModel
+    ) -> AnyView {
         AnyView(
             PlayerHostView(
                 player: playerEngine.player,
@@ -310,6 +313,21 @@ struct AppEnvironment {
                 },
                 endMomentaryPlaybackRate: { [playerEngine] sessionID in
                     playerEngine.endMomentaryPlaybackRate(sessionID: sessionID)
+                },
+                seekByTransportOffset: { [playerEngine] offset in
+                    playerEngine.seekByTransportOffset(offset)
+                },
+                adjustVolume: { [playbackPreferencesController] offset in
+                    playbackPreferencesController.adjustVolume(by: offset)
+                },
+                togglePlayback: { [playerEngine] in
+                    playerEngine.togglePlayback()
+                },
+                toggleDanmaku: { [danmakuModel] in
+                    danmakuModel.toggleEnabled()
+                },
+                toggleSubtitles: { [playerEngine] in
+                    await playerEngine.toggleNativeSubtitles()
                 }
             )
         )

--- a/BiliKitMac/Platform/PlaybackPreferencesController.swift
+++ b/BiliKitMac/Platform/PlaybackPreferencesController.swift
@@ -239,4 +239,12 @@ final class PlaybackPreferencesController {
             store.savePreferredRate(preferredRate)
         }
     }
+
+    @discardableResult
+    func adjustVolume(by offset: Float) -> Float {
+        guard offset.isFinite else { return player.volume }
+        player.isMuted = false
+        player.volume = min(max(player.volume + offset, 0), 1)
+        return player.volume
+    }
 }

--- a/BiliKitMac/Platform/PlayerHostView.swift
+++ b/BiliKitMac/Platform/PlayerHostView.swift
@@ -2,6 +2,7 @@ import AVKit
 import BiliApplication
 import BiliBrowseFeature
 import BiliDanmaku
+import BiliPlayback
 import BiliUI
 import SwiftUI
 
@@ -16,6 +17,11 @@ struct PlayerHostView: View {
     let videoModel: GuestVideoViewModel?
     let beginMomentaryPlaybackRate: ((Float) -> UUID?)?
     let endMomentaryPlaybackRate: ((UUID) -> Void)?
+    let seekByTransportOffset: ((Double) -> Bool)?
+    let adjustVolume: ((Float) -> Float)?
+    let togglePlayback: (() -> Bool?)?
+    let toggleDanmaku: (() -> Bool)?
+    let toggleSubtitles: (() async -> NativeSubtitleToggleResult)?
 
     init(
         player: AVPlayer,
@@ -23,7 +29,12 @@ struct PlayerHostView: View {
         danmakuController: DanmakuPresentationController,
         videoModel: GuestVideoViewModel? = nil,
         beginMomentaryPlaybackRate: ((Float) -> UUID?)? = nil,
-        endMomentaryPlaybackRate: ((UUID) -> Void)? = nil
+        endMomentaryPlaybackRate: ((UUID) -> Void)? = nil,
+        seekByTransportOffset: ((Double) -> Bool)? = nil,
+        adjustVolume: ((Float) -> Float)? = nil,
+        togglePlayback: (() -> Bool?)? = nil,
+        toggleDanmaku: (() -> Bool)? = nil,
+        toggleSubtitles: (() async -> NativeSubtitleToggleResult)? = nil
     ) {
         self.player = player
         self.danmakuRenderer = danmakuRenderer
@@ -31,6 +42,11 @@ struct PlayerHostView: View {
         self.videoModel = videoModel
         self.beginMomentaryPlaybackRate = beginMomentaryPlaybackRate
         self.endMomentaryPlaybackRate = endMomentaryPlaybackRate
+        self.seekByTransportOffset = seekByTransportOffset
+        self.adjustVolume = adjustVolume
+        self.togglePlayback = togglePlayback
+        self.toggleDanmaku = toggleDanmaku
+        self.toggleSubtitles = toggleSubtitles
     }
 
     var body: some View {
@@ -42,7 +58,13 @@ struct PlayerHostView: View {
             resumeNotice: videoModel?.resumeNotice,
             restartFromBeginning: { videoModel?.restartFromBeginning() },
             beginMomentaryPlaybackRate: beginMomentaryPlaybackRate,
-            endMomentaryPlaybackRate: endMomentaryPlaybackRate
+            endMomentaryPlaybackRate: endMomentaryPlaybackRate,
+            seekByTransportOffset: seekByTransportOffset,
+            adjustVolume: adjustVolume,
+            togglePlayback: togglePlayback,
+            toggleDanmaku: toggleDanmaku,
+            toggleSubtitles: toggleSubtitles,
+            focusIdentity: videoModel?.presentedBVID
         )
     }
 
@@ -66,13 +88,24 @@ private struct AVPlayerContainerView: NSViewRepresentable {
     let restartFromBeginning: () -> Void
     let beginMomentaryPlaybackRate: ((Float) -> UUID?)?
     let endMomentaryPlaybackRate: ((UUID) -> Void)?
+    let seekByTransportOffset: ((Double) -> Bool)?
+    let adjustVolume: ((Float) -> Float)?
+    let togglePlayback: (() -> Bool?)?
+    let toggleDanmaku: (() -> Bool)?
+    let toggleSubtitles: (() async -> NativeSubtitleToggleResult)?
+    let focusIdentity: String?
 
     func makeNSView(context: Context) -> DanmakuPlayerView {
         let view = DanmakuPlayerView(
             renderer: renderer,
             controller: controller,
             beginMomentaryPlaybackRate: beginMomentaryPlaybackRate,
-            endMomentaryPlaybackRate: endMomentaryPlaybackRate
+            endMomentaryPlaybackRate: endMomentaryPlaybackRate,
+            seekByTransportOffset: seekByTransportOffset,
+            adjustVolume: adjustVolume,
+            togglePlayback: togglePlayback,
+            toggleDanmaku: toggleDanmaku,
+            toggleSubtitles: toggleSubtitles
         )
         view.player = player
         view.startObservingPlayerItemChanges()
@@ -84,6 +117,7 @@ private struct AVPlayerContainerView: NSViewRepresentable {
             resumeNotice,
             restartFromBeginning: restartFromBeginning
         )
+        view.requestInitialKeyboardFocus(for: focusIdentity)
         return view
     }
 
@@ -92,10 +126,16 @@ private struct AVPlayerContainerView: NSViewRepresentable {
         view.setPlaybackPreparationBlocked(blocksNativePlaybackInteraction)
         view.requestMomentaryPlaybackRate = beginMomentaryPlaybackRate
         view.finishMomentaryPlaybackRate = endMomentaryPlaybackRate
+        view.seekByTransportOffset = seekByTransportOffset
+        view.adjustVolume = adjustVolume
+        view.togglePlayback = togglePlayback
+        view.toggleDanmaku = toggleDanmaku
+        view.toggleSubtitles = toggleSubtitles
         view.setResumeNotice(
             resumeNotice,
             restartFromBeginning: restartFromBeginning
         )
+        view.requestInitialKeyboardFocus(for: focusIdentity)
         if view.player !== player {
             view.cancelMomentaryPlaybackRate()
             view.player = player
@@ -112,6 +152,7 @@ private struct AVPlayerContainerView: NSViewRepresentable {
         view.danmakuOverlay.detachSurface()
         view.stopObservingFocusLoss()
         view.stopObservingPlayerItemChanges()
+        view.stopKeyboardMonitoring()
         view.cancelMomentaryPlaybackRate()
         view.player = nil
     }
@@ -143,30 +184,90 @@ enum PlayerMomentaryRate: Float, Equatable, Sendable {
     }
 }
 
-enum PlayerMomentaryRateSessionPolicy {
-    static func shouldCancel(
-        hasActiveSession: Bool,
-        timeControlStatus: AVPlayer.TimeControlStatus
-    ) -> Bool {
-        hasActiveSession && timeControlStatus == .paused
+enum PlayerShortcutFeedback: Equatable {
+    case momentaryRate(PlayerMomentaryRate)
+    case relativeSeek(Int)
+    case volume(Int)
+    case playback(Bool)
+    case danmaku(Bool)
+    case subtitles(NativeSubtitleToggleResult)
+
+    var label: String {
+        switch self {
+        case .momentaryRate(let rate): rate.label
+        case .relativeSeek(let seconds):
+            seconds < 0 ? "后退 \(-seconds) 秒" : "前进 \(seconds) 秒"
+        case .volume(let percent): "\(percent)%"
+        case .playback(let isPlaying): isPlaying ? "播放" : "暂停"
+        case .danmaku(let enabled): enabled ? "弹幕 开" : "弹幕 关"
+        case .subtitles(.enabled(let label)): "字幕 \(label)"
+        case .subtitles(.disabled): "字幕 关"
+        case .subtitles(.unavailable): "无可用字幕"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .momentaryRate(let rate): rate.symbolName
+        case .relativeSeek(let seconds):
+            seconds < 0 ? "gobackward.5" : "goforward.5"
+        case .volume(let percent):
+            percent == 0 ? "speaker.slash.fill" : "speaker.wave.2.fill"
+        case .playback(let isPlaying):
+            isPlaying ? "play.fill" : "pause.fill"
+        case .danmaku(let enabled):
+            enabled ? "text.bubble.fill" : "text.bubble"
+        case .subtitles(.enabled): "captions.bubble.fill"
+        case .subtitles(.disabled), .subtitles(.unavailable):
+            "captions.bubble"
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch self {
+        case .momentaryRate(let rate): rate.accessibilityLabel
+        case .relativeSeek(let seconds):
+            seconds < 0 ? "已后退 \(-seconds) 秒" : "已前进 \(seconds) 秒"
+        case .volume(let percent): "播放器音量 \(percent)%"
+        case .playback(let isPlaying):
+            isPlaying ? "已开始播放" : "已暂停播放"
+        case .danmaku(let enabled): enabled ? "弹幕已开启" : "弹幕已关闭"
+        case .subtitles(.enabled(let label)): "字幕已开启，\(label)"
+        case .subtitles(.disabled): "字幕已关闭"
+        case .subtitles(.unavailable): "当前视频没有可用字幕"
+        }
     }
 }
 
-private struct PlayerMomentaryRateBadge: View {
-    let rate: PlayerMomentaryRate
+enum PlayerShortcutFeedbackDismissalPolicy {
+    static let delay: Duration = .milliseconds(800)
+    static let fadeDuration: TimeInterval = 0.16
+
+    static func shouldDismiss(displayedID: UUID?, scheduledID: UUID) -> Bool {
+        displayedID == scheduledID
+    }
+
+    static func shouldAnimate(reduceMotion: Bool) -> Bool {
+        !reduceMotion
+    }
+}
+
+private struct PlayerShortcutFeedbackBadge: View {
+    let feedback: PlayerShortcutFeedback
 
     var body: some View {
         HStack(spacing: 8) {
-            Image(systemName: rate.symbolName)
-            Text(rate.label)
+            Image(systemName: feedback.symbolName)
+            Text(feedback.label)
                 .monospacedDigit()
+                .lineLimit(1)
         }
         .font(.title3.weight(.semibold))
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
         .modifier(PlayerGlassCapsuleBackground())
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(rate.accessibilityLabel)
+        .accessibilityLabel(feedback.accessibilityLabel)
     }
 }
 
@@ -215,7 +316,7 @@ enum PlayerPlaybackPreparationPolicy {
     static func controlsStyle(
         blocksNativePlaybackInteraction: Bool
     ) -> AVPlayerViewControlsStyle {
-        blocksNativePlaybackInteraction ? .none : .default
+        blocksNativePlaybackInteraction ? .none : .floating
     }
 }
 
@@ -257,8 +358,8 @@ private struct PlayerResumeButtonStyle: ViewModifier {
 }
 
 @MainActor
-private final class PlayerMomentaryRateBadgeHostingView:
-    NSHostingView<PlayerMomentaryRateBadge>
+private final class PlayerShortcutFeedbackBadgeHostingView:
+    NSHostingView<PlayerShortcutFeedbackBadge>
 {
     override func hitTest(_ point: NSPoint) -> NSView? {
         nil
@@ -273,7 +374,7 @@ final class DanmakuPlayerView: AVPlayerView {
     private var installedDanmakuOverlay = false
     private var installedWindowScrollWheelShield = false
     private var momentaryRateSessionID: UUID?
-    private var momentaryRateItemIdentity: ObjectIdentifier?
+    private var momentaryRatePressID: UUID?
     private weak var observedPlayer: AVPlayer?
     private var playerItemObservation: NSKeyValueObservation?
     private var playerTimeControlObservation: NSKeyValueObservation?
@@ -284,16 +385,28 @@ final class DanmakuPlayerView: AVPlayerView {
     private var resumeRestartAction: (() -> Void)?
     private var resumeNoticeDismissTask: Task<Void, Never>?
     private var blocksNativePlaybackInteraction = false
+    private var lastInitialFocusIdentity: String?
+    private var pendingInitialFocusIdentity: String?
     private var appResignObserver: NSObjectProtocol?
     private var windowResignObserver: NSObjectProtocol?
     var requestMomentaryPlaybackRate: ((Float) -> UUID?)?
     var finishMomentaryPlaybackRate: ((UUID) -> Void)?
+    var seekByTransportOffset: ((Double) -> Bool)?
+    var adjustVolume: ((Float) -> Float)?
+    var togglePlayback: (() -> Bool?)?
+    var toggleDanmaku: (() -> Bool)?
+    var toggleSubtitles: (() async -> NativeSubtitleToggleResult)?
 
     init(
         renderer: CoreAnimationDanmakuRenderer,
         controller: DanmakuPresentationController,
         beginMomentaryPlaybackRate: ((Float) -> UUID?)?,
-        endMomentaryPlaybackRate: ((UUID) -> Void)?
+        endMomentaryPlaybackRate: ((UUID) -> Void)?,
+        seekByTransportOffset: ((Double) -> Bool)? = nil,
+        adjustVolume: ((Float) -> Float)? = nil,
+        togglePlayback: (() -> Bool?)? = nil,
+        toggleDanmaku: (() -> Bool)? = nil,
+        toggleSubtitles: (() async -> NativeSubtitleToggleResult)? = nil
     ) {
         danmakuOverlay = DanmakuOverlayView(
             renderer: renderer,
@@ -301,22 +414,45 @@ final class DanmakuPlayerView: AVPlayerView {
         )
         requestMomentaryPlaybackRate = beginMomentaryPlaybackRate
         finishMomentaryPlaybackRate = endMomentaryPlaybackRate
+        self.seekByTransportOffset = seekByTransportOffset
+        self.adjustVolume = adjustVolume
+        self.togglePlayback = togglePlayback
+        self.toggleDanmaku = toggleDanmaku
+        self.toggleSubtitles = toggleSubtitles
         super.init(frame: .zero)
         updatesNowPlayingInfoCenter = false
-        scrollWheelCaptureView.isMomentaryRateAvailable = { [weak self] in
-            self?.canBeginMomentaryPlaybackRate == true
+        scrollWheelCaptureView.onKeyboardMomentaryRateBegan = {
+            [weak self] rate, pressID in
+            self?.beginMomentaryPlaybackRate(rate, pressID: pressID)
         }
-        scrollWheelCaptureView.onMomentaryRateBegan = { [weak self] rate in
-            self?.beginMomentaryPlaybackRate(rate)
+        scrollWheelCaptureView.onKeyboardMomentaryRateEnded = {
+            [weak self] pressID in
+            self?.endMomentaryPlaybackRate(ifPressID: pressID)
         }
-        scrollWheelCaptureView.onMomentaryRateEnded = { [weak self] in
-            self?.endMomentaryPlaybackRate()
+        scrollWheelCaptureView.onRelativeSeek = { [weak self] offset in
+            self?.seekByTransportOffset?(offset) ?? false
+        }
+        scrollWheelCaptureView.onVolumeStep = { [weak self] offset in
+            self?.adjustVolume?(offset)
+        }
+        scrollWheelCaptureView.onTogglePlayback = { [weak self] in
+            guard let togglePlayback = self?.togglePlayback else { return nil }
+            return togglePlayback()
+        }
+        scrollWheelCaptureView.onToggleDanmaku = { [weak self] in
+            self?.toggleDanmaku?()
+        }
+        scrollWheelCaptureView.onToggleSubtitles = { [weak self] in
+            guard let toggleSubtitles = self?.toggleSubtitles else {
+                return .unavailable
+            }
+            return await toggleSubtitles()
         }
         installDanmakuOverlayIfNeeded()
     }
 
     override var acceptsFirstResponder: Bool {
-        !blocksNativePlaybackInteraction && super.acceptsFirstResponder
+        !blocksNativePlaybackInteraction
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
@@ -325,12 +461,25 @@ final class DanmakuPlayerView: AVPlayerView {
     }
 
     func setPlaybackPreparationBlocked(_ blocked: Bool) {
-        guard blocksNativePlaybackInteraction != blocked else { return }
+        let stateChanged = blocksNativePlaybackInteraction != blocked
         blocksNativePlaybackInteraction = blocked
         controlsStyle = PlayerPlaybackPreparationPolicy.controlsStyle(
             blocksNativePlaybackInteraction: blocked
         )
         setAccessibilityHidden(blocked)
+        scrollWheelCaptureView.setKeyboardInputEnabled(!blocked)
+        guard stateChanged else {
+            if !blocked {
+                applyPendingInitialKeyboardFocus()
+            }
+            return
+        }
+        if blocked {
+            cancelMomentaryPlaybackRate()
+        }
+        if !blocked {
+            applyPendingInitialKeyboardFocus()
+        }
         guard blocked,
             let window,
             let responderView = window.firstResponder as? NSView,
@@ -379,6 +528,7 @@ final class DanmakuPlayerView: AVPlayerView {
         installDanmakuOverlayIfNeeded()
         installWindowScrollWheelShield()
         startObservingFocusLoss()
+        applyPendingInitialKeyboardFocus()
         if let displayedResumeNotice,
             resumeButtonHostingView == nil,
             let resumeRestartAction
@@ -395,6 +545,22 @@ final class DanmakuPlayerView: AVPlayerView {
         installWindowScrollWheelShield()
     }
 
+    func requestInitialKeyboardFocus(for identity: String?) {
+        guard let identity, identity != lastInitialFocusIdentity else { return }
+        pendingInitialFocusIdentity = identity
+        applyPendingInitialKeyboardFocus()
+    }
+
+    private func applyPendingInitialKeyboardFocus() {
+        guard !blocksNativePlaybackInteraction,
+            let identity = pendingInitialFocusIdentity,
+            let window
+        else { return }
+        pendingInitialFocusIdentity = nil
+        lastInitialFocusIdentity = identity
+        window.makeFirstResponder(self)
+    }
+
     func cancelMomentaryPlaybackRate() {
         scrollWheelCaptureView.cancelInputSession()
         if momentaryRateSessionID != nil {
@@ -403,10 +569,7 @@ final class DanmakuPlayerView: AVPlayerView {
     }
 
     func handleWindowSurfaceScrollWheel(_ event: NSEvent) {
-        scrollWheelCaptureView.handleScrollWheel(
-            event,
-            playerFallbackPolicy: .consume
-        )
+        scrollWheelCaptureView.handleScrollWheel(event)
     }
 
     func installWindowScrollWheelShield() {
@@ -416,9 +579,6 @@ final class DanmakuPlayerView: AVPlayerView {
             windowScrollWheelShieldView.autoresizingMask = [.width, .height]
             windowScrollWheelShieldView.onScrollWheel = { [weak self] event in
                 self?.handleWindowSurfaceScrollWheel(event)
-            }
-            windowScrollWheelShieldView.onPointerExited = { [weak self] in
-                self?.resetScrollInputSessionForPointerExit()
             }
         }
         if windowScrollWheelShieldView.frame != bounds {
@@ -438,23 +598,6 @@ final class DanmakuPlayerView: AVPlayerView {
         )
     }
 
-    private func resetScrollInputSessionForPointerExit() {
-        scrollWheelCaptureView.resetInputSessionForPointerExit()
-        if momentaryRateSessionID != nil {
-            endMomentaryPlaybackRate()
-        }
-    }
-
-    func cancelMomentaryPlaybackRateIfItemChanged() {
-        guard let momentaryRateItemIdentity else { return }
-        guard let currentItem = player?.currentItem,
-            ObjectIdentifier(currentItem) == momentaryRateItemIdentity
-        else {
-            cancelMomentaryPlaybackRate()
-            return
-        }
-    }
-
     func startObservingPlayerItemChanges() {
         guard observedPlayer !== player else { return }
         stopObservingPlayerItemChanges()
@@ -463,7 +606,7 @@ final class DanmakuPlayerView: AVPlayerView {
         playerItemObservation = player.observe(\.currentItem, options: [.new]) {
             [weak self] _, _ in
             Task { @MainActor in
-                self?.cancelMomentaryPlaybackRateIfItemChanged()
+                self?.cancelMomentaryPlaybackRate()
                 self?.clearResumeNotice(markDismissed: true)
                 self?.startObservingCurrentItemTimeJumps()
             }
@@ -475,16 +618,7 @@ final class DanmakuPlayerView: AVPlayerView {
             [weak self] _, change in
             guard change.newValue == .paused else { return }
             Task { @MainActor in
-                guard let self,
-                    PlayerMomentaryRateSessionPolicy.shouldCancel(
-                        hasActiveSession: self.momentaryRateSessionID != nil,
-                        timeControlStatus: self.player?.timeControlStatus
-                            ?? .paused
-                    )
-                else {
-                    return
-                }
-                self.cancelMomentaryPlaybackRate()
+                self?.cancelMomentaryPlaybackRate()
             }
         }
         startObservingCurrentItemTimeJumps()
@@ -661,18 +795,13 @@ final class DanmakuPlayerView: AVPlayerView {
         resumeButtonHostingView = nil
     }
 
-    private var canBeginMomentaryPlaybackRate: Bool {
-        guard requestMomentaryPlaybackRate != nil,
-            finishMomentaryPlaybackRate != nil,
-            let player,
-            let item = player.currentItem
-        else {
-            return false
+    private func beginMomentaryPlaybackRate(
+        _ rate: PlayerMomentaryRate,
+        pressID: UUID
+    ) {
+        if momentaryRatePressID != pressID {
+            endMomentaryPlaybackRate()
         }
-        return item.status == .readyToPlay && player.rate > 0
-    }
-
-    private func beginMomentaryPlaybackRate(_ rate: PlayerMomentaryRate) {
         guard let player,
             let item = player.currentItem,
             item.status == .readyToPlay,
@@ -683,8 +812,13 @@ final class DanmakuPlayerView: AVPlayerView {
             return
         }
         momentaryRateSessionID = sessionID
-        momentaryRateItemIdentity = ObjectIdentifier(item)
+        momentaryRatePressID = pressID
         scrollWheelCaptureView.showMomentaryRateBadge(rate)
+    }
+
+    private func endMomentaryPlaybackRate(ifPressID pressID: UUID) {
+        guard momentaryRatePressID == pressID else { return }
+        endMomentaryPlaybackRate()
     }
 
     private func endMomentaryPlaybackRate() {
@@ -696,7 +830,7 @@ final class DanmakuPlayerView: AVPlayerView {
 
     private func clearMomentaryPlaybackRate() {
         momentaryRateSessionID = nil
-        momentaryRateItemIdentity = nil
+        momentaryRatePressID = nil
         scrollWheelCaptureView.clearMomentaryRateBadge()
     }
 
@@ -740,6 +874,10 @@ final class DanmakuPlayerView: AVPlayerView {
         }
     }
 
+    func stopKeyboardMonitoring() {
+        scrollWheelCaptureView.stopKeyboardMonitoring()
+    }
+
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         nil
@@ -748,13 +886,11 @@ final class DanmakuPlayerView: AVPlayerView {
 
 /// 普通窗口中位于 AVPlayerView 原生子视图上方的 scroll-only direct child。
 ///
-/// 该视图没有自己的 router 或播放状态；它只把 precise scroll-wheel 转交给
+/// 该视图没有自己的 router 或播放状态；它只把 scroll-wheel 转交给
 /// `contentOverlayView` capture 持有的唯一 surface coordinator。其他输入穿透给 AVKit。
 @MainActor
 final class PlayerScrollWheelShieldView: NSView {
     var onScrollWheel: (NSEvent) -> Void = { _ in }
-    var onPointerExited: () -> Void = {}
-    private var pointerTrackingArea: NSTrackingArea?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -762,15 +898,13 @@ final class PlayerScrollWheelShieldView: NSView {
     }
 
     static func capturesEvent(
-        ofType type: NSEvent.EventType?,
-        isPrecise: Bool
+        ofType type: NSEvent.EventType?
     ) -> Bool {
-        type == .scrollWheel && isPrecise
+        type == .scrollWheel
     }
 
     static func capturesEvent(_ event: NSEvent) -> Bool {
-        guard event.type == .scrollWheel else { return false }
-        return event.hasPreciseScrollingDeltas
+        capturesEvent(ofType: event.type)
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
@@ -782,32 +916,6 @@ final class PlayerScrollWheelShieldView: NSView {
         onScrollWheel(event)
     }
 
-    override func updateTrackingAreas() {
-        super.updateTrackingAreas()
-        if let pointerTrackingArea {
-            removeTrackingArea(pointerTrackingArea)
-        }
-        let trackingArea = NSTrackingArea(
-            rect: .zero,
-            options: [
-                .mouseEnteredAndExited,
-                .activeInKeyWindow,
-                .inVisibleRect,
-            ],
-            owner: self
-        )
-        addTrackingArea(trackingArea)
-        pointerTrackingArea = trackingArea
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        handlePointerExit()
-    }
-
-    func handlePointerExit() {
-        onPointerExited()
-    }
-
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         nil
@@ -817,31 +925,48 @@ final class PlayerScrollWheelShieldView: NSView {
 /// 安装在 AVKit 公开 content overlay 中、位于原生控制条下方的透明滚轮命中层。
 ///
 /// 只对 scroll-wheel 事件参与 hit testing；点击、拖动、magnify、键盘与辅助功能继续穿透。
-/// AVKit detached 全屏会携带 content overlay，因此同一 capture 可继续处理全屏横向倍速。
+/// AVKit detached 全屏会携带 content overlay；横向 wheel 在所有 surface 都不产生播放器动作。
 @MainActor
 final class PlayerScrollWheelCaptureView: NSView {
-    private lazy var surfaceCapture = PlayerScrollWheelSurfaceCapture(
-        anchorView: self,
-        dispatchToPlayer: { [weak self] event in
-            self?.dispatchScrollWheelToResponderChain(event)
-        }
-    )
+    private enum KeyboardKey: Sendable {
+        case direction(PlayerKeyboardDirection)
+        case shortcut(PlayerKeyboardShortcut)
+    }
+
+    private struct KeyboardEventSnapshot: Sendable {
+        let type: NSEvent.EventType
+        let key: KeyboardKey
+        let hasDisallowedModifier: Bool
+        let isRepeat: Bool
+        let timestamp: TimeInterval
+        let windowNumber: Int
+    }
+
     private var windowResignObserver: NSObjectProtocol?
-    private var momentaryRateBadge: NSView?
-
-    var isMomentaryRateAvailable: () -> Bool {
-        get { surfaceCapture.isMomentaryRateAvailable }
-        set { surfaceCapture.isMomentaryRateAvailable = newValue }
+    private var keyboardMonitor: Any?
+    private var keyboardInputEnabled = true
+    private var keyboardState = PlayerKeyboardInputState()
+    private var scrollWheelRouting = PlayerScrollWheelRouting()
+    private var pendingScrollWheelEvents: [NSEvent] = []
+    private var keyboardLongPressTask: Task<Void, Never>?
+    private var keyboardLongPressID: UUID?
+    private var subtitleToggleTask: Task<Void, Never>?
+    private var feedbackBadge: NSView?
+    private var displayedFeedback: PlayerShortcutFeedback?
+    private var feedbackDismissTask: Task<Void, Never>?
+    private var feedbackFadeTask: Task<Void, Never>?
+    private var feedbackID: UUID?
+    var onKeyboardMomentaryRateBegan: (PlayerMomentaryRate, UUID) -> Void = {
+        _,
+        _ in
     }
-
-    var onMomentaryRateBegan: (PlayerMomentaryRate) -> Void {
-        get { surfaceCapture.onMomentaryRateBegan }
-        set { surfaceCapture.onMomentaryRateBegan = newValue }
-    }
-
-    var onMomentaryRateEnded: () -> Void {
-        get { surfaceCapture.onMomentaryRateEnded }
-        set { surfaceCapture.onMomentaryRateEnded = newValue }
+    var onKeyboardMomentaryRateEnded: (UUID) -> Void = { _ in }
+    var onRelativeSeek: (Double) -> Bool = { _ in false }
+    var onVolumeStep: (Float) -> Float? = { _ in nil }
+    var onTogglePlayback: () -> Bool? = { nil }
+    var onToggleDanmaku: () -> Bool? = { nil }
+    var onToggleSubtitles: () async -> NativeSubtitleToggleResult = {
+        .unavailable
     }
 
     override init(frame frameRect: NSRect) {
@@ -858,17 +983,32 @@ final class PlayerScrollWheelCaptureView: NSView {
     }
 
     override func scrollWheel(with event: NSEvent) {
-        handleScrollWheel(event, playerFallbackPolicy: .dispatchToPlayer)
+        handleScrollWheel(event)
     }
 
-    func handleScrollWheel(
-        _ event: NSEvent,
-        playerFallbackPolicy: PlayerScrollWheelPlayerFallbackPolicy
-    ) {
-        surfaceCapture.handleScrollWheel(
-            event,
-            playerFallbackPolicy: playerFallbackPolicy
+    func handleScrollWheel(_ event: NSEvent) {
+        let route = scrollWheelRouting.route(
+            deltaX: event.scrollingDeltaX,
+            deltaY: event.scrollingDeltaY,
+            phase: event.phase,
+            momentumPhase: event.momentumPhase
         )
+        switch route {
+        case .pending:
+            pendingScrollWheelEvents.append(event)
+        case .ignore:
+            pendingScrollWheelEvents.removeAll(keepingCapacity: true)
+        case .outerScroll:
+            guard let scrollView = detailScrollViewAncestor else {
+                pendingScrollWheelEvents.removeAll(keepingCapacity: true)
+                return
+            }
+            for pendingEvent in pendingScrollWheelEvents {
+                scrollView.scrollWheel(with: pendingEvent)
+            }
+            pendingScrollWheelEvents.removeAll(keepingCapacity: true)
+            scrollView.scrollWheel(with: event)
+        }
     }
 
     override func viewWillMove(toWindow newWindow: NSWindow?) {
@@ -881,7 +1021,9 @@ final class PlayerScrollWheelCaptureView: NSView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        guard let window, windowResignObserver == nil else { return }
+        guard let window else { return }
+        startKeyboardMonitoring()
+        guard windowResignObserver == nil else { return }
         windowResignObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didResignKeyNotification,
             object: window,
@@ -894,34 +1036,348 @@ final class PlayerScrollWheelCaptureView: NSView {
     }
 
     func cancelInputSession() {
-        surfaceCapture.cancelInputSession()
+        scrollWheelRouting.cancel()
+        pendingScrollWheelEvents.removeAll(keepingCapacity: true)
+        cancelKeyboardInputSession()
     }
 
-    func resetInputSessionForPointerExit() {
-        surfaceCapture.resetInputSessionForPointerExit()
+    func setKeyboardInputEnabled(_ enabled: Bool) {
+        guard keyboardInputEnabled != enabled else { return }
+        keyboardInputEnabled = enabled
+        if !enabled {
+            cancelKeyboardInputSession()
+        }
+    }
+
+    private func cancelKeyboardInputSession() {
+        applyKeyboardActions(keyboardState.cancel())
+        keyboardLongPressTask?.cancel()
+        keyboardLongPressTask = nil
+        keyboardLongPressID = nil
+        subtitleToggleTask?.cancel()
+        subtitleToggleTask = nil
+        clearFeedback()
     }
 
     func showMomentaryRateBadge(_ rate: PlayerMomentaryRate) {
-        clearMomentaryRateBadge()
-        let badge = PlayerMomentaryRateBadgeHostingView(
-            rootView: PlayerMomentaryRateBadge(rate: rate)
+        feedbackDismissTask?.cancel()
+        feedbackDismissTask = nil
+        feedbackID = nil
+        showFeedback(.momentaryRate(rate))
+    }
+
+    func clearMomentaryRateBadge() {
+        guard case .momentaryRate = displayedFeedback else { return }
+        dismissFeedbackAnimated()
+    }
+
+    func startKeyboardMonitoring() {
+        guard keyboardMonitor == nil else { return }
+        keyboardMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.keyDown, .keyUp, .leftMouseDown]
+        ) { [weak self] event in
+            if event.type == .leftMouseDown {
+                DispatchQueue.main.async { @MainActor [weak self] in
+                    self?.cancelIfEditableResponder()
+                }
+                return event
+            }
+            guard let snapshot = Self.keyboardSnapshot(from: event) else {
+                DispatchQueue.main.async { @MainActor [weak self] in
+                    self?.cancelIfEditableResponder()
+                }
+                return event
+            }
+            let consumed = MainActor.assumeIsolated {
+                self?.handleKeyboardEvent(snapshot) == true
+            }
+            return consumed ? nil : event
+        }
+    }
+
+    func stopKeyboardMonitoring() {
+        cancelInputSession()
+        if let keyboardMonitor {
+            NSEvent.removeMonitor(keyboardMonitor)
+            self.keyboardMonitor = nil
+        }
+        stopObservingWindowFocusLoss()
+    }
+
+    private func handleKeyboardEvent(_ event: KeyboardEventSnapshot) -> Bool {
+        guard let captureWindow = window else { return false }
+        let isEditable = Self.isEditable(captureWindow.firstResponder)
+        guard
+            PlayerKeyboardEventScope.captures(
+                isEnabled: keyboardInputEnabled,
+                isSupportedKey: true,
+                hasDisallowedModifier: event.hasDisallowedModifier,
+                eventMatchesCaptureWindow:
+                    event.windowNumber == captureWindow.windowNumber,
+                isEditableResponder: isEditable
+            )
+        else {
+            if !keyboardInputEnabled
+                || event.hasDisallowedModifier
+                || isEditable
+            {
+                cancelKeyboardInputSession()
+            }
+            return false
+        }
+
+        let actions: [PlayerKeyboardInputState.Action]
+        switch (event.type, event.key) {
+        case (.keyDown, .direction(let direction)):
+            actions = keyboardState.keyDown(
+                direction,
+                isRepeat: event.isRepeat,
+                timestamp: event.timestamp
+            )
+        case (.keyUp, .direction(let direction)):
+            actions = keyboardState.keyUp(direction)
+        case (.keyDown, .shortcut(let shortcut)):
+            actions = keyboardState.shortcutKeyDown(
+                shortcut,
+                isRepeat: event.isRepeat
+            )
+        case (.keyUp, .shortcut(let shortcut)):
+            actions = keyboardState.shortcutKeyUp(shortcut)
+        default:
+            return false
+        }
+        applyKeyboardActions(actions)
+        return true
+    }
+
+    private func applyKeyboardActions(
+        _ actions: [PlayerKeyboardInputState.Action]
+    ) {
+        for action in actions {
+            switch action {
+            case .scheduleLongPress(let pressID):
+                keyboardLongPressTask?.cancel()
+                keyboardLongPressID = pressID
+                keyboardLongPressTask = Task { [weak self] in
+                    do {
+                        try await Task.sleep(
+                            for: .seconds(
+                                PlayerKeyboardInputState.longPressDelay
+                            )
+                        )
+                    } catch {
+                        return
+                    }
+                    guard let self, self.keyboardLongPressID == pressID else {
+                        return
+                    }
+                    self.keyboardLongPressTask = nil
+                    self.keyboardLongPressID = nil
+                    self.applyKeyboardActions(
+                        self.keyboardState.deadlineReached(pressID: pressID)
+                    )
+                }
+            case .cancelLongPress(let pressID):
+                guard keyboardLongPressID == pressID else { break }
+                keyboardLongPressTask?.cancel()
+                keyboardLongPressTask = nil
+                keyboardLongPressID = nil
+            case .beginMomentaryRate(let rate, let pressID):
+                onKeyboardMomentaryRateBegan(rate, pressID)
+            case .endMomentaryRate(let pressID):
+                onKeyboardMomentaryRateEnded(pressID)
+            case .seekBy(let seconds):
+                if onRelativeSeek(seconds) {
+                    showTransientFeedback(
+                        .relativeSeek(Int(seconds.rounded()))
+                    )
+                }
+            case .adjustVolume(let offset):
+                if let volume = onVolumeStep(offset) {
+                    showTransientFeedback(
+                        .volume(Int((volume * 100).rounded()))
+                    )
+                }
+            case .togglePlayback:
+                if let isPlaying = onTogglePlayback() {
+                    showTransientFeedback(.playback(isPlaying))
+                }
+            case .toggleDanmaku:
+                if let enabled = onToggleDanmaku() {
+                    showTransientFeedback(.danmaku(enabled))
+                }
+            case .toggleSubtitles:
+                subtitleToggleTask?.cancel()
+                subtitleToggleTask = Task { [weak self] in
+                    guard let self else { return }
+                    let result = await self.onToggleSubtitles()
+                    guard !Task.isCancelled else { return }
+                    self.subtitleToggleTask = nil
+                    self.showTransientFeedback(.subtitles(result))
+                }
+            }
+        }
+    }
+
+    private func showTransientFeedback(_ feedback: PlayerShortcutFeedback) {
+        feedbackDismissTask?.cancel()
+        let identity = UUID()
+        feedbackID = identity
+        showFeedback(feedback)
+        feedbackDismissTask = Task { [weak self] in
+            do {
+                try await Task.sleep(
+                    for: PlayerShortcutFeedbackDismissalPolicy.delay
+                )
+            } catch {
+                return
+            }
+            guard let self,
+                PlayerShortcutFeedbackDismissalPolicy.shouldDismiss(
+                    displayedID: self.feedbackID,
+                    scheduledID: identity
+                )
+            else { return }
+            self.dismissFeedbackAnimated()
+        }
+    }
+
+    private func showFeedback(_ feedback: PlayerShortcutFeedback) {
+        feedbackFadeTask?.cancel()
+        feedbackFadeTask = nil
+        feedbackBadge?.removeFromSuperview()
+        let badge = PlayerShortcutFeedbackBadgeHostingView(
+            rootView: PlayerShortcutFeedbackBadge(feedback: feedback)
         )
+        badge.alphaValue = 1
         badge.translatesAutoresizingMaskIntoConstraints = false
         addSubview(badge)
         NSLayoutConstraint.activate([
             badge.centerXAnchor.constraint(equalTo: centerXAnchor),
             badge.topAnchor.constraint(equalTo: topAnchor, constant: 20),
         ])
-        momentaryRateBadge = badge
+        feedbackBadge = badge
+        displayedFeedback = feedback
     }
 
-    func clearMomentaryRateBadge() {
-        momentaryRateBadge?.removeFromSuperview()
-        momentaryRateBadge = nil
+    private func dismissFeedbackAnimated() {
+        feedbackDismissTask?.cancel()
+        feedbackDismissTask = nil
+        feedbackID = nil
+        feedbackFadeTask?.cancel()
+        feedbackFadeTask = nil
+        guard let badge = feedbackBadge else {
+            displayedFeedback = nil
+            return
+        }
+        guard
+            PlayerShortcutFeedbackDismissalPolicy.shouldAnimate(
+                reduceMotion: NSWorkspace.shared
+                    .accessibilityDisplayShouldReduceMotion
+            )
+        else {
+            clearFeedback()
+            return
+        }
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = PlayerShortcutFeedbackDismissalPolicy.fadeDuration
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            badge.animator().alphaValue = 0
+        }
+        feedbackFadeTask = Task { [weak self, weak badge] in
+            do {
+                try await Task.sleep(
+                    for: .seconds(
+                        PlayerShortcutFeedbackDismissalPolicy.fadeDuration
+                    )
+                )
+            } catch {
+                return
+            }
+            guard let self, let badge, self.feedbackBadge === badge else {
+                return
+            }
+            self.feedbackFadeTask = nil
+            badge.removeFromSuperview()
+            self.feedbackBadge = nil
+            self.displayedFeedback = nil
+        }
     }
 
-    private func dispatchScrollWheelToResponderChain(_ event: NSEvent) {
-        super.scrollWheel(with: event)
+    private func clearFeedback() {
+        feedbackDismissTask?.cancel()
+        feedbackDismissTask = nil
+        feedbackFadeTask?.cancel()
+        feedbackFadeTask = nil
+        feedbackID = nil
+        feedbackBadge?.removeFromSuperview()
+        feedbackBadge = nil
+        displayedFeedback = nil
+    }
+
+    private func cancelIfEditableResponder() {
+        guard let window, Self.isEditable(window.firstResponder) else { return }
+        cancelKeyboardInputSession()
+    }
+
+    private static func isEditable(_ responder: NSResponder?) -> Bool {
+        switch responder {
+        case let textView as NSTextView:
+            textView.isEditable
+        case let textField as NSTextField:
+            textField.isEditable
+        default:
+            false
+        }
+    }
+
+    private nonisolated static func keyboardSnapshot(
+        from event: NSEvent
+    ) -> KeyboardEventSnapshot? {
+        let key: KeyboardKey
+        switch event.specialKey {
+        case .leftArrow: key = .direction(.left)
+        case .rightArrow: key = .direction(.right)
+        case .upArrow: key = .direction(.up)
+        case .downArrow: key = .direction(.down)
+        default:
+            switch event.charactersIgnoringModifiers?.lowercased() {
+            case " ": key = .shortcut(.playback)
+            case "d": key = .shortcut(.danmaku)
+            case "c": key = .shortcut(.subtitles)
+            default: return nil
+            }
+        }
+        let disallowedModifiers: NSEvent.ModifierFlags = [
+            .command, .control, .option, .shift,
+        ]
+        return KeyboardEventSnapshot(
+            type: event.type,
+            key: key,
+            hasDisallowedModifier:
+                !event.modifierFlags.intersection(disallowedModifiers).isEmpty,
+            isRepeat: event.isARepeat,
+            timestamp: event.timestamp,
+            windowNumber: event.windowNumber
+        )
+    }
+
+    /// 忽略 AVPlayerView 内部可能存在的滚动视图，只找播放器之外的详情容器。
+    private var detailScrollViewAncestor: NSScrollView? {
+        var ancestor = superview
+        var passedPlayerView = false
+        while let current = ancestor {
+            if current is AVPlayerView {
+                passedPlayerView = true
+            } else if passedPlayerView,
+                let scrollView = current as? NSScrollView
+            {
+                return scrollView
+            }
+            ancestor = current.superview
+        }
+        return nil
     }
 
     private func stopObservingWindowFocusLoss() {
@@ -937,492 +1393,123 @@ final class PlayerScrollWheelCaptureView: NSView {
     }
 }
 
-/// 由唯一 AVPlayerView content overlay surface 拥有的滚轮序列处理器。
-///
-/// 本类型不安装 event monitor，也不向 AVKit 私有子视图重放事件。
-@MainActor
-final class PlayerScrollWheelSurfaceCapture {
-    private weak var anchorView: NSView?
-    private let dispatchToPlayer: (NSEvent) -> Void
-    private var scrollWheelRouter = PlayerScrollWheelRouter()
-    private var horizontalRateGesture = PlayerHorizontalRateGestureState()
-    private var pendingScrollWheelEvents: [NSEvent] = []
-    private var pendingPlayerFallbackPolicy: PlayerScrollWheelPlayerFallbackPolicy?
-    private var activePlayerFallbackPolicy: PlayerScrollWheelPlayerFallbackPolicy?
-    private var previousEventPhase: NSEvent.Phase = []
-    var isMomentaryRateAvailable: () -> Bool = { false }
-    var onMomentaryRateBegan: (PlayerMomentaryRate) -> Void = { _ in }
-    var onMomentaryRateEnded: () -> Void = {}
-
-    init(
-        anchorView: NSView,
-        dispatchToPlayer: @escaping (NSEvent) -> Void = { _ in }
-    ) {
-        self.anchorView = anchorView
-        self.dispatchToPlayer = dispatchToPlayer
-    }
-
-    var hasDetailScrollViewAncestor: Bool {
-        detailScrollViewAncestor != nil
-    }
-
-    /// 纵向滚动交给详情页；播放中的精确横向手势用于临时倍速。
-    func handleScrollWheel(
-        _ event: NSEvent,
-        playerFallbackPolicy: PlayerScrollWheelPlayerFallbackPolicy =
-            .dispatchToPlayer
-    ) {
-        defer { previousEventPhase = event.phase }
-        cancelAbandonedMomentaryRate(before: event)
-        flushAbandonedPendingEvents(before: event)
-        let sequenceFallbackPolicy = fallbackPolicy(
-            for: event,
-            requested: playerFallbackPolicy
-        )
-        let route = scrollWheelRouter.route(
-            deltaX: event.scrollingDeltaX,
-            deltaY: event.scrollingDeltaY,
-            phase: event.phase,
-            momentumPhase: event.momentumPhase,
-            isPrecise: event.hasPreciseScrollingDeltas,
-            allowsMomentaryRate: isMomentaryRateAvailable(),
-            adoptsOrphanedVerticalGesture:
-                sequenceFallbackPolicy == .consume
-        )
-        if route == .pending {
-            if pendingPlayerFallbackPolicy == nil {
-                pendingPlayerFallbackPolicy = sequenceFallbackPolicy
-            }
-            pendingScrollWheelEvents.append(event)
-            return
-        }
-
-        let events = pendingScrollWheelEvents + [event]
-        pendingScrollWheelEvents.removeAll(keepingCapacity: true)
-        let resolvedFallbackPolicy =
-            pendingPlayerFallbackPolicy ?? sequenceFallbackPolicy
-        pendingPlayerFallbackPolicy = nil
-        switch route {
-        case .outerScroll:
-            guard let scrollView = detailScrollViewAncestor else {
-                handlePlayerFallback(
-                    events,
-                    policy: resolvedFallbackPolicy
-                )
-                finishFallbackPolicyIfNeeded(after: event)
-                return
-            }
-            for event in events {
-                scrollView.scrollWheel(with: event)
-            }
-        case .player:
-            handlePlayerFallback(events, policy: resolvedFallbackPolicy)
-        case .momentaryRate:
-            for event in events {
-                applyHorizontalRateAction(
-                    horizontalRateGesture.handle(
-                        deltaX: Self.deviceRelativeDeltaX(
-                            event.scrollingDeltaX,
-                            isDirectionInverted:
-                                event.isDirectionInvertedFromDevice
-                        ),
-                        phase: event.phase,
-                        momentumPhase: event.momentumPhase
-                    )
-                )
-            }
-        case .discard:
-            break
-        case .pending:
-            assertionFailure("Pending scroll events must return before dispatch")
-        }
-        finishFallbackPolicyIfNeeded(after: event)
-    }
-
-    func cancelInputSession() {
-        resetInputSession(quarantinesRemainder: true)
-    }
-
-    func resetInputSessionForPointerExit() {
-        resetInputSession(quarantinesRemainder: false)
-    }
-
-    private func resetInputSession(quarantinesRemainder: Bool) {
-        let action = horizontalRateGesture.cancel()
-        pendingScrollWheelEvents.removeAll(keepingCapacity: true)
-        pendingPlayerFallbackPolicy = nil
-        activePlayerFallbackPolicy = nil
-        if quarantinesRemainder {
-            scrollWheelRouter.cancelInputSession()
-        } else {
-            scrollWheelRouter.resetPreservingCancellationQuarantine()
-        }
-        previousEventPhase = []
-        applyHorizontalRateAction(action)
-    }
-
-    static func deviceRelativeDeltaX(
-        _ deltaX: CGFloat,
-        isDirectionInverted: Bool
-    ) -> CGFloat {
-        isDirectionInverted ? -deltaX : deltaX
-    }
-
-    private func applyHorizontalRateAction(
-        _ action: PlayerHorizontalRateGestureState.Action
-    ) {
-        switch action {
-        case .none:
-            return
-        case .begin(let rate):
-            onMomentaryRateBegan(rate)
-        case .end:
-            onMomentaryRateEnded()
-        }
-    }
-
-    /// 忽略 AVPlayerView 内部可能存在的滚动视图，只找播放器之外的详情容器。
-    private var detailScrollViewAncestor: NSScrollView? {
-        var ancestor = anchorView?.superview
-        var passedPlayerView = false
-        while let current = ancestor {
-            if current is AVPlayerView {
-                passedPlayerView = true
-            } else if passedPlayerView,
-                let scrollView = current as? NSScrollView
-            {
-                return scrollView
-            }
-            ancestor = current.superview
-        }
-        return nil
-    }
-
-    private func dispatchToAVKit<Events: Sequence>(_ events: Events)
-    where Events.Element == NSEvent {
-        for event in events {
-            dispatchToPlayer(event)
-        }
-    }
-
-    private func handlePlayerFallback<Events: Sequence>(
-        _ events: Events,
-        policy: PlayerScrollWheelPlayerFallbackPolicy
-    ) where Events.Element == NSEvent {
-        guard policy == .dispatchToPlayer else { return }
-        dispatchToAVKit(events)
-    }
-
-    private func flushAbandonedPendingEvents(
-        before event: NSEvent
-    ) {
-        guard !pendingScrollWheelEvents.isEmpty else { return }
-        let leavesDirectGesture =
-            event.phase.isEmpty && event.momentumPhase.isEmpty
-        guard startsNewDirectGesture(event) || leavesDirectGesture else {
-            return
-        }
-        handlePlayerFallback(
-            pendingScrollWheelEvents,
-            policy: pendingPlayerFallbackPolicy ?? .dispatchToPlayer
-        )
-        pendingScrollWheelEvents.removeAll(keepingCapacity: true)
-        pendingPlayerFallbackPolicy = nil
-        activePlayerFallbackPolicy = nil
-        applyHorizontalRateAction(horizontalRateGesture.cancel())
-        scrollWheelRouter.reset()
-        previousEventPhase = []
-    }
-
-    private func fallbackPolicy(
-        for event: NSEvent,
-        requested: PlayerScrollWheelPlayerFallbackPolicy
-    ) -> PlayerScrollWheelPlayerFallbackPolicy {
-        let startsUnphasedInput =
-            event.phase.isEmpty && event.momentumPhase.isEmpty
-        if startsNewDirectGesture(event) || startsUnphasedInput {
-            activePlayerFallbackPolicy = requested
-        } else if activePlayerFallbackPolicy == nil {
-            activePlayerFallbackPolicy = requested
-        }
-        return activePlayerFallbackPolicy ?? requested
-    }
-
-    private func finishFallbackPolicyIfNeeded(after event: NSEvent) {
-        if event.phase.contains(.cancelled)
-            || event.momentumPhase.contains(.ended)
-            || event.momentumPhase.contains(.cancelled)
-            || (event.phase.isEmpty && event.momentumPhase.isEmpty)
-        {
-            activePlayerFallbackPolicy = nil
-        }
-    }
-
-    private func cancelAbandonedMomentaryRate(before event: NSEvent) {
-        let startsUnphasedInput =
-            event.phase.isEmpty && event.momentumPhase.isEmpty
-        guard startsNewDirectGesture(event) || startsUnphasedInput else {
-            return
-        }
-        applyHorizontalRateAction(horizontalRateGesture.cancel())
-    }
-
-    private func startsNewDirectGesture(_ event: NSEvent) -> Bool {
-        event.phase.contains(.mayBegin)
-            || (event.phase.contains(.began)
-                && !previousEventPhase.contains(.mayBegin))
-    }
-}
-
-enum PlayerScrollWheelPlayerFallbackPolicy: Equatable {
-    case dispatchToPlayer
-    case consume
-}
-
-struct PlayerHorizontalRateGestureState {
-    enum Action: Equatable {
-        case none
-        case begin(PlayerMomentaryRate)
-        case end
-    }
-
-    static let activationThreshold: CGFloat = 30
-
-    private var accumulatedDeltaX: CGFloat = 0
-    private var activeRate: PlayerMomentaryRate?
-
-    mutating func handle(
-        deltaX: CGFloat,
-        phase: NSEvent.Phase,
-        momentumPhase: NSEvent.Phase
-    ) -> Action {
-        if phase.contains(.ended) || phase.contains(.cancelled) {
-            return cancel()
-        }
-
-        if !momentumPhase.isEmpty {
-            return cancel()
-        }
-
-        if phase.contains(.mayBegin) || phase.contains(.began) {
-            let action = cancel()
-            accumulatedDeltaX = deltaX
-            return action
-        }
-
-        accumulatedDeltaX += deltaX
-        guard activeRate == nil,
-            abs(accumulatedDeltaX) >= Self.activationThreshold
-        else {
-            return .none
-        }
-
-        let rate: PlayerMomentaryRate =
-            accumulatedDeltaX < 0 ? .fast : .slow
-        activeRate = rate
-        return .begin(rate)
-    }
-
-    mutating func cancel() -> Action {
-        let action: Action = activeRate == nil ? .none : .end
-        accumulatedDeltaX = 0
-        activeRate = nil
-        return action
-    }
-}
-
-struct PlayerScrollWheelRouter {
+struct PlayerScrollWheelRouting {
     enum Route: Equatable {
-        case outerScroll
-        case player
-        case momentaryRate
-        case discard
         case pending
+        case outerScroll
+        case ignore
     }
 
-    private static let minimumAxisTravel: CGFloat = 4
-    private static let minimumAxisLead: CGFloat = 2
-    private static let maximumPendingSampleCount = 16
+    private static let minimumAxisTravel: CGFloat = 1
+    private static let minimumAxisLead: CGFloat = 0.5
 
-    private var gestureRoute: Route?
-    private var completedGestureRoute: Route?
+    private var directRoute: Route?
+    private var completedRoute: Route?
     private var accumulatedDeltaX: CGFloat = 0
     private var accumulatedDeltaY: CGFloat = 0
-    private var pendingSampleCount = 0
-    private var directGestureHasBegun = false
-    private var discardsCancelledGestureRemainder = false
+    private var directGestureIsActive = false
+    private var discardsCancelledRemainder = false
 
     mutating func route(
         deltaX: CGFloat,
         deltaY: CGFloat,
         phase: NSEvent.Phase,
-        momentumPhase: NSEvent.Phase,
-        isPrecise: Bool = true,
-        allowsMomentaryRate: Bool = false,
-        adoptsOrphanedVerticalGesture: Bool = false
+        momentumPhase: NSEvent.Phase
     ) -> Route {
-        if discardsCancelledGestureRemainder {
-            let startsNewDirectGesture =
-                phase.contains(.mayBegin) || phase.contains(.began)
-            let startsUnphasedInput = phase.isEmpty && momentumPhase.isEmpty
-            guard startsNewDirectGesture || startsUnphasedInput else {
-                return .discard
+        let startsDirectGesture =
+            phase.contains(.mayBegin) || phase.contains(.began)
+        let isUnphasedInput = phase.isEmpty && momentumPhase.isEmpty
+
+        if discardsCancelledRemainder {
+            guard startsDirectGesture || isUnphasedInput else {
+                return .ignore
             }
-            discardsCancelledGestureRemainder = false
+            discardsCancelledRemainder = false
         }
 
         if !momentumPhase.isEmpty {
             let route =
-                gestureRoute
-                ?? completedGestureRoute
+                directRoute
+                ?? completedRoute
                 ?? dominantRoute(deltaX: deltaX, deltaY: deltaY)
             if momentumPhase.contains(.ended)
                 || momentumPhase.contains(.cancelled)
             {
-                gestureRoute = nil
-                completedGestureRoute = nil
+                reset()
             }
             return route
         }
 
         if phase.isEmpty {
+            completedRoute = nil
             return dominantRoute(deltaX: deltaX, deltaY: deltaY)
         }
 
-        if phase.contains(.began) || phase.contains(.mayBegin) {
+        if startsDirectGesture {
             reset()
-            directGestureHasBegun = true
-        } else if !directGestureHasBegun {
-            guard adoptsOrphanedVerticalGesture,
-                isPrecise,
-                phase.contains(.changed),
-                isClearlyVertical(deltaX: deltaX, deltaY: deltaY)
-            else {
-                return .player
-            }
-            reset()
-            directGestureHasBegun = true
-            gestureRoute = .outerScroll
+            directGestureIsActive = true
+        } else if !directGestureIsActive {
+            guard phase.contains(.changed) else { return .ignore }
+            directGestureIsActive = true
+            directRoute = dominantRoute(deltaX: deltaX, deltaY: deltaY)
         }
 
-        if !isPrecise {
-            if gestureRoute == nil {
-                gestureRoute = unambiguousRoute(
-                    deltaX: deltaX,
-                    deltaY: deltaY
-                )
-            }
-            if gestureRoute == nil,
-                phase.contains(.ended) || phase.contains(.cancelled)
-            {
-                gestureRoute = .player
-            }
-            let route = gestureRoute ?? .pending
-            if phase.contains(.ended) {
-                completedGestureRoute = route
-                resetDirectGesture()
-            } else if phase.contains(.cancelled) {
-                completedGestureRoute = nil
-                resetDirectGesture()
-            }
-            return route
-        }
-
-        if gestureRoute == nil {
+        if directRoute == nil {
             accumulatedDeltaX += deltaX
             accumulatedDeltaY += deltaY
-            pendingSampleCount += 1
-            gestureRoute = accumulatedRoute(
-                allowsMomentaryRate: allowsMomentaryRate
-            )
-            if gestureRoute == nil,
-                phase.contains(.ended)
-                    || phase.contains(.cancelled)
-                    || pendingSampleCount >= Self.maximumPendingSampleCount
-            {
-                gestureRoute = .player
+            directRoute = accumulatedRoute()
+        }
+
+        let resolvedRoute: Route
+        if phase.contains(.ended) || phase.contains(.cancelled) {
+            resolvedRoute =
+                directRoute
+                ?? dominantRoute(
+                    deltaX: accumulatedDeltaX,
+                    deltaY: accumulatedDeltaY
+                )
+            if phase.contains(.ended) {
+                completedRoute = resolvedRoute
+                resetDirectGesture()
+            } else {
+                reset()
             }
+        } else {
+            resolvedRoute = directRoute ?? .pending
         }
-
-        let route = gestureRoute ?? .pending
-        if phase.contains(.ended) {
-            completedGestureRoute = gestureRoute
-            resetDirectGesture()
-        } else if phase.contains(.cancelled) {
-            completedGestureRoute = nil
-            resetDirectGesture()
-        }
-        return route
+        return resolvedRoute
     }
 
-    mutating func reset() {
-        gestureRoute = nil
-        completedGestureRoute = nil
-        resetDirectGesture()
-    }
-
-    private mutating func resetDirectGesture() {
-        gestureRoute = nil
-        accumulatedDeltaX = 0
-        accumulatedDeltaY = 0
-        pendingSampleCount = 0
-        directGestureHasBegun = false
-        discardsCancelledGestureRemainder = false
-    }
-
-    mutating func cancelInputSession() {
+    mutating func cancel() {
         reset()
-        discardsCancelledGestureRemainder = true
+        discardsCancelledRemainder = true
     }
 
-    mutating func resetPreservingCancellationQuarantine() {
-        let preservesCancellationQuarantine =
-            discardsCancelledGestureRemainder
-        reset()
-        discardsCancelledGestureRemainder =
-            preservesCancellationQuarantine
-    }
-
-    private func accumulatedRoute(
-        allowsMomentaryRate: Bool
-    ) -> Route? {
+    private func accumulatedRoute() -> Route? {
         let horizontalMagnitude = abs(accumulatedDeltaX)
         let verticalMagnitude = abs(accumulatedDeltaY)
-        let dominantMagnitude = max(horizontalMagnitude, verticalMagnitude)
-        let axisLead = abs(horizontalMagnitude - verticalMagnitude)
-        guard dominantMagnitude >= Self.minimumAxisTravel,
-            axisLead >= Self.minimumAxisLead
-        else {
-            return nil
-        }
-        if verticalMagnitude > horizontalMagnitude {
-            return .outerScroll
-        }
-        return allowsMomentaryRate ? .momentaryRate : .player
+        guard
+            max(horizontalMagnitude, verticalMagnitude)
+                >= Self.minimumAxisTravel,
+            abs(verticalMagnitude - horizontalMagnitude)
+                >= Self.minimumAxisLead
+        else { return nil }
+        return verticalMagnitude > horizontalMagnitude ? .outerScroll : .ignore
     }
 
     private func dominantRoute(deltaX: CGFloat, deltaY: CGFloat) -> Route {
-        unambiguousRoute(deltaX: deltaX, deltaY: deltaY) ?? .player
+        abs(deltaY) > abs(deltaX) ? .outerScroll : .ignore
     }
 
-    private func unambiguousRoute(
-        deltaX: CGFloat,
-        deltaY: CGFloat
-    ) -> Route? {
-        let horizontalMagnitude = abs(deltaX)
-        let verticalMagnitude = abs(deltaY)
-        guard horizontalMagnitude != verticalMagnitude else { return nil }
-        return verticalMagnitude > horizontalMagnitude ? .outerScroll : .player
+    private mutating func resetDirectGesture() {
+        directRoute = nil
+        accumulatedDeltaX = 0
+        accumulatedDeltaY = 0
+        directGestureIsActive = false
     }
 
-    private func isClearlyVertical(
-        deltaX: CGFloat,
-        deltaY: CGFloat
-    ) -> Bool {
-        let horizontalMagnitude = abs(deltaX)
-        let verticalMagnitude = abs(deltaY)
-        return verticalMagnitude >= Self.minimumAxisTravel
-            && verticalMagnitude - horizontalMagnitude
-                >= Self.minimumAxisLead
+    private mutating func reset() {
+        resetDirectGesture()
+        completedRoute = nil
     }
 }

--- a/BiliKitMac/Platform/PlayerKeyboardInputState.swift
+++ b/BiliKitMac/Platform/PlayerKeyboardInputState.swift
@@ -1,0 +1,232 @@
+import Foundation
+
+enum PlayerKeyboardDirection: Equatable, Hashable, Sendable {
+    case left
+    case right
+    case up
+    case down
+
+    var momentaryRate: PlayerMomentaryRate? {
+        switch self {
+        case .left: .slow
+        case .right: .fast
+        case .up, .down: nil
+        }
+    }
+
+    var seekOffsetSeconds: Double? {
+        switch self {
+        case .left: -5
+        case .right: 5
+        case .up, .down: nil
+        }
+    }
+
+    var volumeOffset: Float? {
+        switch self {
+        case .up: 0.05
+        case .down: -0.05
+        case .left, .right: nil
+        }
+    }
+}
+
+enum PlayerKeyboardShortcut: Equatable, Hashable, Sendable {
+    case playback
+    case danmaku
+    case subtitles
+}
+
+struct PlayerKeyboardInputState: Equatable, Sendable {
+    static let longPressDelay: TimeInterval = 0.35
+    static let minimumVolumeRepeatInterval: TimeInterval = 0.08
+
+    enum Action: Equatable, Sendable {
+        case scheduleLongPress(pressID: UUID)
+        case cancelLongPress(pressID: UUID)
+        case beginMomentaryRate(rate: PlayerMomentaryRate, pressID: UUID)
+        case endMomentaryRate(pressID: UUID)
+        case seekBy(seconds: Double)
+        case adjustVolume(by: Float)
+        case togglePlayback
+        case toggleDanmaku
+        case toggleSubtitles
+    }
+
+    private struct HorizontalPress: Equatable, Sendable {
+        enum Phase: Equatable, Sendable {
+            case waitingForDeadline
+            case longActivated
+        }
+
+        let direction: PlayerKeyboardDirection
+        let pressID: UUID
+        var phase: Phase
+    }
+
+    private var horizontalPress: HorizontalPress?
+    private var suppressedHorizontalKeys: Set<PlayerKeyboardDirection> = []
+    private var heldVolumeKeys: Set<PlayerKeyboardDirection> = []
+    private var suppressedVolumeKeys: Set<PlayerKeyboardDirection> = []
+    private var lastVolumeStepTime: [PlayerKeyboardDirection: TimeInterval] = [:]
+    private var heldShortcuts: Set<PlayerKeyboardShortcut> = []
+    private var suppressedShortcuts: Set<PlayerKeyboardShortcut> = []
+
+    mutating func keyDown(
+        _ direction: PlayerKeyboardDirection,
+        isRepeat: Bool,
+        timestamp: TimeInterval,
+        makePressID: () -> UUID = UUID.init
+    ) -> [Action] {
+        if let volumeOffset = direction.volumeOffset {
+            return volumeKeyDown(
+                direction,
+                offset: volumeOffset,
+                isRepeat: isRepeat,
+                timestamp: timestamp
+            )
+        }
+
+        if suppressedHorizontalKeys.contains(direction) {
+            guard !isRepeat else { return [] }
+            suppressedHorizontalKeys.remove(direction)
+        }
+        if horizontalPress?.direction == direction {
+            return []
+        }
+        guard !isRepeat else { return [] }
+
+        var actions = cancelHorizontalPress(suppressHeldKey: true)
+        let pressID = makePressID()
+        horizontalPress = HorizontalPress(
+            direction: direction,
+            pressID: pressID,
+            phase: .waitingForDeadline
+        )
+        actions.append(.scheduleLongPress(pressID: pressID))
+        return actions
+    }
+
+    mutating func keyUp(_ direction: PlayerKeyboardDirection) -> [Action] {
+        if direction.volumeOffset != nil {
+            heldVolumeKeys.remove(direction)
+            suppressedVolumeKeys.remove(direction)
+            lastVolumeStepTime[direction] = nil
+            return []
+        }
+        if suppressedHorizontalKeys.remove(direction) != nil {
+            return []
+        }
+        guard let horizontalPress,
+            horizontalPress.direction == direction
+        else { return [] }
+        self.horizontalPress = nil
+        switch horizontalPress.phase {
+        case .waitingForDeadline:
+            guard let offset = direction.seekOffsetSeconds else { return [] }
+            return [
+                .cancelLongPress(pressID: horizontalPress.pressID),
+                .seekBy(seconds: offset),
+            ]
+        case .longActivated:
+            return [.endMomentaryRate(pressID: horizontalPress.pressID)]
+        }
+    }
+
+    mutating func deadlineReached(pressID: UUID) -> [Action] {
+        guard var horizontalPress,
+            horizontalPress.pressID == pressID,
+            horizontalPress.phase == .waitingForDeadline,
+            let rate = horizontalPress.direction.momentaryRate
+        else { return [] }
+        horizontalPress.phase = .longActivated
+        self.horizontalPress = horizontalPress
+        return [.beginMomentaryRate(rate: rate, pressID: pressID)]
+    }
+
+    mutating func shortcutKeyDown(
+        _ shortcut: PlayerKeyboardShortcut,
+        isRepeat: Bool
+    ) -> [Action] {
+        if suppressedShortcuts.contains(shortcut) {
+            guard !isRepeat else { return [] }
+            suppressedShortcuts.remove(shortcut)
+        }
+        guard !isRepeat, heldShortcuts.insert(shortcut).inserted else {
+            return []
+        }
+        return switch shortcut {
+        case .playback: [.togglePlayback]
+        case .danmaku: [.toggleDanmaku]
+        case .subtitles: [.toggleSubtitles]
+        }
+    }
+
+    mutating func shortcutKeyUp(_ shortcut: PlayerKeyboardShortcut) -> [Action] {
+        heldShortcuts.remove(shortcut)
+        suppressedShortcuts.remove(shortcut)
+        return []
+    }
+
+    mutating func cancel() -> [Action] {
+        suppressedVolumeKeys.formUnion(heldVolumeKeys)
+        heldVolumeKeys.removeAll(keepingCapacity: true)
+        lastVolumeStepTime.removeAll(keepingCapacity: true)
+        suppressedShortcuts.formUnion(heldShortcuts)
+        heldShortcuts.removeAll(keepingCapacity: true)
+        return cancelHorizontalPress(suppressHeldKey: true)
+    }
+
+    private mutating func volumeKeyDown(
+        _ direction: PlayerKeyboardDirection,
+        offset: Float,
+        isRepeat: Bool,
+        timestamp: TimeInterval
+    ) -> [Action] {
+        if suppressedVolumeKeys.contains(direction) {
+            guard !isRepeat else { return [] }
+            suppressedVolumeKeys.remove(direction)
+        }
+        heldVolumeKeys.insert(direction)
+        if isRepeat,
+            let previous = lastVolumeStepTime[direction],
+            timestamp - previous < Self.minimumVolumeRepeatInterval
+        {
+            return []
+        }
+        lastVolumeStepTime[direction] = timestamp
+        return [.adjustVolume(by: offset)]
+    }
+
+    private mutating func cancelHorizontalPress(
+        suppressHeldKey: Bool
+    ) -> [Action] {
+        guard let horizontalPress else { return [] }
+        self.horizontalPress = nil
+        if suppressHeldKey {
+            suppressedHorizontalKeys.insert(horizontalPress.direction)
+        }
+        switch horizontalPress.phase {
+        case .waitingForDeadline:
+            return [.cancelLongPress(pressID: horizontalPress.pressID)]
+        case .longActivated:
+            return [.endMomentaryRate(pressID: horizontalPress.pressID)]
+        }
+    }
+}
+
+enum PlayerKeyboardEventScope {
+    static func captures(
+        isEnabled: Bool,
+        isSupportedKey: Bool,
+        hasDisallowedModifier: Bool,
+        eventMatchesCaptureWindow: Bool,
+        isEditableResponder: Bool
+    ) -> Bool {
+        isEnabled
+            && isSupportedKey
+            && !hasDisallowedModifier
+            && eventMatchesCaptureWindow
+            && !isEditableResponder
+    }
+}

--- a/BiliKitMacTests/PlaybackPreferencesControllerTests.swift
+++ b/BiliKitMacTests/PlaybackPreferencesControllerTests.swift
@@ -8,6 +8,24 @@ import Testing
 struct PlaybackPreferencesControllerTests {
     @Test
     @MainActor
+    func relativeVolumeClampsUnmutesAndUsesTheObservedPlayer() {
+        let player = AVPlayer()
+        player.volume = 0.98
+        player.isMuted = true
+        let controller = PlaybackPreferencesController(
+            player: player,
+            store: InMemoryPlaybackPreferencesStore()
+        )
+
+        #expect(controller.adjustVolume(by: 0.05) == 1)
+        #expect(player.volume == 1)
+        #expect(!player.isMuted)
+        #expect(controller.adjustVolume(by: -2) == 0)
+        #expect(player.volume == 0)
+    }
+
+    @Test
+    @MainActor
     func nativePlayerPreferencesPersistSynchronouslyAndRestore() {
         withIsolatedDefaults { defaults in
             let firstPlayer = AVPlayer()
@@ -133,4 +151,13 @@ struct PlaybackPreferencesControllerTests {
     private func load(from defaults: UserDefaults) -> PlaybackPreferences {
         UserDefaultsPlaybackPreferencesStore(defaults: defaults).load()
     }
+}
+
+private final class InMemoryPlaybackPreferencesStore:
+    PlaybackPreferencesStoring, @unchecked Sendable
+{
+    func load() -> PlaybackPreferences { .defaults }
+    func saveVolume(_ volume: Float) {}
+    func saveMuted(_ isMuted: Bool) {}
+    func savePreferredRate(_ rate: Float) {}
 }

--- a/BiliKitMacTests/PlayerHostViewIdentityTests.swift
+++ b/BiliKitMacTests/PlayerHostViewIdentityTests.swift
@@ -66,6 +66,10 @@ struct PlayerHostViewIdentityTests {
             endMomentaryPlaybackRate: nil
         )
 
+        view.setPlaybackPreparationBlocked(false)
+        #expect(view.controlsStyle == .floating)
+        #expect(!view.isAccessibilityHidden())
+
         view.setPlaybackPreparationBlocked(true)
         #expect(view.controlsStyle == .none)
         #expect(!view.acceptsFirstResponder)
@@ -73,7 +77,7 @@ struct PlayerHostViewIdentityTests {
         #expect(view.isAccessibilityHidden())
 
         view.setPlaybackPreparationBlocked(false)
-        #expect(view.controlsStyle == .default)
+        #expect(view.controlsStyle == .floating)
         #expect(!view.isAccessibilityHidden())
     }
 
@@ -191,9 +195,7 @@ struct PlayerHostViewIdentityTests {
 
     @Test
     @MainActor
-    func playerSurfaceCaptureRoutesVerticalWheelWithoutLocalMonitor()
-        throws
-    {
+    func playerSurfaceForwardsOnlyVerticalWheelToDetailScroll() throws {
         let scrollView = ScrollWheelRecordingScrollView(
             frame: NSRect(x: 0, y: 0, width: 800, height: 600)
         )
@@ -203,811 +205,211 @@ struct PlayerHostViewIdentityTests {
         let playerView = AVPlayerView(
             frame: NSRect(x: 0, y: 900, width: 800, height: 300)
         )
-        let scrollCaptureView = PlayerScrollWheelCaptureView(
-            frame: playerView.bounds
-        )
+        let capture = PlayerScrollWheelCaptureView(frame: playerView.bounds)
         scrollView.documentView = documentView
         documentView.addSubview(playerView)
-        playerView.addSubview(scrollCaptureView)
+        playerView.addSubview(capture)
 
-        let event = try makeScrollWheelEvent(deltaX: 0, deltaY: -80)
-        #expect(event.hasPreciseScrollingDeltas)
+        let vertical = try makeScrollWheelEvent(deltaX: 2, deltaY: -80)
+        let horizontal = try makeScrollWheelEvent(deltaX: -80, deltaY: 2)
+        capture.scrollWheel(with: vertical)
+        capture.scrollWheel(with: horizontal)
 
-        scrollCaptureView.scrollWheel(with: event)
-
-        #expect(scrollView.receivedScrollWheelEvents.count == 1)
-        #expect(scrollView.receivedScrollWheelEvents.first === event)
-
-        var shieldPlayerEvents: [NSEvent] = []
-        let shieldCapture = PlayerScrollWheelSurfaceCapture(
-            anchorView: NSView(frame: .zero),
-            dispatchToPlayer: { shieldPlayerEvents.append($0) }
-        )
-        let horizontalEvent = try makeScrollWheelEvent(
-            deltaX: -80,
-            deltaY: 0
-        )
-        shieldCapture.handleScrollWheel(
-            horizontalEvent,
-            playerFallbackPolicy: .consume
-        )
-        #expect(shieldPlayerEvents.isEmpty)
-
-        var overlayPlayerEvents: [NSEvent] = []
-        let overlayCapture = PlayerScrollWheelSurfaceCapture(
-            anchorView: NSView(frame: .zero),
-            dispatchToPlayer: { overlayPlayerEvents.append($0) }
-        )
-        overlayCapture.handleScrollWheel(horizontalEvent)
-        #expect(overlayPlayerEvents.count == 1)
-        #expect(overlayPlayerEvents.first === horizontalEvent)
-
-        var alternatingPlayerEvents: [NSEvent] = []
-        let alternatingCapture = PlayerScrollWheelSurfaceCapture(
-            anchorView: NSView(frame: .zero),
-            dispatchToPlayer: { alternatingPlayerEvents.append($0) }
-        )
-        let pendingShieldEvent = try makeScrollWheelEvent(
-            deltaX: 1,
-            deltaY: 1,
-            phase: .began
-        )
-        let resolvingOverlayEvent = try makeScrollWheelEvent(
-            deltaX: -80,
-            deltaY: 0,
-            phase: .changed
-        )
-        alternatingCapture.handleScrollWheel(
-            pendingShieldEvent,
-            playerFallbackPolicy: .consume
-        )
-        alternatingCapture.handleScrollWheel(
-            resolvingOverlayEvent,
-            playerFallbackPolicy: .dispatchToPlayer
-        )
-        #expect(alternatingPlayerEvents.isEmpty)
-
-        var crossingPlayerEvents: [NSEvent] = []
-        let crossingCapture = PlayerScrollWheelSurfaceCapture(
-            anchorView: NSView(frame: .zero),
-            dispatchToPlayer: { crossingPlayerEvents.append($0) }
-        )
-        let mayBeginShieldEvent = try makeScrollWheelEvent(
-            deltaX: -80,
-            deltaY: 0,
-            phase: .mayBegin
-        )
-        let beganOverlayEvent = try makeScrollWheelEvent(
-            deltaX: 1,
-            deltaY: 1,
-            phase: .began
-        )
-        let followingOverlayEvent = try makeScrollWheelEvent(
-            deltaX: -20,
-            deltaY: 0,
-            phase: .changed
-        )
-        crossingCapture.handleScrollWheel(
-            mayBeginShieldEvent,
-            playerFallbackPolicy: .consume
-        )
-        crossingCapture.handleScrollWheel(
-            beganOverlayEvent,
-            playerFallbackPolicy: .dispatchToPlayer
-        )
-        crossingCapture.handleScrollWheel(
-            resolvingOverlayEvent,
-            playerFallbackPolicy: .dispatchToPlayer
-        )
-        crossingCapture.handleScrollWheel(
-            followingOverlayEvent,
-            playerFallbackPolicy: .dispatchToPlayer
-        )
-        #expect(crossingPlayerEvents.isEmpty)
-
-        var reversePlayerEvents: [NSEvent] = []
-        let reverseCapture = PlayerScrollWheelSurfaceCapture(
-            anchorView: NSView(frame: .zero),
-            dispatchToPlayer: { reversePlayerEvents.append($0) }
-        )
-        reverseCapture.handleScrollWheel(
-            pendingShieldEvent,
-            playerFallbackPolicy: .dispatchToPlayer
-        )
-        reverseCapture.handleScrollWheel(
-            resolvingOverlayEvent,
-            playerFallbackPolicy: .consume
-        )
-        #expect(reversePlayerEvents.count == 2)
-        #expect(reversePlayerEvents[0] === pendingShieldEvent)
-        #expect(reversePlayerEvents[1] === resolvingOverlayEvent)
-
-        var momentumPlayerEvents: [NSEvent] = []
-        let momentumCapture = PlayerScrollWheelSurfaceCapture(
-            anchorView: NSView(frame: .zero),
-            dispatchToPlayer: { momentumPlayerEvents.append($0) }
-        )
-        let overlayMomentumEvent = try makeScrollWheelEvent(
-            deltaX: -80,
-            deltaY: 0,
-            momentumPhase: .began
-        )
-        momentumCapture.handleScrollWheel(
-            pendingShieldEvent,
-            playerFallbackPolicy: .consume
-        )
-        momentumCapture.handleScrollWheel(
-            overlayMomentumEvent,
-            playerFallbackPolicy: .dispatchToPlayer
-        )
-        #expect(momentumPlayerEvents.isEmpty)
-
-        let pointerExitCapture = PlayerScrollWheelSurfaceCapture(
-            anchorView: scrollCaptureView
-        )
-        pointerExitCapture.handleScrollWheel(
-            pendingShieldEvent,
-            playerFallbackPolicy: .consume
-        )
-        pointerExitCapture.resetInputSessionForPointerExit()
-        let orphanedVerticalEvent = try makeScrollWheelEvent(
-            deltaX: 1,
-            deltaY: -12,
-            phase: .changed
-        )
-        pointerExitCapture.handleScrollWheel(
-            orphanedVerticalEvent,
-            playerFallbackPolicy: .consume
-        )
-        #expect(scrollView.receivedScrollWheelEvents.count == 2)
+        #expect(scrollView.receivedScrollWheelEvents == [vertical])
+        var routing = PlayerScrollWheelRouting()
         #expect(
-            scrollView.receivedScrollWheelEvents.last
-                === orphanedVerticalEvent
-        )
-
-        let quarantineCapture = PlayerScrollWheelSurfaceCapture(
-            anchorView: scrollCaptureView
-        )
-        quarantineCapture.cancelInputSession()
-        quarantineCapture.resetInputSessionForPointerExit()
-        quarantineCapture.handleScrollWheel(
-            orphanedVerticalEvent,
-            playerFallbackPolicy: .consume
-        )
-        #expect(scrollView.receivedScrollWheelEvents.count == 2)
-
-        let newVerticalGestureEvent = try makeScrollWheelEvent(
-            deltaX: 1,
-            deltaY: -12,
-            phase: .began
-        )
-        quarantineCapture.handleScrollWheel(
-            newVerticalGestureEvent,
-            playerFallbackPolicy: .consume
-        )
-        #expect(scrollView.receivedScrollWheelEvents.count == 3)
-        #expect(
-            scrollView.receivedScrollWheelEvents.last
-                === newVerticalGestureEvent
-        )
-    }
-
-    @Test
-    @MainActor
-    func contentOverlayCaptureOnlyParticipatesInScrollWheelHitTesting() throws {
-        #expect(
-            PlayerScrollWheelCaptureView.capturesEvent(
-                ofType: .scrollWheel
-            )
+            routing.route(
+                deltaX: -80,
+                deltaY: 2,
+                phase: [],
+                momentumPhase: []
+            ) == .ignore
         )
         #expect(
-            !PlayerScrollWheelCaptureView.capturesEvent(
-                ofType: .leftMouseDown
-            )
-        )
-        #expect(
-            !PlayerScrollWheelCaptureView.capturesEvent(
-                ofType: .magnify
-            )
-        )
-        #expect(!PlayerScrollWheelCaptureView.capturesEvent(ofType: nil))
-        #expect(
-            PlayerScrollWheelShieldView.capturesEvent(
-                ofType: .scrollWheel,
-                isPrecise: true
-            )
-        )
-        #expect(
-            !PlayerScrollWheelShieldView.capturesEvent(
-                ofType: .scrollWheel,
-                isPrecise: false
-            )
-        )
-        let shield = PlayerScrollWheelShieldView(frame: .zero)
-        var pointerExitCount = 0
-        shield.onPointerExited = { pointerExitCount += 1 }
-        shield.handlePointerExit()
-        #expect(pointerExitCount == 1)
-        #expect(
-            !PlayerScrollWheelShieldView.capturesEvent(
-                ofType: .leftMouseDown,
-                isPrecise: true
-            )
-        )
-        #expect(
-            !PlayerScrollWheelShieldView.capturesEvent(
-                ofType: .magnify,
-                isPrecise: true
-            )
-        )
-        #expect(
-            !PlayerScrollWheelShieldView.capturesEvent(
-                ofType: nil,
-                isPrecise: true
-            )
-        )
-        let mouseMoveEvent = NSEvent.mouseEvent(
-            with: .mouseMoved,
-            location: .zero,
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: 0,
-            context: nil,
-            eventNumber: 0,
-            clickCount: 0,
-            pressure: 0
-        )
-        #expect(
-            !PlayerScrollWheelShieldView.capturesEvent(
-                try #require(mouseMoveEvent)
-            )
-        )
-    }
-
-    @Test
-    @MainActor
-    func scrollWheelRouterLocksDominantAxisThroughMomentum() {
-        var verticalRouter = PlayerScrollWheelRouter()
-        #expect(
-            verticalRouter.route(
+            routing.route(
                 deltaX: 2,
-                deltaY: -12,
+                deltaY: -80,
+                phase: [],
+                momentumPhase: []
+            )
+                == .outerScroll
+        )
+    }
+
+    @Test
+    @MainActor
+    func verticalWheelSequencePreservesBeginningEndingAndMomentum() throws {
+        var routing = PlayerScrollWheelRouting()
+        let routes = [
+            routing.route(
+                deltaX: 0,
+                deltaY: 0,
                 phase: .began,
                 momentumPhase: []
-            ) == .outerScroll
-        )
-
-        var boundaryRouter = PlayerScrollWheelRouter()
-        #expect(
-            boundaryRouter.route(
+            ),
+            routing.route(
                 deltaX: 1,
                 deltaY: -12,
                 phase: .changed,
-                momentumPhase: [],
-                adoptsOrphanedVerticalGesture: true
-            ) == .outerScroll
-        )
-        #expect(
-            boundaryRouter.route(
-                deltaX: -20,
-                deltaY: -1,
-                phase: .changed,
-                momentumPhase: [],
-                adoptsOrphanedVerticalGesture: true
-            ) == .outerScroll
-        )
-        var orphanedHorizontalRouter = PlayerScrollWheelRouter()
-        #expect(
-            orphanedHorizontalRouter.route(
-                deltaX: -12,
-                deltaY: 1,
-                phase: .changed,
-                momentumPhase: [],
-                allowsMomentaryRate: true,
-                adoptsOrphanedVerticalGesture: true
-            ) == .player
-        )
-        var orphanedNoiseRouter = PlayerScrollWheelRouter()
-        #expect(
-            orphanedNoiseRouter.route(
-                deltaX: 0.1,
-                deltaY: 0.2,
-                phase: .changed,
-                momentumPhase: [],
-                adoptsOrphanedVerticalGesture: true
-            ) == .player
-        )
-        #expect(
-            orphanedNoiseRouter.route(
-                deltaX: 1,
-                deltaY: -12,
-                phase: .changed,
-                momentumPhase: [],
-                adoptsOrphanedVerticalGesture: true
-            ) == .outerScroll
-        )
-        #expect(
-            verticalRouter.route(
+                momentumPhase: []
+            ),
+            routing.route(
                 deltaX: -20,
                 deltaY: -1,
                 phase: .changed,
                 momentumPhase: []
-            ) == .outerScroll
-        )
-        #expect(
-            verticalRouter.route(
+            ),
+            routing.route(
                 deltaX: 0,
                 deltaY: 0,
                 phase: .ended,
                 momentumPhase: []
-            ) == .outerScroll
-        )
-        #expect(
-            verticalRouter.route(
+            ),
+            routing.route(
                 deltaX: -8,
                 deltaY: -1,
                 phase: [],
                 momentumPhase: .began
-            ) == .outerScroll
-        )
-        #expect(
-            verticalRouter.route(
+            ),
+            routing.route(
+                deltaX: 0,
+                deltaY: -6,
+                phase: [],
+                momentumPhase: .changed
+            ),
+            routing.route(
                 deltaX: 0,
                 deltaY: 0,
                 phase: [],
                 momentumPhase: .ended
-            ) == .outerScroll
+            ),
+        ]
+        #expect(
+            routes == [
+                .pending,
+                .outerScroll,
+                .outerScroll,
+                .outerScroll,
+                .outerScroll,
+                .outerScroll,
+                .outerScroll,
+            ]
         )
 
-        var horizontalRouter = PlayerScrollWheelRouter()
+        let scrollView = ScrollWheelRecordingScrollView(
+            frame: NSRect(x: 0, y: 0, width: 800, height: 600)
+        )
+        let documentView = NSView(
+            frame: NSRect(x: 0, y: 0, width: 800, height: 1_200)
+        )
+        let playerView = AVPlayerView(
+            frame: NSRect(x: 0, y: 900, width: 800, height: 300)
+        )
+        let capture = PlayerScrollWheelCaptureView(frame: playerView.bounds)
+        scrollView.documentView = documentView
+        documentView.addSubview(playerView)
+        playerView.addSubview(capture)
+
+        let events = try [
+            makeScrollWheelEvent(deltaX: 0, deltaY: 0, phase: .began),
+            makeScrollWheelEvent(deltaX: 1, deltaY: -12, phase: .changed),
+            makeScrollWheelEvent(deltaX: -20, deltaY: -1, phase: .changed),
+            makeScrollWheelEvent(deltaX: 0, deltaY: 0, phase: .ended),
+            makeScrollWheelEvent(
+                deltaX: -8,
+                deltaY: -1,
+                momentumPhase: .began
+            ),
+            makeScrollWheelEvent(
+                deltaX: 0,
+                deltaY: -6,
+                momentumPhase: .changed
+            ),
+        ]
+        let expectedForwardedCounts = [0, 2, 3, 4, 5, 6]
+        for (index, event) in events.enumerated() {
+            capture.scrollWheel(with: event)
+            #expect(
+                scrollView.receivedScrollWheelEvents.count
+                    == expectedForwardedCounts[index]
+            )
+        }
+
+        #expect(scrollView.receivedScrollWheelEvents == events)
+    }
+
+    @Test
+    @MainActor
+    func horizontalSequenceIsIgnoredAndOrphanedVerticalChangeResumesImmediately()
+        throws
+    {
+        var routing = PlayerScrollWheelRouting()
         #expect(
-            horizontalRouter.route(
-                deltaX: -12,
-                deltaY: -2,
+            routing.route(
+                deltaX: 0,
+                deltaY: 0,
                 phase: .began,
                 momentumPhase: []
-            ) == .player
+            ) == .pending
         )
         #expect(
-            horizontalRouter.route(
-                deltaX: -1,
-                deltaY: -20,
+            routing.route(
+                deltaX: -12,
+                deltaY: 1,
                 phase: .changed,
                 momentumPhase: []
-            ) == .player
+            ) == .ignore
         )
         #expect(
-            horizontalRouter.route(
+            routing.route(
                 deltaX: 0,
                 deltaY: 0,
                 phase: .ended,
                 momentumPhase: []
-            ) == .player
+            ) == .ignore
         )
         #expect(
-            horizontalRouter.route(
-                deltaX: -1,
+            routing.route(
+                deltaX: 0,
+                deltaY: -10,
+                phase: [],
+                momentumPhase: .changed
+            ) == .ignore
+        )
+
+        var orphanedRouting = PlayerScrollWheelRouting()
+        #expect(
+            orphanedRouting.route(
+                deltaX: 1,
+                deltaY: -12,
+                phase: .changed,
+                momentumPhase: []
+            ) == .outerScroll
+        )
+        orphanedRouting.cancel()
+        #expect(
+            orphanedRouting.route(
+                deltaX: 0,
                 deltaY: -8,
                 phase: [],
-                momentumPhase: .ended
-            ) == .player
+                momentumPhase: .changed
+            ) == .ignore
         )
     }
 
     @Test
     @MainActor
-    func scrollWheelRouterWaitsPastInitialNoiseBeforeLockingAxis() {
-        var verticalRouter = PlayerScrollWheelRouter()
+    func scrollShieldAndOverlayCaptureOnlyWheelEvents() throws {
+        #expect(PlayerScrollWheelCaptureView.capturesEvent(ofType: .scrollWheel))
+        #expect(!PlayerScrollWheelCaptureView.capturesEvent(ofType: .leftMouseDown))
         #expect(
-            verticalRouter.route(
-                deltaX: 0.2,
-                deltaY: 0.1,
-                phase: .began,
-                momentumPhase: []
-            ) == .pending
+            PlayerScrollWheelShieldView.capturesEvent(ofType: .scrollWheel)
         )
         #expect(
-            verticalRouter.route(
-                deltaX: 0.2,
-                deltaY: 12,
-                phase: .changed,
-                momentumPhase: []
-            ) == .outerScroll
+            !PlayerScrollWheelShieldView.capturesEvent(ofType: .leftMouseDown)
         )
-
-        var horizontalRouter = PlayerScrollWheelRouter()
-        #expect(
-            horizontalRouter.route(
-                deltaX: 0.1,
-                deltaY: 0.2,
-                phase: .mayBegin,
-                momentumPhase: []
-            ) == .pending
-        )
-        #expect(
-            horizontalRouter.route(
-                deltaX: 12,
-                deltaY: 0.2,
-                phase: .changed,
-                momentumPhase: []
-            ) == .player
-        )
-
-        var ambiguousRouter = PlayerScrollWheelRouter()
-        #expect(
-            ambiguousRouter.route(
-                deltaX: 1,
-                deltaY: 1,
-                phase: .began,
-                momentumPhase: []
-            ) == .pending
-        )
-        #expect(
-            ambiguousRouter.route(
-                deltaX: 0,
-                deltaY: 0,
-                phase: .cancelled,
-                momentumPhase: []
-            ) == .player
-        )
-    }
-
-    @Test
-    @MainActor
-    func unphasedScrollWheelUsesStrictDominantAxis() {
-        var router = PlayerScrollWheelRouter()
-        #expect(
-            router.route(
-                deltaX: 0,
-                deltaY: -1,
-                phase: [],
-                momentumPhase: []
-            ) == .outerScroll
-        )
-        #expect(
-            router.route(
-                deltaX: -4,
-                deltaY: -9,
-                phase: [],
-                momentumPhase: []
-            ) == .outerScroll
-        )
-        #expect(
-            router.route(
-                deltaX: -9,
-                deltaY: -4,
-                phase: [],
-                momentumPhase: []
-            ) == .player
-        )
-        #expect(
-            router.route(
-                deltaX: -5,
-                deltaY: -5,
-                phase: [],
-                momentumPhase: []
-            ) == .player
-        )
-        #expect(
-            router.route(
-                deltaX: 0,
-                deltaY: 0,
-                phase: [],
-                momentumPhase: []
-            ) == .player
-        )
-        #expect(
-            router.route(
-                deltaX: 0,
-                deltaY: -1,
-                phase: .began,
-                momentumPhase: [],
-                isPrecise: false
-            ) == .outerScroll
-        )
-        #expect(
-            router.route(
-                deltaX: -20,
-                deltaY: -1,
-                phase: .changed,
-                momentumPhase: [],
-                isPrecise: false
-            ) == .outerScroll
-        )
-        #expect(
-            router.route(
-                deltaX: 0,
-                deltaY: 0,
-                phase: .ended,
-                momentumPhase: [],
-                isPrecise: false
-            ) == .outerScroll
-        )
-        #expect(
-            router.route(
-                deltaX: -8,
-                deltaY: -1,
-                phase: [],
-                momentumPhase: .ended,
-                isPrecise: false
-            ) == .outerScroll
-        )
-    }
-
-    @Test
-    func momentaryRateBadgeUsesNativeSymbolsAndRequestedLabels() {
-        #expect(PlayerMomentaryRate.fast.label == "2X")
-        #expect(PlayerMomentaryRate.fast.symbolName == "forward.fill")
-        #expect(PlayerMomentaryRate.slow.label == "0.5X")
-        #expect(PlayerMomentaryRate.slow.symbolName == "backward.fill")
-    }
-
-    @Test
-    func ordinaryBufferingDoesNotCancelTheScrollInputSession() {
-        #expect(
-            !PlayerMomentaryRateSessionPolicy.shouldCancel(
-                hasActiveSession: false,
-                timeControlStatus: .paused
-            )
-        )
-        #expect(
-            PlayerMomentaryRateSessionPolicy.shouldCancel(
-                hasActiveSession: true,
-                timeControlStatus: .paused
-            )
-        )
-        #expect(
-            !PlayerMomentaryRateSessionPolicy.shouldCancel(
-                hasActiveSession: true,
-                timeControlStatus: .waitingToPlayAtSpecifiedRate
-            )
-        )
-        #expect(
-            !PlayerMomentaryRateSessionPolicy.shouldCancel(
-                hasActiveSession: true,
-                timeControlStatus: .playing
-            )
-        )
-    }
-
-    @Test
-    @MainActor
-    func preciseHorizontalGestureCanReserveWholeSequenceForMomentaryRate() {
-        var router = PlayerScrollWheelRouter()
-        #expect(
-            router.route(
-                deltaX: 0.2,
-                deltaY: 0.1,
-                phase: .began,
-                momentumPhase: [],
-                allowsMomentaryRate: true
-            ) == .pending
-        )
-        #expect(
-            router.route(
-                deltaX: 8,
-                deltaY: 0.2,
-                phase: .changed,
-                momentumPhase: [],
-                allowsMomentaryRate: true
-            ) == .momentaryRate
-        )
-        #expect(
-            router.route(
-                deltaX: 0,
-                deltaY: -30,
-                phase: .changed,
-                momentumPhase: [],
-                allowsMomentaryRate: true
-            ) == .momentaryRate
-        )
-        #expect(
-            router.route(
-                deltaX: 0,
-                deltaY: 0,
-                phase: .ended,
-                momentumPhase: [],
-                allowsMomentaryRate: true
-            ) == .momentaryRate
-        )
-        #expect(
-            router.route(
-                deltaX: 12,
-                deltaY: 0,
-                phase: [],
-                momentumPhase: .began,
-                allowsMomentaryRate: true
-            ) == .momentaryRate
-        )
-        #expect(
-            router.route(
-                deltaX: 0,
-                deltaY: 0,
-                phase: [],
-                momentumPhase: .ended,
-                allowsMomentaryRate: true
-            ) == .momentaryRate
-        )
-    }
-
-    @Test
-    @MainActor
-    func unphasedAndNonPreciseHorizontalWheelRemainNative() {
-        var unphasedRouter = PlayerScrollWheelRouter()
-        #expect(
-            unphasedRouter.route(
-                deltaX: 40,
-                deltaY: 0,
-                phase: [],
-                momentumPhase: [],
-                allowsMomentaryRate: true
-            ) == .player
-        )
-
-        var nonPreciseRouter = PlayerScrollWheelRouter()
-        #expect(
-            nonPreciseRouter.route(
-                deltaX: 40,
-                deltaY: 0,
-                phase: .began,
-                momentumPhase: [],
-                isPrecise: false,
-                allowsMomentaryRate: true
-            ) == .player
-        )
-    }
-
-    @Test
-    @MainActor
-    func horizontalRateGestureActivatesAfterThresholdAndEndsBeforeMomentum() {
-        var gesture = PlayerHorizontalRateGestureState()
-        #expect(
-            gesture.handle(
-                deltaX: -1,
-                phase: .began,
-                momentumPhase: []
-            ) == .none
-        )
-        #expect(
-            gesture.handle(
-                deltaX: -20,
-                phase: .changed,
-                momentumPhase: []
-            ) == .none
-        )
-        #expect(
-            gesture.handle(
-                deltaX: -10,
-                phase: .changed,
-                momentumPhase: []
-            ) == .begin(.fast)
-        )
-        #expect(
-            gesture.handle(
-                deltaX: 12,
-                phase: .changed,
-                momentumPhase: []
-            ) == .none
-        )
-        #expect(
-            gesture.handle(
-                deltaX: 0,
-                phase: .ended,
-                momentumPhase: []
-            ) == .end
-        )
-        #expect(
-            gesture.handle(
-                deltaX: 18,
-                phase: [],
-                momentumPhase: .began
-            ) == .none
-        )
-    }
-
-    @Test
-    @MainActor
-    func horizontalRateGestureUsesOppositeDirectionForSlowRate() {
-        var gesture = PlayerHorizontalRateGestureState()
-        _ = gesture.handle(
-            deltaX: 4,
-            phase: .began,
-            momentumPhase: []
-        )
-        #expect(
-            gesture.handle(
-                deltaX: 26,
-                phase: .changed,
-                momentumPhase: []
-            ) == .begin(.slow)
-        )
-        #expect(gesture.cancel() == .end)
-    }
-
-    @Test
-    @MainActor
-    func deviceRelativeHorizontalDeltaIgnoresNaturalScrollingPreference() {
-        #expect(
-            PlayerScrollWheelSurfaceCapture.deviceRelativeDeltaX(
-                20,
-                isDirectionInverted: true
-            ) == -20
-        )
-        #expect(
-            PlayerScrollWheelSurfaceCapture.deviceRelativeDeltaX(
-                -20,
-                isDirectionInverted: false
-            ) == -20
-        )
-    }
-
-    @Test
-    @MainActor
-    func horizontalRateGestureEndsWhenMomentumArrivesWithoutDirectEnd() {
-        var gesture = PlayerHorizontalRateGestureState()
-        _ = gesture.handle(
-            deltaX: -30,
-            phase: .began,
-            momentumPhase: []
-        )
-        _ = gesture.handle(
-            deltaX: -1,
-            phase: .changed,
-            momentumPhase: []
-        )
-
-        #expect(
-            gesture.handle(
-                deltaX: -12,
-                phase: [],
-                momentumPhase: .began
-            ) == .end
-        )
-    }
-
-    @Test
-    @MainActor
-    func scrollWheelRouterQuarantinesCancelledGestureRemainder() {
-        var router = PlayerScrollWheelRouter()
-        #expect(
-            router.route(
-                deltaX: -12,
-                deltaY: 0,
-                phase: .began,
-                momentumPhase: [],
-                allowsMomentaryRate: true
-            ) == .momentaryRate
-        )
-
-        router.cancelInputSession()
-
-        #expect(
-            router.route(
-                deltaX: -40,
-                deltaY: 0,
-                phase: .changed,
-                momentumPhase: [],
-                allowsMomentaryRate: true
-            ) == .discard
-        )
-        #expect(
-            router.route(
-                deltaX: -30,
-                deltaY: 0,
-                phase: [],
-                momentumPhase: .began,
-                allowsMomentaryRate: true
-            ) == .discard
-        )
-        #expect(
-            router.route(
-                deltaX: 0,
-                deltaY: 8,
-                phase: .began,
-                momentumPhase: [],
-                allowsMomentaryRate: true
-            ) == .outerScroll
-        )
+        let shield = PlayerScrollWheelShieldView(frame: .zero)
+        #expect(!shield.isAccessibilityElement())
     }
 
     @Test(.timeLimit(.minutes(1)))

--- a/BiliKitMacTests/PlayerKeyboardInputStateTests.swift
+++ b/BiliKitMacTests/PlayerKeyboardInputStateTests.swift
@@ -1,0 +1,163 @@
+import BiliPlayback
+import Foundation
+import Testing
+
+@testable import BiliKit
+
+struct PlayerKeyboardInputStateTests {
+    @Test
+    func shortAndLongPressAreMutuallyExclusiveAndRepeatIndependent() {
+        var shortState = PlayerKeyboardInputState()
+        let shortID = UUID()
+        #expect(
+            shortState.keyDown(.right, isRepeat: false, timestamp: 0) {
+                shortID
+            } == [.scheduleLongPress(pressID: shortID)]
+        )
+        #expect(shortState.keyDown(.right, isRepeat: true, timestamp: 0.1).isEmpty)
+        #expect(
+            shortState.keyUp(.right) == [
+                .cancelLongPress(pressID: shortID),
+                .seekBy(seconds: 5),
+            ]
+        )
+        #expect(shortState.deadlineReached(pressID: shortID).isEmpty)
+
+        var longState = PlayerKeyboardInputState()
+        let longID = UUID()
+        _ = longState.keyDown(.left, isRepeat: false, timestamp: 0) { longID }
+        #expect(
+            longState.deadlineReached(pressID: longID) == [
+                .beginMomentaryRate(rate: .slow, pressID: longID)
+            ]
+        )
+        #expect(longState.keyUp(.left) == [.endMomentaryRate(pressID: longID)])
+    }
+
+    @Test
+    func staleKeyUpAndLifecycleCancellationCannotEndNewPress() {
+        var state = PlayerKeyboardInputState()
+        let leftID = UUID()
+        let rightID = UUID()
+        _ = state.keyDown(.left, isRepeat: false, timestamp: 0) { leftID }
+        _ = state.deadlineReached(pressID: leftID)
+        #expect(
+            state.keyDown(.right, isRepeat: false, timestamp: 1) { rightID }
+                == [
+                    .endMomentaryRate(pressID: leftID),
+                    .scheduleLongPress(pressID: rightID),
+                ]
+        )
+        #expect(state.keyUp(.left).isEmpty)
+        #expect(
+            state.cancel() == [.cancelLongPress(pressID: rightID)]
+        )
+        #expect(state.keyDown(.right, isRepeat: true, timestamp: 2).isEmpty)
+    }
+
+    @Test
+    func volumeAndDiscreteShortcutsHaveBoundedRepeatBehavior() {
+        var state = PlayerKeyboardInputState()
+        #expect(
+            state.keyDown(.up, isRepeat: false, timestamp: 1)
+                == [.adjustVolume(by: 0.05)]
+        )
+        #expect(state.keyDown(.up, isRepeat: true, timestamp: 1.04).isEmpty)
+        #expect(
+            state.keyDown(.up, isRepeat: true, timestamp: 1.08)
+                == [.adjustVolume(by: 0.05)]
+        )
+
+        let cases: [(PlayerKeyboardShortcut, PlayerKeyboardInputState.Action)] = [
+            (.playback, .togglePlayback),
+            (.danmaku, .toggleDanmaku),
+            (.subtitles, .toggleSubtitles),
+        ]
+        for (shortcut, action) in cases {
+            #expect(state.shortcutKeyDown(shortcut, isRepeat: false) == [action])
+            #expect(state.shortcutKeyDown(shortcut, isRepeat: true).isEmpty)
+            _ = state.shortcutKeyUp(shortcut)
+        }
+    }
+
+    @Test
+    func detailWindowScopeExcludesModifiersEditingAndOtherWindows() {
+        #expect(
+            PlayerKeyboardEventScope.captures(
+                isEnabled: true,
+                isSupportedKey: true,
+                hasDisallowedModifier: false,
+                eventMatchesCaptureWindow: true,
+                isEditableResponder: false
+            )
+        )
+        for excluded in [
+            (false, true, false, true, false),
+            (true, false, false, true, false),
+            (true, true, true, true, false),
+            (true, true, false, false, false),
+            (true, true, false, true, true),
+        ] {
+            #expect(
+                !PlayerKeyboardEventScope.captures(
+                    isEnabled: excluded.0,
+                    isSupportedKey: excluded.1,
+                    hasDisallowedModifier: excluded.2,
+                    eventMatchesCaptureWindow: excluded.3,
+                    isEditableResponder: excluded.4
+                )
+            )
+        }
+    }
+
+    @Test
+    func feedbackDismissalUsesStaleIdentityGuard() {
+        let identity = UUID()
+        #expect(PlayerShortcutFeedbackDismissalPolicy.delay == .milliseconds(800))
+        #expect(PlayerShortcutFeedbackDismissalPolicy.fadeDuration == 0.16)
+        #expect(
+            PlayerShortcutFeedbackDismissalPolicy.shouldAnimate(
+                reduceMotion: false
+            )
+        )
+        #expect(
+            !PlayerShortcutFeedbackDismissalPolicy.shouldAnimate(
+                reduceMotion: true
+            )
+        )
+        #expect(
+            PlayerShortcutFeedbackDismissalPolicy.shouldDismiss(
+                displayedID: identity,
+                scheduledID: identity
+            )
+        )
+        #expect(
+            !PlayerShortcutFeedbackDismissalPolicy.shouldDismiss(
+                displayedID: UUID(),
+                scheduledID: identity
+            )
+        )
+        #expect(PlayerShortcutFeedback.volume(55).label == "55%")
+        #expect(PlayerShortcutFeedback.relativeSeek(-5).label == "后退 5 秒")
+        #expect(PlayerShortcutFeedback.relativeSeek(5).label == "前进 5 秒")
+        #expect(
+            PlayerShortcutFeedback.relativeSeek(-5).symbolName
+                == "gobackward.5"
+        )
+        #expect(
+            PlayerShortcutFeedback.relativeSeek(5).accessibilityLabel
+                == "已前进 5 秒"
+        )
+        #expect(PlayerShortcutFeedback.playback(true).label == "播放")
+        #expect(PlayerShortcutFeedback.playback(false).label == "暂停")
+        #expect(PlayerShortcutFeedback.playback(true).symbolName == "play.fill")
+        #expect(
+            PlayerShortcutFeedback.playback(false).accessibilityLabel
+                == "已暂停播放"
+        )
+        #expect(PlayerShortcutFeedback.danmaku(false).label == "弹幕 关")
+        #expect(
+            PlayerShortcutFeedback.subtitles(.unavailable).label == "无可用字幕"
+        )
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/VideoDetail/Danmaku/DanmakuControlsViewModel.swift
@@ -75,6 +75,12 @@ public final class DanmakuControlsViewModel {
         presentation.setEnabled(enabled)
     }
 
+    @discardableResult
+    public func toggleEnabled() -> Bool {
+        setEnabled(!isEnabled)
+        return isEnabled
+    }
+
     public func setShowsScrolling(_ shows: Bool) {
         guard showsScrolling != shows else { return }
         showsScrolling = shows

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
@@ -21,6 +21,105 @@ public enum AVPlayerEngineError: Error, Sendable, Equatable {
     case seekFailed
 }
 
+public enum NativeSubtitleToggleResult: Sendable, Equatable {
+    case enabled(label: String)
+    case disabled
+    case unavailable
+}
+
+private struct NativeSubtitleSelectionPreference: Sendable {
+    let propertyListData: Data?
+}
+
+enum PlaybackToggleAction: Equatable, Sendable {
+    case play
+    case pause
+
+    init?(
+        timeControlStatus: AVPlayer.TimeControlStatus,
+        timelineState: PlaybackTimelineState
+    ) {
+        guard timelineState != .ended else { return nil }
+        self = timeControlStatus == .paused ? .play : .pause
+    }
+}
+
+struct TransportSeekOperationState: Sendable {
+    struct Operation: Equatable, Sendable {
+        let id: UUID
+        let generation: UUID
+        let itemIdentity: ObjectIdentifier
+        let targetSeconds: Double
+    }
+
+    enum Completion: Equatable, Sendable {
+        case ignored
+        case failed
+        case completed(positionSeconds: Double)
+    }
+
+    private(set) var current: Operation?
+
+    mutating func prepare(
+        offsetSeconds: Double,
+        currentSeconds: Double,
+        durationSeconds: Double,
+        generation: UUID,
+        itemIdentity: ObjectIdentifier,
+        makeOperationID: () -> UUID = UUID.init
+    ) -> Operation? {
+        guard offsetSeconds.isFinite,
+            currentSeconds.isFinite,
+            currentSeconds >= 0,
+            durationSeconds.isFinite,
+            durationSeconds > 0
+        else { return nil }
+        let base =
+            if let current,
+                current.generation == generation,
+                current.itemIdentity == itemIdentity
+            {
+                current.targetSeconds
+            } else {
+                currentSeconds
+            }
+        let operation = Operation(
+            id: makeOperationID(),
+            generation: generation,
+            itemIdentity: itemIdentity,
+            targetSeconds: min(max(base + offsetSeconds, 0), durationSeconds)
+        )
+        current = operation
+        return operation
+    }
+
+    func matches(_ operation: Operation) -> Bool {
+        current == operation
+    }
+
+    mutating func complete(
+        _ operation: Operation,
+        finished: Bool,
+        resolvedPositionSeconds: Double?
+    ) -> Completion {
+        guard matches(operation) else { return .ignored }
+        current = nil
+        guard finished,
+            let resolvedPositionSeconds,
+            resolvedPositionSeconds.isFinite,
+            resolvedPositionSeconds >= 0
+        else { return .failed }
+        return .completed(positionSeconds: resolvedPositionSeconds)
+    }
+
+    @discardableResult
+    mutating func invalidate() -> Operation? {
+        let operation = current
+        current = nil
+        return operation
+    }
+}
+
 @MainActor
 /// AVPlayer、DASH→HLS 会话与统一播放时间线的唯一资源 owner。
 ///
@@ -45,10 +144,13 @@ public final class AVPlayerEngine:
     private var loadIntent: PlaybackLoadIntent?
     private var activeResumeToken: PlaybackResumeToken?
     private var restartOperation: UUID?
-    private var explicitSeekOperation = UUID()
+    private var activeSeekOperationID: UUID?
     private var preparedAsset: PreparedPlaybackAsset?
     private var subtitleIdentity: PlaybackItemIdentity?
     private var subtitleResetTask: Task<Void, Never>?
+    private var subtitleToggleOperationID: UUID?
+    private var lastSubtitleSelection: NativeSubtitleSelectionPreference?
+    private var transportSeek = TransportSeekOperationState()
 
     public init(
         player: AVPlayer = AVPlayer(),
@@ -76,6 +178,10 @@ public final class AVPlayerEngine:
         timeline.onFailed = { [weak self] in
             self?.handleCurrentItemFailure()
         }
+        timeline.onSeekSupersededByExternalJump = {
+            [weak self] operationID in
+            self?.handleSeekSupersededByExternalJump(operationID)
+        }
     }
 
     deinit {
@@ -99,6 +205,60 @@ public final class AVPlayerEngine:
 
     public var nativeSubtitlesEnabled: Bool {
         subtitleUseCase != nil
+    }
+
+    public func toggleNativeSubtitles() async -> NativeSubtitleToggleResult {
+        guard subtitleUseCase != nil, let item = player.currentItem else {
+            return .unavailable
+        }
+        let operationID = UUID()
+        let generation = loadGeneration
+        subtitleToggleOperationID = operationID
+
+        do {
+            guard
+                let group = try await item.asset.loadMediaSelectionGroup(
+                    for: .legible
+                ),
+                !Task.isCancelled,
+                subtitleToggleOperationID == operationID,
+                loadGeneration == generation,
+                player.currentItem === item
+            else {
+                finishSubtitleToggle(operationID)
+                return .unavailable
+            }
+
+            if let selected = item.currentMediaSelection.selectedMediaOption(
+                in: group
+            ) {
+                guard group.allowsEmptySelection else {
+                    finishSubtitleToggle(operationID)
+                    return .unavailable
+                }
+                lastSubtitleSelection = Self.subtitlePreference(for: selected)
+                item.select(nil, in: group)
+                finishSubtitleToggle(operationID)
+                return .disabled
+            }
+
+            guard
+                let option = Self.subtitleOption(
+                    in: group,
+                    restoring: lastSubtitleSelection
+                )
+            else {
+                finishSubtitleToggle(operationID)
+                return .unavailable
+            }
+            item.select(option, in: group)
+            lastSubtitleSelection = Self.subtitlePreference(for: option)
+            finishSubtitleToggle(operationID)
+            return .enabled(label: option.displayName)
+        } catch {
+            finishSubtitleToggle(operationID)
+            return .unavailable
+        }
     }
 
     public func timelineUpdates() -> AsyncStream<PlaybackTimelineSnapshot> {
@@ -170,7 +330,9 @@ public final class AVPlayerEngine:
         try Task.checkCancellation()
 
         loadGeneration = generation
-        explicitSeekOperation = UUID()
+        activeSeekOperationID = nil
+        invalidateSubtitleToggle(clearPreference: true)
+        invalidateTransportSeek()
         loadIntent = intent
         activeResumeToken = nil
         restartOperation = nil
@@ -236,7 +398,7 @@ public final class AVPlayerEngine:
             if loadGeneration == generation {
                 loadTask = nil
                 readinessTask = nil
-                explicitSeekOperation = UUID()
+                activeSeekOperationID = nil
                 preparedAsset?.stop()
                 preparedAsset = nil
                 player.replaceCurrentItem(with: nil)
@@ -249,7 +411,7 @@ public final class AVPlayerEngine:
             if loadGeneration == generation {
                 loadTask = nil
                 readinessTask = nil
-                explicitSeekOperation = UUID()
+                activeSeekOperationID = nil
                 preparedAsset?.stop()
                 preparedAsset = nil
                 player.replaceCurrentItem(with: nil)
@@ -268,7 +430,9 @@ public final class AVPlayerEngine:
     private func cancelLoad(generation: UUID) {
         guard loadGeneration == generation else { return }
         loadGeneration = UUID()
-        explicitSeekOperation = UUID()
+        activeSeekOperationID = nil
+        invalidateSubtitleToggle(clearPreference: true)
+        invalidateTransportSeek()
         loadIntent = nil
         activeResumeToken = nil
         restartOperation = nil
@@ -314,15 +478,27 @@ public final class AVPlayerEngine:
             return .startedAtBeginning
         }
 
-        timeline.prepareInitialSeek(to: initialPositionSeconds)
+        let operation = UUID()
+        activeSeekOperationID = operation
+        timeline.prepareInitialSeek(
+            operationID: operation,
+            to: initialPositionSeconds
+        )
         let tolerance = CMTime(seconds: 0.25, preferredTimescale: 600)
         let didSeek = await player.seek(
             to: CMTime(seconds: initialPositionSeconds, preferredTimescale: 600),
             toleranceBefore: tolerance,
             toleranceAfter: tolerance
         )
+        guard activeSeekOperationID == operation else {
+            if !didSeek {
+                timeline.discardStaleSeekLanding(operationID: operation)
+            }
+            return .rejected
+        }
         guard didSeek else {
-            timeline.initialSeekFailed()
+            timeline.initialSeekFailed(operationID: operation)
+            activeSeekOperationID = nil
             return .preparationFailed
         }
         guard loadGeneration == currentGeneration,
@@ -335,8 +511,9 @@ public final class AVPlayerEngine:
                 || timeline.currentSnapshot.state == .buffering
         else {
             if player.currentItem === item {
-                timeline.initialSeekFailed()
+                timeline.initialSeekFailed(operationID: operation)
             }
+            activeSeekOperationID = nil
             return .rejected
         }
 
@@ -346,10 +523,15 @@ public final class AVPlayerEngine:
                 durationSeconds: durationSeconds
             )
         else {
-            timeline.initialSeekFailed()
+            timeline.initialSeekFailed(operationID: operation)
+            activeSeekOperationID = nil
             return .preparationFailed
         }
-        timeline.initialSeekCompleted(at: resolvedPosition)
+        timeline.initialSeekCompleted(
+            operationID: operation,
+            at: resolvedPosition
+        )
+        activeSeekOperationID = nil
         let token = PlaybackResumeToken()
         activeResumeToken = token
         timeline.playAfterInternalSeek()
@@ -374,6 +556,8 @@ public final class AVPlayerEngine:
             let item = player.currentItem
         else { return false }
         let operation = UUID()
+        supersedeTransportSeek()
+        activeSeekOperationID = operation
         restartOperation = operation
         defer {
             if restartOperation == operation {
@@ -381,8 +565,7 @@ public final class AVPlayerEngine:
             }
         }
         let currentGeneration = loadGeneration
-        explicitSeekOperation = UUID()
-        timeline.prepareResumeRestart()
+        timeline.prepareResumeRestart(operationID: operation)
         let interactionRevision = timeline.playbackInteractionRevision
         let didSeek = await player.seek(
             to: .zero,
@@ -390,10 +573,14 @@ public final class AVPlayerEngine:
             toleranceAfter: .zero
         )
         guard restartOperation == operation else {
+            if !didSeek {
+                timeline.discardStaleSeekLanding(operationID: operation)
+            }
             return false
         }
         guard didSeek else {
-            timeline.resumeRestartFailed()
+            timeline.resumeRestartFailed(operationID: operation)
+            activeSeekOperationID = nil
             return false
         }
         guard activeResumeToken == resumeToken,
@@ -404,17 +591,20 @@ public final class AVPlayerEngine:
             timeline.playbackInteractionRevision == interactionRevision
         else {
             if player.currentItem === item {
-                timeline.resumeRestartFailed()
+                timeline.resumeRestartFailed(operationID: operation)
             }
+            activeSeekOperationID = nil
             return false
         }
         guard let resolvedPosition = Self.validSeconds(player.currentTime()),
             resolvedPosition <= 0.5
         else {
-            timeline.resumeRestartFailed()
+            timeline.resumeRestartFailed(operationID: operation)
+            activeSeekOperationID = nil
             return false
         }
-        timeline.resumeRestartCompleted()
+        timeline.resumeRestartCompleted(operationID: operation)
+        activeSeekOperationID = nil
         activeResumeToken = nil
         timeline.playAfterInternalSeek()
         emit(.stateChanged(.playing))
@@ -433,6 +623,24 @@ public final class AVPlayerEngine:
         emit(.stateChanged(.paused))
     }
 
+    @discardableResult
+    public func togglePlayback() -> Bool? {
+        guard player.currentItem != nil,
+            let action = PlaybackToggleAction(
+                timeControlStatus: player.timeControlStatus,
+                timelineState: currentTimelineSnapshot.state
+            )
+        else { return nil }
+        switch action {
+        case .play:
+            play()
+            return true
+        case .pause:
+            pause()
+            return false
+        }
+    }
+
     public func setRate(_ rate: Double) throws {
         try timeline.setRate(rate)
     }
@@ -447,6 +655,82 @@ public final class AVPlayerEngine:
         timeline.endMomentaryRate(sessionID: sessionID)
     }
 
+    /// 在当前 VOD item 上累计执行播放器 transport 的相对跳转。
+    @discardableResult
+    public func seekByTransportOffset(_ offsetSeconds: Double) -> Bool {
+        guard let item = player.currentItem,
+            let currentSeconds = Self.validSeconds(player.currentTime()),
+            let durationSeconds = Self.validSeconds(item.duration)
+        else { return false }
+        let generation = loadGeneration
+        let itemIdentity = ObjectIdentifier(item)
+        guard
+            let operation = transportSeek.prepare(
+                offsetSeconds: offsetSeconds,
+                currentSeconds: currentSeconds,
+                durationSeconds: durationSeconds,
+                generation: generation,
+                itemIdentity: itemIdentity
+            )
+        else { return false }
+
+        restartOperation = nil
+        activeSeekOperationID = operation.id
+        timeline.prepareTransportSeek(
+            operationID: operation.id,
+            to: operation.targetSeconds
+        )
+        let tolerance = CMTime(seconds: 0.25, preferredTimescale: 600)
+        player.seek(
+            to: CMTime(
+                seconds: operation.targetSeconds,
+                preferredTimescale: 600
+            ),
+            toleranceBefore: tolerance,
+            toleranceAfter: tolerance
+        ) { [weak self, weak item] finished in
+            guard let item else { return }
+            Task { @MainActor [weak self] in
+                guard let self,
+                    self.loadGeneration == generation,
+                    self.player.currentItem === item
+                else { return }
+                guard self.activeSeekOperationID == operation.id,
+                    self.transportSeek.matches(operation)
+                else {
+                    if !finished {
+                        self.timeline.discardStaleSeekLanding(
+                            operationID: operation.id
+                        )
+                    }
+                    return
+                }
+                let resolved =
+                    finished ? Self.validSeconds(self.player.currentTime()) : nil
+                switch self.transportSeek.complete(
+                    operation,
+                    finished: finished,
+                    resolvedPositionSeconds: resolved
+                ) {
+                case .ignored:
+                    return
+                case .failed:
+                    self.timeline.transportSeekFailed(
+                        operationID: operation.id
+                    )
+                    self.activeSeekOperationID = nil
+                case .completed(let positionSeconds):
+                    self.timeline.transportSeekCompleted(
+                        operationID: operation.id,
+                        at: positionSeconds
+                    )
+                    self.activeSeekOperationID = nil
+                }
+            }
+        }
+        return true
+    }
+
     /// 执行精确 seek，并只为一次用户 seek 发布一个 discontinuity generation。
     public func seek(to time: Duration) async throws {
         guard let item = player.currentItem else {
@@ -455,28 +739,34 @@ public final class AVPlayerEngine:
         let generation = loadGeneration
         let operation = UUID()
         restartOperation = nil
-        explicitSeekOperation = operation
+        supersedeTransportSeek()
+        activeSeekOperationID = operation
         let components = time.components
         let seconds =
             Double(components.seconds)
             + Double(components.attoseconds) / 1_000_000_000_000_000_000
-        timeline.prepareExplicitSeek(to: seconds)
+        timeline.prepareExplicitSeek(operationID: operation, to: seconds)
         let didSeek = await player.seek(
             to: CMTime(seconds: seconds, preferredTimescale: 600),
             toleranceBefore: .zero,
             toleranceAfter: .zero
         )
-        guard explicitSeekOperation == operation,
+        guard activeSeekOperationID == operation,
             loadGeneration == generation,
             player.currentItem === item
         else {
+            if !didSeek {
+                timeline.discardStaleSeekLanding(operationID: operation)
+            }
             throw CancellationError()
         }
         guard didSeek else {
-            timeline.explicitSeekFailed()
+            timeline.explicitSeekFailed(operationID: operation)
+            activeSeekOperationID = nil
             throw AVPlayerEngineError.seekFailed
         }
-        timeline.explicitSeekCompleted(at: seconds)
+        timeline.explicitSeekCompleted(operationID: operation, at: seconds)
+        activeSeekOperationID = nil
     }
 
     /// 同步接受当前 item 上的精确 seek，并在 engine 内完成 generation-safe 的异步收尾。
@@ -498,8 +788,9 @@ public final class AVPlayerEngine:
         let generation = loadGeneration
         let operation = UUID()
         restartOperation = nil
-        explicitSeekOperation = operation
-        timeline.prepareExplicitSeek(to: seconds)
+        supersedeTransportSeek()
+        activeSeekOperationID = operation
+        timeline.prepareExplicitSeek(operationID: operation, to: seconds)
         player.seek(
             to: CMTime(seconds: seconds, preferredTimescale: 600),
             toleranceBefore: .zero,
@@ -507,15 +798,25 @@ public final class AVPlayerEngine:
         ) { [weak self, weak item] didSeek in
             Task { @MainActor in
                 guard let self, let item,
-                    self.explicitSeekOperation == operation,
                     self.loadGeneration == generation,
                     self.player.currentItem === item
                 else { return }
-                self.explicitSeekOperation = UUID()
+                guard self.activeSeekOperationID == operation else {
+                    if !didSeek {
+                        self.timeline.discardStaleSeekLanding(
+                            operationID: operation
+                        )
+                    }
+                    return
+                }
+                self.activeSeekOperationID = nil
                 if didSeek {
-                    self.timeline.explicitSeekCompleted(at: seconds)
+                    self.timeline.explicitSeekCompleted(
+                        operationID: operation,
+                        at: seconds
+                    )
                 } else {
-                    self.timeline.explicitSeekFailed()
+                    self.timeline.explicitSeekFailed(operationID: operation)
                 }
             }
         }
@@ -525,7 +826,9 @@ public final class AVPlayerEngine:
     /// 幂等终止当前及在途播放，将唯一时间线恢复为 `.idle` 状态。
     public func stop() {
         loadGeneration = UUID()
-        explicitSeekOperation = UUID()
+        activeSeekOperationID = nil
+        invalidateSubtitleToggle(clearPreference: true)
+        invalidateTransportSeek()
         loadIntent = nil
         activeResumeToken = nil
         restartOperation = nil
@@ -546,6 +849,61 @@ public final class AVPlayerEngine:
         let seconds = CMTimeGetSeconds(time)
         guard seconds.isFinite, seconds >= 0 else { return nil }
         return seconds
+    }
+
+    private static func subtitlePreference(
+        for option: AVMediaSelectionOption
+    ) -> NativeSubtitleSelectionPreference {
+        NativeSubtitleSelectionPreference(
+            propertyListData: try? PropertyListSerialization.data(
+                fromPropertyList: option.propertyList(),
+                format: .binary,
+                options: 0
+            )
+        )
+    }
+
+    private static func subtitleOption(
+        in group: AVMediaSelectionGroup,
+        restoring preference: NativeSubtitleSelectionPreference?
+    ) -> AVMediaSelectionOption? {
+        let playable = AVMediaSelectionGroup.playableMediaSelectionOptions(
+            from: group.options
+        )
+        guard !playable.isEmpty else { return nil }
+        if let preference {
+            if let data = preference.propertyListData,
+                let propertyList = try? PropertyListSerialization.propertyList(
+                    from: data,
+                    options: [],
+                    format: nil
+                ),
+                let exact = group.mediaSelectionOption(
+                    withPropertyList: propertyList
+                ),
+                exact.isPlayable
+            {
+                return exact
+            }
+        }
+        let preferred = AVMediaSelectionGroup.mediaSelectionOptions(
+            from: playable,
+            filteredAndSortedAccordingToPreferredLanguages:
+                Locale.preferredLanguages
+        )
+        return preferred.first ?? playable.first
+    }
+
+    private func finishSubtitleToggle(_ operationID: UUID) {
+        guard subtitleToggleOperationID == operationID else { return }
+        subtitleToggleOperationID = nil
+    }
+
+    private func invalidateSubtitleToggle(clearPreference: Bool) {
+        subtitleToggleOperationID = nil
+        if clearPreference {
+            lastSubtitleSelection = nil
+        }
     }
 
     static func validatedResolvedInitialPosition(
@@ -653,7 +1011,9 @@ public final class AVPlayerEngine:
             let intent = loadIntent
         else { return }
         loadGeneration = UUID()
-        explicitSeekOperation = UUID()
+        activeSeekOperationID = nil
+        invalidateSubtitleToggle(clearPreference: true)
+        invalidateTransportSeek()
         loadIntent = nil
         loadTask?.cancel()
         loadTask = nil
@@ -668,6 +1028,32 @@ public final class AVPlayerEngine:
             PlaybackFailureEvent(identity: identity, intent: intent)
         )
         emit(.failed(message: "PlaybackItemFailed"))
+    }
+
+    private func invalidateTransportSeek() {
+        guard let operation = transportSeek.invalidate() else { return }
+        timeline.transportSeekFailed(operationID: operation.id)
+        if activeSeekOperationID == operation.id {
+            activeSeekOperationID = nil
+        }
+    }
+
+    private func supersedeTransportSeek() {
+        guard let operation = transportSeek.invalidate() else { return }
+        if activeSeekOperationID == operation.id {
+            activeSeekOperationID = nil
+        }
+    }
+
+    private func handleSeekSupersededByExternalJump(_ operationID: UUID) {
+        guard activeSeekOperationID == operationID else { return }
+        activeSeekOperationID = nil
+        if restartOperation == operationID {
+            restartOperation = nil
+        }
+        if transportSeek.current?.id == operationID {
+            transportSeek.invalidate()
+        }
     }
 
     @discardableResult

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerTimelineAdapter.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerTimelineAdapter.swift
@@ -176,6 +176,17 @@ final class PlaybackInteractionTracker: Sendable {
 /// 所有 callback 都同时核对当前 `AVPlayerItem` 与 item token；observer bag 在替换、失败和
 /// clear 时统一释放，避免旧 item 继续推进字幕或弹幕。
 final class AVPlayerTimelineAdapter {
+    private struct PendingSeek {
+        let operationID: UUID
+        let targetSeconds: Double
+        var observedLanding = false
+    }
+
+    private struct SeekLanding {
+        let operationID: UUID
+        let positionSeconds: Double
+    }
+
     private struct MomentaryRateSession {
         let id: UUID
         let item: AVPlayerItem
@@ -184,6 +195,7 @@ final class AVPlayerTimelineAdapter {
 
     var onEnded: (@MainActor () -> Void)?
     var onFailed: (@MainActor () -> Void)?
+    var onSeekSupersededByExternalJump: (@MainActor (UUID) -> Void)?
 
     var currentSnapshot: PlaybackTimelineSnapshot {
         store.currentSnapshot
@@ -203,7 +215,9 @@ final class AVPlayerTimelineAdapter {
     private var token: PlaybackTimelineItemToken?
     private var failedToken: PlaybackTimelineItemToken?
     private var momentaryRateSession: MomentaryRateSession?
-    private var pendingExplicitSeekPosition: Double?
+    private var pendingSeek: PendingSeek?
+    private var completedSeekLanding: SeekLanding?
+    private var staleSeekLandings: [SeekLanding] = []
     private var interactionTracker = PlaybackInteractionTracker()
 
     init(player: AVPlayer) {
@@ -219,7 +233,9 @@ final class AVPlayerTimelineAdapter {
     func begin(identity: PlaybackItemIdentity) {
         momentaryRateSession = nil
         observers.reset()
-        pendingExplicitSeekPosition = nil
+        pendingSeek = nil
+        completedSeekLanding = nil
+        staleSeekLandings.removeAll(keepingCapacity: true)
         interactionTracker = PlaybackInteractionTracker()
         token = store.beginItem(identity: identity)
         failedToken = nil
@@ -349,28 +365,11 @@ final class AVPlayerTimelineAdapter {
             object: item,
             queue: .main
         ) { [weak self, weak item] _ in
-            if let item,
-                let position = Self.seconds(from: item.currentTime())
-            {
-                interactionTracker.observeTimeJump(at: position)
-            }
             Task { @MainActor in
                 guard let self, let item, self.player.currentItem === item,
-                    self.store.currentSnapshot.state != .loading,
                     let position = Self.seconds(from: item.currentTime())
                 else { return }
-
-                if let explicit = self.pendingExplicitSeekPosition,
-                    abs(explicit - position) <= 0.25
-                {
-                    self.pendingExplicitSeekPosition = nil
-                    return
-                }
-                self.pendingExplicitSeekPosition = nil
-                self.store.markDiscontinuity(
-                    token: token,
-                    positionSeconds: position
-                )
+                self.observeTimeJump(at: position)
             }
         }
 
@@ -494,52 +493,198 @@ final class AVPlayerTimelineAdapter {
         )
     }
 
-    func prepareExplicitSeek(to positionSeconds: Double) {
-        interactionTracker.markObserved()
-        pendingExplicitSeekPosition = positionSeconds
+    func prepareExplicitSeek(
+        operationID: UUID,
+        to positionSeconds: Double
+    ) {
+        prepareObservedSeek(operationID: operationID, to: positionSeconds)
     }
 
-    func prepareInitialSeek(to positionSeconds: Double) {
+    func prepareTransportSeek(
+        operationID: UUID,
+        to positionSeconds: Double
+    ) {
+        prepareObservedSeek(operationID: operationID, to: positionSeconds)
+    }
+
+    func transportSeekFailed(operationID: UUID) {
+        seekFailed(operationID: operationID)
+    }
+
+    func transportSeekCompleted(
+        operationID: UUID,
+        at positionSeconds: Double
+    ) {
+        seekCompleted(operationID: operationID, at: positionSeconds)
+    }
+
+    func prepareInitialSeek(operationID: UUID, to positionSeconds: Double) {
         interactionTracker.allowInternalSeek(to: positionSeconds)
-        pendingExplicitSeekPosition = positionSeconds
+        beginPendingSeek(operationID: operationID, to: positionSeconds)
     }
 
-    func prepareResumeRestart() {
+    func prepareResumeRestart(operationID: UUID) {
         interactionTracker.markObservedAllowingInternalSeek(to: 0)
-        pendingExplicitSeekPosition = 0
+        beginPendingSeek(operationID: operationID, to: 0)
     }
 
-    func resumeRestartFailed() {
-        pendingExplicitSeekPosition = nil
-        interactionTracker.cancelInternalSeek()
+    func resumeRestartFailed(operationID: UUID) {
+        seekFailed(operationID: operationID)
     }
 
-    func resumeRestartCompleted() {
-        interactionTracker.completeInternalSeek(at: 0)
-        explicitSeekCompleted(at: 0)
+    func resumeRestartCompleted(operationID: UUID) {
+        seekCompleted(operationID: operationID, at: 0)
     }
 
-    func initialSeekFailed() {
-        pendingExplicitSeekPosition = nil
-        interactionTracker.cancelInternalSeek()
+    func initialSeekFailed(operationID: UUID) {
+        seekFailed(operationID: operationID)
     }
 
-    func initialSeekCompleted(at positionSeconds: Double) {
-        guard let token else { return }
-        pendingExplicitSeekPosition = nil
-        interactionTracker.completeInternalSeek(at: positionSeconds)
+    func initialSeekCompleted(
+        operationID: UUID,
+        at positionSeconds: Double
+    ) {
+        seekCompleted(operationID: operationID, at: positionSeconds)
+    }
+
+    func explicitSeekFailed(operationID: UUID) {
+        seekFailed(operationID: operationID)
+    }
+
+    func explicitSeekCompleted(
+        operationID: UUID,
+        at positionSeconds: Double
+    ) {
+        seekCompleted(operationID: operationID, at: positionSeconds)
+    }
+
+    private func prepareObservedSeek(
+        operationID: UUID,
+        to positionSeconds: Double
+    ) {
+        interactionTracker.markObservedAllowingInternalSeek(to: positionSeconds)
+        beginPendingSeek(operationID: operationID, to: positionSeconds)
+    }
+
+    private func beginPendingSeek(
+        operationID: UUID,
+        to positionSeconds: Double
+    ) {
+        if let pendingSeek, !pendingSeek.observedLanding {
+            appendStaleSeekLanding(
+                operationID: pendingSeek.operationID,
+                positionSeconds: pendingSeek.targetSeconds
+            )
+        }
+        if let completedSeekLanding {
+            appendStaleSeekLanding(completedSeekLanding)
+        }
+        pendingSeek = PendingSeek(
+            operationID: operationID,
+            targetSeconds: positionSeconds
+        )
+        completedSeekLanding = nil
+    }
+
+    func observeTimeJump(at positionSeconds: Double) {
+        interactionTracker.observeTimeJump(at: positionSeconds)
+        guard store.currentSnapshot.state != .loading, let token else { return }
+        if var pendingSeek {
+            let currentDistance = abs(
+                pendingSeek.targetSeconds - positionSeconds
+            )
+            if consumeStaleSeekLanding(
+                at: positionSeconds,
+                closerThan: currentDistance
+            ) {
+                return
+            }
+            if currentDistance <= 0.5 {
+                discardEquivalentStaleSeekLandings(
+                    to: pendingSeek.targetSeconds
+                )
+                pendingSeek.observedLanding = true
+                self.pendingSeek = pendingSeek
+                return
+            }
+            appendStaleSeekLanding(
+                operationID: pendingSeek.operationID,
+                positionSeconds: pendingSeek.targetSeconds
+            )
+            self.pendingSeek = nil
+            completedSeekLanding = nil
+            interactionTracker.markObserved()
+            store.markDiscontinuity(
+                token: token,
+                positionSeconds: positionSeconds
+            )
+            onSeekSupersededByExternalJump?(pendingSeek.operationID)
+            return
+        }
+        let completedDistance =
+            completedSeekLanding.map {
+                abs($0.positionSeconds - positionSeconds)
+            } ?? .infinity
+        if consumeStaleSeekLanding(
+            at: positionSeconds,
+            closerThan: completedDistance
+        ) {
+            return
+        }
+        if completedDistance <= 0.5 {
+            if let completedSeekLanding {
+                discardEquivalentStaleSeekLandings(
+                    to: completedSeekLanding.positionSeconds
+                )
+            }
+            completedSeekLanding = nil
+            return
+        }
+        if let completedSeekLanding {
+            appendStaleSeekLanding(completedSeekLanding)
+        }
+        completedSeekLanding = nil
         store.markDiscontinuity(
             token: token,
             positionSeconds: positionSeconds
         )
     }
 
-    func explicitSeekFailed() {
-        pendingExplicitSeekPosition = nil
+    private func seekFailed(operationID: UUID) {
+        guard pendingSeek?.operationID == operationID else { return }
+        pendingSeek = nil
+        interactionTracker.cancelInternalSeek()
     }
 
-    func explicitSeekCompleted(at positionSeconds: Double) {
-        guard let token else { return }
+    func discardStaleSeekLanding(operationID: UUID) {
+        staleSeekLandings.removeAll {
+            $0.operationID == operationID
+        }
+    }
+
+    private func discardEquivalentStaleSeekLandings(to positionSeconds: Double) {
+        staleSeekLandings.removeAll {
+            abs($0.positionSeconds - positionSeconds) <= 0.000_001
+        }
+    }
+
+    private func seekCompleted(
+        operationID: UUID,
+        at positionSeconds: Double
+    ) {
+        guard let completedPendingSeek = pendingSeek,
+            completedPendingSeek.operationID == operationID,
+            let token
+        else { return }
+        pendingSeek = nil
+        completedSeekLanding =
+            completedPendingSeek.observedLanding
+            ? nil
+            : SeekLanding(
+                operationID: operationID,
+                positionSeconds: positionSeconds
+            )
+        interactionTracker.completeInternalSeek(at: positionSeconds)
         store.markDiscontinuity(
             token: token,
             positionSeconds: positionSeconds
@@ -549,10 +694,49 @@ final class AVPlayerTimelineAdapter {
     func clear() {
         momentaryRateSession = nil
         observers.reset()
-        pendingExplicitSeekPosition = nil
+        pendingSeek = nil
+        completedSeekLanding = nil
+        staleSeekLandings.removeAll(keepingCapacity: true)
         store.clear(token: token)
         token = nil
         failedToken = nil
+    }
+
+    private func appendStaleSeekLanding(
+        operationID: UUID,
+        positionSeconds: Double
+    ) {
+        appendStaleSeekLanding(
+            SeekLanding(
+                operationID: operationID,
+                positionSeconds: positionSeconds
+            )
+        )
+    }
+
+    private func appendStaleSeekLanding(_ landing: SeekLanding) {
+        staleSeekLandings.append(landing)
+        if staleSeekLandings.count > 16 {
+            staleSeekLandings.removeFirst()
+        }
+    }
+
+    private func consumeStaleSeekLanding(
+        at positionSeconds: Double,
+        closerThan competingDistance: Double
+    ) -> Bool {
+        guard
+            let candidate = staleSeekLandings.enumerated().min(
+                by: {
+                    abs($0.element.positionSeconds - positionSeconds)
+                        < abs($1.element.positionSeconds - positionSeconds)
+                }
+            )
+        else { return false }
+        let distance = abs(candidate.element.positionSeconds - positionSeconds)
+        guard distance <= 0.5, distance < competingDistance else { return false }
+        staleSeekLandings.remove(at: candidate.offset)
+        return true
     }
 
     private func fail(

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/DanmakuControlsViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/DanmakuControlsViewModelTests.swift
@@ -6,6 +6,17 @@ import Testing
 @Suite
 struct DanmakuControlsViewModelTests {
     @Test
+    @MainActor
+    func toggleEnabledUsesExistingPresentationOwner() {
+        let presentation = RecordingDanmakuPresentation()
+        let model = DanmakuControlsViewModel(presentation: presentation)
+
+        #expect(!model.toggleEnabled())
+        #expect(model.toggleEnabled())
+        #expect(presentation.enabledValues.suffix(2) == [false, true])
+    }
+
+    @Test
     func selectionControlsAndResetReachApplicationPort() throws {
         let presentation = RecordingDanmakuPresentation()
         var savedSpeedLevels: [DanmakuSpeedLevel] = []

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/AVPlayerTimelineAdapterTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/AVPlayerTimelineAdapterTests.swift
@@ -6,6 +6,401 @@ import Testing
 
 struct AVPlayerTimelineAdapterTests {
     @Test
+    func playbackTogglePausesUnlessPlayerIsPaused() {
+        #expect(
+            PlaybackToggleAction(
+                timeControlStatus: .paused,
+                timelineState: .paused
+            ) == .play
+        )
+        #expect(
+            PlaybackToggleAction(
+                timeControlStatus: .playing,
+                timelineState: .playing
+            ) == .pause
+        )
+        #expect(
+            PlaybackToggleAction(
+                timeControlStatus: .waitingToPlayAtSpecifiedRate,
+                timelineState: .buffering
+            ) == .pause
+        )
+        #expect(
+            PlaybackToggleAction(
+                timeControlStatus: .paused,
+                timelineState: .ended
+            ) == nil
+        )
+    }
+
+    @Test
+    func transportSeekAccumulatesClampsAndRejectsStaleCompletion() throws {
+        final class Item {}
+        var state = TransportSeekOperationState()
+        let generation = UUID()
+        let itemObject = Item()
+        let item = ObjectIdentifier(itemObject)
+        let firstCandidate = state.prepare(
+            offsetSeconds: 5,
+            currentSeconds: 90,
+            durationSeconds: 100,
+            generation: generation,
+            itemIdentity: item
+        )
+        let first = try #require(firstCandidate)
+        let secondCandidate = state.prepare(
+            offsetSeconds: 5,
+            currentSeconds: 90,
+            durationSeconds: 100,
+            generation: generation,
+            itemIdentity: item
+        )
+        let second = try #require(secondCandidate)
+
+        #expect(first.targetSeconds == 95)
+        #expect(second.targetSeconds == 100)
+        #expect(
+            state.complete(
+                first,
+                finished: false,
+                resolvedPositionSeconds: nil
+            ) == .ignored
+        )
+        #expect(state.current == second)
+        #expect(
+            state.complete(
+                second,
+                finished: true,
+                resolvedPositionSeconds: 99.8
+            ) == .completed(positionSeconds: 99.8)
+        )
+        #expect(state.current == nil)
+    }
+
+    @Test
+    func transportSeekRejectsIndefiniteDurationAndIsolatesReplacement() {
+        final class Item {}
+        var state = TransportSeekOperationState()
+        let firstItemObject = Item()
+        let replacementItemObject = Item()
+        let firstGeneration = UUID()
+        let replacementGeneration = UUID()
+
+        #expect(
+            state.prepare(
+                offsetSeconds: 5,
+                currentSeconds: 10,
+                durationSeconds: .infinity,
+                generation: firstGeneration,
+                itemIdentity: ObjectIdentifier(firstItemObject)
+            ) == nil
+        )
+        let first = state.prepare(
+            offsetSeconds: -50,
+            currentSeconds: 10,
+            durationSeconds: 100,
+            generation: firstGeneration,
+            itemIdentity: ObjectIdentifier(firstItemObject)
+        )
+        #expect(first?.targetSeconds == 0)
+        let replacement = state.prepare(
+            offsetSeconds: 5,
+            currentSeconds: 40,
+            durationSeconds: 100,
+            generation: replacementGeneration,
+            itemIdentity: ObjectIdentifier(replacementItemObject)
+        )
+        #expect(replacement?.targetSeconds == 45)
+        if let first {
+            #expect(!state.matches(first))
+        }
+        state.invalidate()
+        #expect(state.current == nil)
+    }
+
+    @Test
+    @MainActor
+    func completedTransportSeekAdvancesDiscontinuityWithoutResuming() {
+        let player = AVPlayer()
+        let timeline = AVPlayerTimelineAdapter(player: player)
+        timeline.begin(
+            identity: PlaybackItemIdentity(bvid: "BVTransportFixture", cid: 1)
+        )
+        let before = timeline.currentSnapshot.discontinuityGeneration
+        let operationID = UUID()
+
+        timeline.prepareTransportSeek(operationID: operationID, to: 15)
+        timeline.transportSeekCompleted(
+            operationID: operationID,
+            at: 14.9
+        )
+
+        #expect(player.rate == 0)
+        #expect(
+            timeline.currentSnapshot.discontinuityGeneration == before + 1
+        )
+        #expect(timeline.currentSnapshot.positionSeconds == 14.9)
+    }
+
+    @Test
+    @MainActor
+    func seekCompletionSuppressesOnlyItsOwnLateLandingNotification() {
+        let timeline = AVPlayerTimelineAdapter(player: AVPlayer())
+        timeline.begin(
+            identity: PlaybackItemIdentity(bvid: "BVSeekLanding", cid: 1)
+        )
+        timeline.markReady(
+            duration: CMTime(seconds: 100, preferredTimescale: 600)
+        )
+        let operationID = UUID()
+        let before = timeline.currentSnapshot.discontinuityGeneration
+
+        timeline.prepareTransportSeek(operationID: operationID, to: 15)
+        timeline.transportSeekCompleted(operationID: operationID, at: 14.9)
+        timeline.observeTimeJump(at: 14.9)
+
+        #expect(
+            timeline.currentSnapshot.discontinuityGeneration == before + 1
+        )
+        timeline.observeTimeJump(at: 30)
+        #expect(
+            timeline.currentSnapshot.discontinuityGeneration == before + 2
+        )
+    }
+
+    @Test
+    @MainActor
+    func landingBeforeCompletionDoesNotLeaveStaleSuppression() {
+        let timeline = AVPlayerTimelineAdapter(player: AVPlayer())
+        timeline.begin(
+            identity: PlaybackItemIdentity(bvid: "BVSeekEarlyLanding", cid: 1)
+        )
+        timeline.markReady(
+            duration: CMTime(seconds: 100, preferredTimescale: 600)
+        )
+        let operationID = UUID()
+        let before = timeline.currentSnapshot.discontinuityGeneration
+
+        timeline.prepareExplicitSeek(operationID: operationID, to: 15)
+        timeline.observeTimeJump(at: 15)
+        timeline.explicitSeekCompleted(operationID: operationID, at: 14.9)
+
+        #expect(
+            timeline.currentSnapshot.discontinuityGeneration == before + 1
+        )
+        timeline.observeTimeJump(at: 14.9)
+        #expect(
+            timeline.currentSnapshot.discontinuityGeneration == before + 2
+        )
+    }
+
+    @Test
+    @MainActor
+    func staleSeekCallbacksCannotClearOrCompleteReplacementOperation() {
+        let timeline = AVPlayerTimelineAdapter(player: AVPlayer())
+        timeline.begin(
+            identity: PlaybackItemIdentity(bvid: "BVSeekReplacement", cid: 1)
+        )
+        timeline.markReady(
+            duration: CMTime(seconds: 100, preferredTimescale: 600)
+        )
+        let initial = UUID()
+        let remote = UUID()
+        let transport = UUID()
+        let before = timeline.currentSnapshot.discontinuityGeneration
+
+        timeline.prepareInitialSeek(operationID: initial, to: 10)
+        timeline.prepareExplicitSeek(operationID: remote, to: 20)
+        timeline.initialSeekFailed(operationID: initial)
+        timeline.prepareTransportSeek(operationID: transport, to: 25)
+        timeline.explicitSeekCompleted(operationID: remote, at: 20)
+        timeline.transportSeekCompleted(operationID: transport, at: 24.9)
+
+        #expect(
+            timeline.currentSnapshot.discontinuityGeneration == before + 1
+        )
+        #expect(timeline.currentSnapshot.positionSeconds == 24.9)
+    }
+
+    @Test
+    @MainActor
+    func nonmatchingNativeJumpSupersedesPendingEngineSeek() {
+        let timeline = AVPlayerTimelineAdapter(player: AVPlayer())
+        timeline.begin(
+            identity: PlaybackItemIdentity(bvid: "BVNativeSupersede", cid: 1)
+        )
+        timeline.markReady(
+            duration: CMTime(seconds: 100, preferredTimescale: 600)
+        )
+        let operationID = UUID()
+        let before = timeline.currentSnapshot.discontinuityGeneration
+        var supersededOperations: [UUID] = []
+        timeline.onSeekSupersededByExternalJump = {
+            supersededOperations.append($0)
+        }
+
+        timeline.prepareTransportSeek(operationID: operationID, to: 15)
+        timeline.observeTimeJump(at: 50)
+        timeline.transportSeekCompleted(operationID: operationID, at: 15)
+
+        #expect(supersededOperations == [operationID])
+        #expect(
+            timeline.currentSnapshot.discontinuityGeneration == before + 1
+        )
+        #expect(timeline.currentSnapshot.positionSeconds == 50)
+    }
+
+    @Test
+    @MainActor
+    func replacedFarSeekLandingCannotSupersedeCurrentSeek() {
+        let timeline = AVPlayerTimelineAdapter(player: AVPlayer())
+        timeline.begin(
+            identity: PlaybackItemIdentity(bvid: "BVFarSeekABA", cid: 1)
+        )
+        timeline.markReady(
+            duration: CMTime(seconds: 100, preferredTimescale: 600)
+        )
+        let first = UUID()
+        let second = UUID()
+        let before = timeline.currentSnapshot.discontinuityGeneration
+        var supersededOperations: [UUID] = []
+        timeline.onSeekSupersededByExternalJump = {
+            supersededOperations.append($0)
+        }
+
+        timeline.prepareTransportSeek(operationID: first, to: 5)
+        timeline.prepareTransportSeek(operationID: second, to: 10)
+        timeline.observeTimeJump(at: 5)
+        timeline.transportSeekCompleted(operationID: second, at: 10)
+        timeline.observeTimeJump(at: 10)
+
+        #expect(supersededOperations.isEmpty)
+        #expect(
+            timeline.currentSnapshot.discontinuityGeneration == before + 1
+        )
+        #expect(timeline.currentSnapshot.positionSeconds == 10)
+    }
+
+    @Test
+    @MainActor
+    func replacedNearbySeekLandingCannotPoseAsCurrentLanding() {
+        let timeline = AVPlayerTimelineAdapter(player: AVPlayer())
+        timeline.begin(
+            identity: PlaybackItemIdentity(bvid: "BVNearSeekABA", cid: 1)
+        )
+        timeline.markReady(
+            duration: CMTime(seconds: 100, preferredTimescale: 600)
+        )
+        let first = UUID()
+        let second = UUID()
+        let before = timeline.currentSnapshot.discontinuityGeneration
+        var supersededOperations: [UUID] = []
+        timeline.onSeekSupersededByExternalJump = {
+            supersededOperations.append($0)
+        }
+
+        timeline.prepareExplicitSeek(operationID: first, to: 0.2)
+        timeline.prepareExplicitSeek(operationID: second, to: 0.5)
+        timeline.observeTimeJump(at: 0.2)
+        timeline.explicitSeekCompleted(operationID: second, at: 0.5)
+        timeline.observeTimeJump(at: 0.5)
+
+        #expect(supersededOperations.isEmpty)
+        #expect(
+            timeline.currentSnapshot.discontinuityGeneration == before + 1
+        )
+        #expect(timeline.currentSnapshot.positionSeconds == 0.5)
+    }
+
+    @Test
+    @MainActor
+    func cancelledReplacedSeekDoesNotLeaveAStaleLandingAllowance() {
+        let timeline = AVPlayerTimelineAdapter(player: AVPlayer())
+        timeline.begin(
+            identity: PlaybackItemIdentity(bvid: "BVCancelledSeek", cid: 1)
+        )
+        timeline.markReady(
+            duration: CMTime(seconds: 100, preferredTimescale: 600)
+        )
+        let first = UUID()
+        let second = UUID()
+        let before = timeline.currentSnapshot.discontinuityGeneration
+
+        timeline.prepareTransportSeek(operationID: first, to: 5)
+        timeline.prepareTransportSeek(operationID: second, to: 10)
+        timeline.discardStaleSeekLanding(operationID: first)
+        timeline.transportSeekCompleted(operationID: second, at: 10)
+        timeline.observeTimeJump(at: 10)
+        timeline.observeTimeJump(at: 5)
+
+        #expect(
+            timeline.currentSnapshot.discontinuityGeneration == before + 2
+        )
+        #expect(timeline.currentSnapshot.positionSeconds == 5)
+    }
+
+    @Test
+    @MainActor
+    func lateTransportLandingCannotSupersedeReplacementExplicitSeek() {
+        let timeline = AVPlayerTimelineAdapter(player: AVPlayer())
+        timeline.begin(
+            identity: PlaybackItemIdentity(bvid: "BVTransportToExplicit", cid: 1)
+        )
+        timeline.markReady(
+            duration: CMTime(seconds: 100, preferredTimescale: 600)
+        )
+        let transport = UUID()
+        let explicit = UUID()
+        let before = timeline.currentSnapshot.discontinuityGeneration
+        var supersededOperations: [UUID] = []
+        timeline.onSeekSupersededByExternalJump = {
+            supersededOperations.append($0)
+        }
+
+        timeline.prepareTransportSeek(operationID: transport, to: 15)
+        timeline.prepareExplicitSeek(operationID: explicit, to: 50)
+        timeline.observeTimeJump(at: 15)
+        timeline.explicitSeekCompleted(operationID: explicit, at: 50)
+        timeline.observeTimeJump(at: 50)
+
+        #expect(supersededOperations.isEmpty)
+        #expect(
+            timeline.currentSnapshot.discontinuityGeneration == before + 1
+        )
+        #expect(timeline.currentSnapshot.positionSeconds == 50)
+    }
+
+    @Test
+    @MainActor
+    func identicalSeekTargetsShareOneLandingAllowance() {
+        let timeline = AVPlayerTimelineAdapter(player: AVPlayer())
+        timeline.begin(
+            identity: PlaybackItemIdentity(bvid: "BVIdenticalSeek", cid: 1)
+        )
+        timeline.markReady(
+            duration: CMTime(seconds: 100, preferredTimescale: 600)
+        )
+        let first = UUID()
+        let second = UUID()
+        let before = timeline.currentSnapshot.discontinuityGeneration
+
+        timeline.prepareTransportSeek(operationID: first, to: 100)
+        timeline.prepareTransportSeek(operationID: second, to: 100)
+        timeline.transportSeekCompleted(operationID: second, at: 100)
+        timeline.observeTimeJump(at: 100)
+
+        #expect(
+            timeline.currentSnapshot.discontinuityGeneration == before + 1
+        )
+        timeline.observeTimeJump(at: 50)
+        timeline.observeTimeJump(at: 100)
+        #expect(
+            timeline.currentSnapshot.discontinuityGeneration == before + 3
+        )
+        #expect(timeline.currentSnapshot.positionSeconds == 100)
+    }
+
+    @Test
     @MainActor
     func resolvedInitialPositionUsesMediaBoundsInsteadOfTargetDelta() {
         #expect(

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
@@ -2719,6 +2719,16 @@ struct LoopbackPlaybackServerTests {
         )
         #expect(await subtitleRepository.cueRequestCount == 0)
 
+        let enabledResult = await engine.toggleNativeSubtitles()
+        let selectedByShortcut = try #require(
+            item.currentMediaSelection.selectedMediaOption(in: group)
+        )
+        #expect(enabledResult == .enabled(label: selectedByShortcut.displayName))
+        #expect(await engine.toggleNativeSubtitles() == .disabled)
+        #expect(
+            item.currentMediaSelection.selectedMediaOption(in: group) == nil
+        )
+
         item.select(authoredSubtitle, in: group)
         engine.play()
         try await waitUntilAsync {

--- a/docs/validation/M5.0-player-input-fullscreen-pip-2026-08-07.md
+++ b/docs/validation/M5.0-player-input-fullscreen-pip-2026-08-07.md
@@ -1,289 +1,102 @@
-# M5.0 播放器输入、全屏与画中画验证记录（2026-08-07）
+# M5.0 播放器输入、全屏与 PiP 最终契约
 
-## 状态与用途
+> 最终裁决：2026-08-21。本文取代本文件此前关于“方向键保持 AVKit 原生”以及
+> “横向触控板临时倍速”的结论。2026-08-20 的方向键报告只保留为研究证据，不是产品契约。
 
-本记录保存一次从“播放器区域内纵向滚动详情页”逐步收口到横向临时倍速、全屏一致性与
-原生画中画的实现证据和失败路线。它用于防止后续再次依赖错误的 responder chain、误测
-旧 App，或把 AVKit 原生行为误判为产品实现。
+## 产品结果
 
-2026-08-07 当时的生产结果通过了本地 App gate，并由用户在签名开发版、真实远端播放和
-真实触控板上确认以下行为：
-
-- 指针位于视频区域时，纵向双指滚动可以滚动外层详情页；
-- 播放中横向双指手势分别提供临时 `2X`／`0.5X`，松开后恢复原速；
-- 详情页与 AVKit detached fullscreen 使用相同的手势和提示层；
-- 提示位于弹幕之上、AVKit 原生控制条之下；
-- 原生全屏按钮和原生画中画可用，退出后仍回到同一个播放器宿主。
-
-2026-08-11 又确认了一个此前未覆盖的边界：窗口态改用 `.default`／inline controls 后，
-`contentOverlayView` capture 位于原生控制条下方。指针从详情容器进入播放器控件区域时，
-同一触控板序列可能转由 AVKit 处理，表现为短暂停顿后触发原生横向 seek。当前生产契约因此
-补充为：普通窗口用一个 scroll-only direct-child shield 覆盖完整 AVPlayerView；AVKit detached
-fullscreen 仍使用随 `contentOverlayView` 迁移的原 capture。两个入口共享同一 router、临时
-倍速 session 和 badge owner，不创建第二个播放器或第二套手势状态。
-
-这不是对所有鼠标、触控板设置、macOS 版本或辅助技术的完整兼容性声明。当前实现和测试
-仍应以代码与质量 Gate 为准，本文只记录 2026-08-07 的决策与证据。
-
-## 最终交互契约
-
-| 输入／状态 | 结果 |
-| --- | --- |
-| 有明确纵向主轴的滚轮或触控板序列 | 交给播放器外层的详情 `NSScrollView` |
-| 播放中、有 phase 且有 precise delta 的横向触控板序列 | 达到阈值后临时 `2X`／`0.5X`，结束时恢复 |
-| 普通窗口内的 precise 横向输入，但倍速不可用 | 由 direct-child shield 消费，不回落 AVKit seek |
-| 普通窗口内 precise 但无 phase 的纵向输入 | 交给外层详情滚动 |
-| 普通窗口内 precise 但无 phase 的横向输入 | 由 shield 消费，不回落 AVKit seek |
-| 非 precise 输入 | 穿透 shield，保留 AVPlayerView 原路径 |
-| 斜向输入 | 缓冲初始噪声后按累计主轴锁定，整段序列只交给一个 owner |
-| momentum | 沿用已完成的路由；临时倍速在 momentum 前结束 |
-| 点击、双击、拖动、magnify、键盘和辅助功能 | 透明捕获层返回 `nil`，继续使用 AVKit 原行为 |
-| 全屏视频区域 | AVKit 携带同一个 `contentOverlayView` capture，不建立第二个 player host |
-| 全屏原生控制区域 | 继续由 AVKit 处理；不承诺自定义滚轮优先 |
-| 画中画 | 使用 AVKit 原生 PiP；当前不暂停详情播放器中的弹幕呈现 |
-
-横向方向先用 `NSEvent.isDirectionInvertedFromDevice` 归一化，因此产品的物理滑动方向不应
-随系统“自然滚动”偏好翻转。普通窗口中，direct-child shield 命中的 precise 序列不会再回落为
-AVKit seek；明确纵向序列交给外层详情滚动，明确横向序列在播放可用时进入临时倍速。全屏
-原生控制区域不在这项强保证内。
-
-从详情容器跨入播放器时，AppKit 可能只把后半段 `.changed` 事件交给 shield。窗口入口只在
-当前 delta 已明确纵向时接续这种 orphaned sequence，并在后续样本中锁定外层滚动；孤立横向
-changed 会被消费，但不会中途启动临时倍速，以免指针再次离开播放器后收不到结束事件。
-
-## 最终视图层级
+播放详情使用既有唯一对象图：
 
 ```text
-DanmakuPlayerView : AVPlayerView
-├─ AVKit video content
-├─ contentOverlayView（随 detached fullscreen 迁移）
-│  ├─ DanmakuOverlayView
-│  │  └─ CoreAnimationDanmakuRenderer.rootLayer
-│  └─ PlayerScrollWheelCaptureView（唯一 router/session/badge owner）
-│     └─ PlayerMomentaryRateBadgeHostingView（仅激活期间存在）
-├─ AVKit native controls
-└─ PlayerScrollWheelShieldView（普通窗口 direct child，仅 precise scroll 命中）
+AppWindowOwner
+  -> AppEnvironment
+  -> AVPlayerEngine / AVPlayer
+  -> SystemNowPlayingWindowCoordinator
+       -> SystemNowPlayingController
+            -> AVPlayerEngine play / pause / exact seek
+  -> PlayerHostView / DanmakuPlayerView(AVPlayerView)
+       -> contentOverlayView
+            -> DanmakuOverlayView
+            -> PlayerScrollWheelCaptureView
 ```
 
-`contentOverlayView` 是 AVKit 用于把自定义内容放在视频和原生控制之间的公开 API。弹幕、
-唯一滚轮 coordinator 和临时倍速提示仍统一由这个 surface 承载；
-`DanmakuOverlayView.hitTest` 继续始终返回 `nil`。普通窗口的 direct-child shield 不拥有 router
-或播放状态，只把 precise scroll 转发给该 coordinator；点击、拖动、magnify、键盘、辅助
-功能和非 precise 滚轮都返回 `nil`，继续命中 AVKit。现有 probe 中 detached fullscreen
-没有迁移这个 direct child，运行时因此回到 `contentOverlayView` 入口；这不是 AVKit 的公开
-迁移保证，生产改动后仍需全屏往返复测。
+没有第二个 player、rate/seek/fullscreen owner。AVKit detached fullscreen 继续携带公开
+`contentOverlayView`；PiP 只承诺同一 AVPlayer 和系统原生路径，不承诺快捷键接管。
 
-## 2026-08-11：控制条上方的普通窗口 scroll 命中入口
+详情 capture window 中，只要 first responder 不在可编辑 `NSTextField`/`NSTextView`
+等输入区域，播放器拥有以下裸键：
 
-此前“capture 位于 `contentOverlayView`”只证明视频区域与 detached fullscreen 可以共用
-入口，没有证明 inline controls 上方的真实 hit target。后来测试也只直接调用 capture 和
-纯 router，未覆盖从详情容器跨进控制区的物理触控板序列。因此 controls style 从
-`.floating` 变为 `.default` 后，AVKit 可以先命中控制区并恢复原生 seek。
+- 左／右短按在 keyUp 跳转 -5／+5 秒；
+- 左／右由独立 350ms deadline 进入临时 0.5X／2X，keyUp 恢复此前永久倍速；
+- 上／下每步调整播放器相对音量 5%，限制在 0...1，并解除 mute；repeat 最快约 80ms 一步；
+- D 切换现有弹幕 presentation；
+- C 切换当前 item 的现有原生字幕选择；
+- Space 在同一 AVPlayerEngine 上切换播放／暂停。
 
-只读 local monitor 即使返回 `nil`，也不能保证 AVKit 没有从更早的内部观察或相关 gesture
-stream 获得同一输入；在 `.inline`、`.floating`、`.minimal` 与 `.none` 四种样式的 probe 中，
-monitor 均看到了事件，但播放器时间仍从 30 秒明显前进。相反，普通窗口的 direct-child shield
-改变了真实 hit target：真实触控板横向滑动时 shield 收到 143 个事件，时间保持 30.00 秒；
-随后直接拖动原生进度条仍能把时间移动到 76.96 秒。这证明它只隔离 scroll，没有破坏点击
-与拖动。
+一次水平按压只产生短跳转或临时倍速之一，长按不依赖系统 repeat。D、C、Space 每次物理
+按压只触发一次。Command、Control、Option、Shift 组合、VoiceOver Control+Option、Tab、
+Return、J/K/L、菜单 tracking 和其他按键保持系统分发。
 
-probe 中同一 shield 未被 AVKit 携带进 detached fullscreen；直接 child 没有公共迁移保证。
-因此当前选择显式的不对称运行时边界：窗口态在完整播放器区域保证自定义 precise scroll
-优先；全屏视频区域继续由 `contentOverlayView` capture 处理，全屏原生控制区域保持 AVKit 原生。
-这比自建控制条或 App 管理整窗全屏复杂度低，也避免了后者曾出现的整窗白边问题。
+初次进入详情把 first responder 交给现有播放器一次；此后不循环抢焦点。详情 window 级
+owner 使普通非编辑控件持焦时仍可使用快捷键。进入可编辑区域会取消 deadline、repeat、
+临时倍速、反馈和异步字幕任务；离开编辑区域后 window owner 自然恢复，无需伪造 AX 焦点。
 
-## 踩过的坑与结论
+## 滚轮与触控板
 
-### 1. 键盘长按不是可靠入口
+播放器上方只为详情页纵向滚动保留一个最小 scroll-only 命中边界：
 
-最初尝试用长按左右方向键触发临时倍速。真实运行中先出现系统提示音，随后按键落到
-AVPlayerView 的原生逐帧行为：播放按钮持有焦点时，方向键本来就由 AVKit 处理。给
-`AVPlayerView` 强行争夺 first responder、使用 SwiftUI focus，或安装更宽范围的键盘
-monitor，都会与 AVKit 的播放／暂停、逐帧和辅助功能 responder 竞争。
+- 明确纵向事件转发给播放器外层的详情 `NSScrollView`；
+- 以一次手势序列为单位锁定方向，起始噪声只短暂缓存；一旦判定为纵向，后续 direct、ended
+  与 momentum 原始事件都保持同一归属，不再逐事件按瞬时 delta 改判；
+- 横向或等轴事件忽略，不映射为倍速、seek 或其他播放器动作；
+- 点击、拖动、magnify、AVKit floating controls 与辅助功能命中不被该边界遮挡；
+- 生产代码不再包含横向倍速 gesture state、router、source/session 或 feedback 接线。
 
-调试还曾同时运行两个相同 Bundle Identifier 的 App：旧二进制在前台，新二进制在后台。
-这让若干轮人工结果看似证明“准入条件失败”，实际测试的根本不是新实现。后续真实 App
-验证必须按完整 executable path 和 PID 确认唯一进程，不能只按 App 名或 Bundle ID 激活。
+非阻塞状态使用 AVKit 原生 `.floating` controls；准备态仍为 `.none`。不自制
+控制条，不改变系统全屏和 PiP owner。
 
-最终裁决：不保留键盘倍速 workaround，不安装全局或局部 keyboard event monitor；标准
-方向键、Space 和 J/K/L 继续由 AVPlayerView 原生处理。
+## Engine 与反馈所有权
 
-### 2. 重写外层 AVPlayerView 只对详情页有效
+5 秒 transport jump 在唯一 `AVPlayerEngine` 内从同 generation/item 的 pending target
+累计，clamp 到 finite duration，使用前后各 0.25 秒 tolerance。completion 必须同时匹配
+operation ID、load generation 和 item identity；旧 `finished=false` 不得清除新 operation。
+精确 restart 仍使用 zero tolerance，首次 resume 保持原有 0.25 秒策略。
 
-在普通详情页中，事件可以命中 `DanmakuPlayerView`，因此 subclass 的 `scrollWheel` 或
-挂在外层 host 上的提示看似有效。进入全屏后，AVKit 会创建 detached fullscreen window
-和新的内容容器；它不会承诺把整个 `DanmakuPlayerView` 外壳原样放入全屏 responder
-chain。真实调试证明全屏事件可以绕过 subclass override。
+系统控制中心通过进程级 `SystemNowPlayingController` 把 remote exact seek 接回同一个 engine，
+不形成第二 seek owner。initial、restart、remote/explicit 与 keyboard transport 共用带 identity 的
+单一 pending seek；新入口 supersede 旧入口，旧 completion/failure 不能清除新状态，同一次 seek
+的 completion 与迟到 `timeJumpedNotification` 只发布一个 discontinuity generation。若在途期间
+AVKit 原生控制产生明显不同目标的 jump，则原生 jump 立即 supersede engine operation 并成为唯一
+有效 discontinuity。
 
-AVKit 会携带公开的 `contentOverlayView` 进入 detached fullscreen。将透明捕获层迁到该
-surface 后，详情页和全屏第一次共用相同的事件入口。实现不依赖调试时看到的 AVKit 私有
-类名，也不调用私有 API。
+键盘长按复用现有唯一 momentary-rate session，并以 press identity 隔离旧 keyUp。音量通过
+`PlaybackPreferencesController` 写同一 AVPlayer，继续由既有 KVO/UserDefaults 持久化。
+D 复用 `DanmakuControlsViewModel`，C 复用 AVPlayer 原生 legible media selection，Space
+复用 engine 的原子 play/pause 动作。
 
-### 3. 把横向事件原样交还 AVKit 不等于临时倍速
+临时倍速、transport seek、音量、播放／暂停、弹幕和字幕反馈由一个
+`PlayerShortcutFeedbackBadge` owner 管理，统一 typography、padding、Capsule 和 stale
+identity dismiss。macOS 26 使用 `glassEffect`，macOS 15 使用 material fallback。transient
+反馈显示 800ms 后以 160ms opacity fade 淡出；开启 Reduce Motion 时立即移除。新反馈替换、
+失焦、Back、item replacement 与 dismantle 仍同步取消旧 dismiss/fade 并立即清理。
+seek 或播放切换只有在 engine 接受动作后才显示；自然结束态不把 Space 解释为自动重播。
 
-AVPlayerView 的横向触控板行为会随播放／暂停、原生控制状态和手势阶段表现为扫描、暂停或
-seek；长距离滑动中还可能从暂停式扫描转为 seek。它是合理的原生播放器行为，但不能作为
-确定性的“按住 2X／0.5X”产品入口。
+## 生命周期
 
-最终将播放中的 precise、phase-bearing 横向序列完整保留给临时倍速状态机；其他横向输入
-仍交给 AVKit。这样没有把同一序列的一半交给倍速、另一半交给原生 seek。
+capture window 迁移、window/app resign、进入编辑、item replacement、pause、failure、Back、
+dismantle 与 stop 都必须取消输入 deadline、repeat、异步字幕任务、反馈和匹配的临时倍速。
+engine load generation、item identity 与 operation ID 负责隔离迟到 seek/subtitle completion。
+local monitor 只观察本 App 且只消费当前 capture window 的最终快捷键；不使用 global monitor、
+CGEvent tap、私有 AVKit 类或 AX 权限。
 
-### 4. 第一个 delta 不能直接永久锁轴
+## 验证边界
 
-真实触控板常以很小的斜向噪声开始。例如首个样本略偏横向，后续才出现明确纵向移动。
-若第一个非等轴样本立即锁定，详情滚动和横向手势都会随机失败。
+自动测试固定短／长互斥、deadline/keyUp race、repeat 无关、stale keyUp、生命周期取消、
+window/editable/modifier scope、D/C/Space 单次触发、音量 clamp/unmute/throttle、pending
+seek 累计与 stale completion、纵向 wheel 的 phase/momentum 序列转发、横向无 player action、
+controlsStyle 映射，以及 feedback 文案、duration、identity 与 Reduce Motion policy。
 
-路由器因此累计 precise delta，在达到明确位移阈值或样本上限后锁轴；pending 样本最终
-批量交给同一个接收者。`mayBegin → began → changed → ended/cancelled → momentum` 必须作为
-一段连续输入管理。non-precise 但带 phase 的输入也必须锁定；只有无 phase 的传统滚轮才
-允许逐 tick 判轴。
-
-### 5. 外层 ScrollView 不一定存在
-
-全屏重挂载或未来复用 host 时，捕获层的 responder chain 不一定包含详情 `NSScrollView`。
-仅检查 `nextResponder != nil` 会把纵向事件送进一个没有详情 scroll owner 的链并吞掉。
-
-当前实现只在确认穿过 AVPlayerView 后找到外层 `NSScrollView` 时转交纵向序列；找不到时，
-全屏 `contentOverlayView` 入口回退 AVKit 原路径，普通窗口 shield 入口则消费 precise 序列，
-避免重新触发原生 seek。
-
-### 6. 生命周期取消必须隔离旧手势尾流
-
-window/app resign、host 重挂载、item 替换或播放停止时，系统不保证总能送达原序列的
-`ended/cancelled`。只结束倍速、不重置 router，会让旧 rate 或 pending 样本污染下一次
-输入；只 reset router 又会把旧 `.changed`／momentum 尾流送给 AVKit，可能作用于新 item。
-
-当前取消顺序为：结束临时 rate、清 pending、重置输入 session，并进入 quarantine。
-quarantine 丢弃旧 changed/ended/cancelled/momentum，直到新的 mayBegin/began 或明确无 phase
-新输入才解锁。
-
-### 7. 临时 `player.rate` 不能污染永久速度
-
-直接写 `AVPlayer.rate` 会触发时间线 rate observation。若 observation 把临时 `2`／`0.5`
-记成永久偏好，而手势期间又发生 item 替换、结束、失败或 clear，下一条视频可能继承临时
-速度。
-
-最终由 playback engine/timeline 拥有 temporary-rate session token：永久偏好使用
-`defaultRate`，临时会话只改变有效 `rate`；匹配临时会话的 observation 不回写永久偏好。
-load、stop、pause、setRate、item end/failure 和 clear 都能清理 session，旧 token 不能恢复
-或覆盖新 item。
-
-### 8. UI badge 与播放 session 必须同步取消
-
-只弱持有旧 `AVPlayerItem` 会在 item 释放后失去比较依据，造成引擎已取消临时倍速、提示却
-仍留在画面。异步把 rate 回写 SwiftUI Binding 还会产生 sibling Task 顺序竞态：旧 begin
-可能晚于 end 落地，或旧 end 覆盖新 begin。
-
-最终不再通过页面级 SwiftUI state/Binding 桥接提示。`PlayerScrollWheelCaptureView` 直接在
-主线程拥有一个 badge hosting view；item identity 使用 `ObjectIdentifier`，播放器与焦点
-观察在执行取消前重新检查当前状态。
-
-### 9. 同在 contentOverlayView 仍可能层级错误
-
-把提示迁入 `contentOverlayView` 后，最初先插入捕获层、后插入弹幕。提示虽然是捕获层的
-子视图，但整个捕获 subtree 仍位于弹幕 sibling 下方，因此提示被密集弹幕覆盖。
-
-最终先安装弹幕，再使用 AppKit 的明确相对定位把捕获层放在弹幕之上；测试锁定两个 sibling
-的相对顺序。不能只测试“badge 存在”，还要测试它所在 subtree 的 z-order。
-
-### 10. AVPlayerView 的可选原生按钮默认不会自动出现
-
-`.floating` 控制样式并不意味着所有原生能力都会显示。`showsFullScreenToggleButton` 和
-`allowsPictureInPicturePlayback` 默认都不会替产品自动打开。全屏曾因遗漏显式开关而被误判
-为双击或事件捕获问题。
-
-当前显式开启：
-
-- `showsFullScreenToggleButton = true`；
-- `allowsPictureInPicturePlayback = true`。
-
-没有开启逐帧按钮、分享按钮、时间码或自定义 action menu。画中画继续使用同一个
-AVPlayer，不创建第二个 host。系统 PiP 不承诺显示 `contentOverlayView` 的弹幕；当前进入
-PiP 后详情播放器的弹幕呈现继续运行，以换取退出 PiP 时自然连续。只有实测出现明显资源
-问题时，才考虑暂停弹幕呈现并按当前播放时间恢复，不能暂停播放引擎或重建 renderer。
-
-## 被否决的 workaround
-
-- 全局 `NSEvent` monitor；
-- 为键盘倍速强制抢占 AVPlayerView first responder；
-- 把滚轮解释为 seek；
-- 向 AVKit 私有子视图重放事件；
-- 依赖 AVKit 私有 class、selector 或 view hierarchy；
-- 为详情页与全屏分别维护两套 router、session 或提示状态；
-- 新建第二个 `AVPlayerView`／player host；
-- 自制播放器控制条代替 AVKit；
-- 用大量 XCUITest 模拟系统滚轮 routing 并把它当成真实触控板证据。
-
-## 自动化与人工证据
-
-验证环境为 Xcode 26.6（17F113）、macOS arm64。2026-08-11 清理重放到最新 main 后，
-`sh Scripts/run-quality-gates.sh app` 通过：378 个 Package 测试、App build-for-testing 和
-34 个 App 测试通过，签名 Keychain smoke 按条件跳过。依赖 SwiftUI/AppKit 子树、滚动位置、
-z-order 和 probe 生命周期的旧宿主测试已删除。当前自动化只覆盖稳定契约：
-
-- axis 初始噪声、斜向累计判定、phase/momentum 和 non-precise 序列；
-- natural scrolling 的横向方向归一；
-- 临时倍速阈值、结束、item replacement、stop、pause、用户改速与旧 token 隔离；
-- failure/clear 路径有源码清理守卫，但没有在临时 session 激活时分别触发的专门断言；
-- 生命周期 cancel 后的 stale changed/momentum quarantine；
-- pointer-exit helper 与生产 closure wiring 会重置旧 router/pending/rate；明确纵向的后续 orphaned
-  `.changed` 仍可接续外层滚动。`NSTrackingArea` 的真实系统投递尚未由自动测试覆盖；
-- pending 与 momentum 的 fallback policy 按输入序列锁定，入口切换不会改变旧序列 owner；
-- 一个最小真实 `PlayerHostView` 边界检查按公开类型确认 window shield 已安装，并验证纵向
-  滚轮到达外层 scroll owner；不固定 sibling index、frame 或完整子树；
-- capture 只参与 scroll-wheel hit testing；
-- 普通窗口 shield 只命中 precise scroll，并在 fallback 路径消费序列；content overlay 入口
-  仍保留自己的 AVKit fallback；
-- 真实 AVPlayerView identity/dismantle 连续性。
-
-2026-08-11 的首次签名 App 复测发现并关闭了一个启动级回归：AppKit 在 tracking-area／cursor
-刷新期间会用非 scroll-wheel 当前事件执行 shield `hitTest`，而直接读取该事件的
-`hasPreciseScrollingDeltas` 会抛 Objective-C exception。修复后只有先确认事件类型为
-`.scrollWheel` 才读取 precise 属性；单元测试用真实 `.mouseMoved` `NSEvent` 锁定该边界。
-重新 Apple Development 签名后，真实账号产品已能打开视频卡片并稳定显示原生播放器、全屏、
-PiP、时间线和弹幕控件；复测后没有生成新的 crash report。此观察仍不等于物理触控板手势通过。
-
-用户在多轮签名 App 观察中确认：
-
-- 详情页纵向滚动和左右临时倍速；
-- 播放器控制条仍可使用；
-- 全屏入口、全屏左右临时倍速和提示位置；
-- 提示不再被弹幕遮挡；
-- 画中画进入／退出正常，弹幕继续呈现可接受。
-- 最终签名产品中，普通窗口跨播放器滚动成功；进入全屏后继续使用原有
-  `contentOverlayView` 捕获路径，行为保持不变。
-
-自动测试不能替代这些触控板与 AVKit detached window 观察；反过来，一次人工成功也不能
-替代 router、rate owner 和资源清理测试。
-
-## 仍未关闭的边界
-
-- 尚未分别以“自然滚动”开／关做两次真人方向复核；当前只有纯函数测试覆盖归一化；
-- VoiceOver、Full Keyboard Access、Reduce Motion 和较大文字未因本轮完成而自动关闭；
-- 画中画期间继续运行弹幕的 CPU/GPU 成本未测量；没有症状前不增加暂停／恢复分支；
-- 不同触控板硬件、传统鼠标、Intel 和其他 macOS 版本没有本轮真实矩阵；
-- AVKit 内部控件与 detached fullscreen 结构不是公开稳定契约；实现只能依赖
-  `contentOverlayView`、公开 customization property 和标准 responder 行为。
-- 普通窗口 direct-child shield 的历史物理触控板观察覆盖 inline timeline 上方横向滚动与
-  随后鼠标拖动；用户也曾确认签名产品进入 detached fullscreen 后保持原有
-  `contentOverlayView` 捕获逻辑。当前自动测试只锁定最小 wiring、fallback policy 与唯一
-  AVPlayerView identity，未覆盖不同硬件和系统设置矩阵。
-
-## 后续修改前检查表
-
-1. 确认测试的 executable 完整路径和 PID，排除同 Bundle ID 的旧进程。
-2. 保持唯一 `PlayerHostView`／`AVPlayerView`／`AVPlayer`，不要为全屏或 PiP 建第二套 surface。
-3. 自定义视频覆盖内容优先放在公开 `contentOverlayView`，并显式测试 sibling z-order；若
-   窗口态必须覆盖 inline controls，只增加无状态的 scroll-only direct-child 入口。
-4. 新输入只能扩展现有 router/session owner；不能增加全局／local monitor 或跨 responder
-   重放。
-5. 临时播放状态由 engine/timeline 拥有，UI 只显示 session 结果。
-6. 修改 event routing、rate lifecycle 或 overlay hierarchy 后运行 App gate，并使用签名 App
-   完成一次真实触控板的详情／全屏／PiP 往返。
-
-## 公开 API 参考
-
-- Apple [`AVPlayerView`](https://developer.apple.com/documentation/avkit/avplayerview)
-- Apple [`contentOverlayView`](https://developer.apple.com/documentation/avkit/avplayerview/contentoverlayview)
-- Apple [`showsFullScreenToggleButton`](https://developer.apple.com/documentation/avkit/avplayerview/showsfullscreentogglebutton)
-- Apple [`allowsPictureInPicturePlayback`](https://developer.apple.com/documentation/avkit/avplayerview/allowspictureinpictureplayback)
+签名真实 App 仍需按完整 executable path/PID 检查普通详情、编辑暂停/恢复、全部快捷键、
+播放器上纵向滚动、横向无动作、floating controls、detached fullscreen 往返和同一 player。
+真实长按手感、关闭 repeat 的键盘、VoiceOver、Full Keyboard Access、菜单 tracking 与远端
+HLS 连续 seek 是真人验收边界，不能由 synthetic event、AX tree 或 build 结果替代。


### PR DESCRIPTION
## 变化

- 在详情页窗口范围内接管裸方向键、D、C 与 Space；编辑区域、组合键及其他按键继续原生分发。
- 左右短按累计跳转 5 秒，长按临时切换 0.5X/2X；上下键调整并持久化播放器音量。
- 复用现有弹幕、原生字幕和唯一 `AVPlayerEngine` 的播放／暂停、transport seek 与 momentary-rate owner。
- 播放器区域只把纵向滚轮交给详情页外层滚动；横向滚轮不产生播放器动作。
- 非准备态 AVPlayerView 使用 `.floating` 控件，准备态保持 `.none`。
- 统一快捷键反馈 badge，覆盖倍速、seek、音量、播放／暂停、弹幕和字幕；800ms 后以 160ms 淡出，并尊重 Reduce Motion。
- 将 transport、system exact seek 与 AVKit 原生 jump 纳入同一 operation identity，隔离替换、迟到 completion 与 time-jump 回调顺序。

## 原因

详情页此前需要依赖 AVKit/responder 的偶然焦点与滚轮分发，键盘播放操作和播放器上方的页面滚动体验不稳定。本实现把输入边界收敛到当前详情 window，同时保持唯一 player、seek、rate、fullscreen 与 PiP owner。

## 用户影响

- 进入详情页后无需先点击视频即可使用约定快捷键；进入可编辑文本区域时自动暂停接管。
- 播放器上方的双指纵向滚动保留 phase 与惯性，横向动作不会误触发播放行为。
- 所有主动快捷键提示使用一致的液态玻璃／material 胶囊样式和可访问性文案。
- 播放自然结束后 Space 不伪装成自动重播，也不会显示错误的播放提示。

## 验证

- 三条独立审查线覆盖输入／AVKit 生命周期、engine 并发接线、测试／文档；修复 finding 后复审均为 clean。
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer BILIKIT_COMPACT_LOGS=1 sh Scripts/run-quality-gates.sh app`
  - 静态、架构、秘密模式、工程契约与 strict Swift format 通过。
  - Package：555 tests / 56 suites 通过。
  - App build-for-testing 与 App tests 通过。
- Apple Development 签名 App 通过 `codesign --verify --deep --strict` 并完成真实启动；播放器内纵向滚动与惯性由真人确认无异常。

## 未覆盖边界

真实长按手感、关闭 repeat 的键盘、VoiceOver、Full Keyboard Access、菜单 tracking、远端 HLS 连续 seek，以及最终构建的 detached fullscreen 往返仍属于真人验收边界，不以 synthetic event、AX tree 或 build 结果替代。
