### PR TITLE
feat(playback): 增加手动线路偏好与有界测速

### DIFF
--- a/BiliKitMac/App/AppRootView.swift
+++ b/BiliKitMac/App/AppRootView.swift
@@ -23,17 +23,23 @@ enum HistoryRouteOwnership {
 struct AppRootView: View {
     @State private var windowOwner: AppWindowOwner
     private let accountSessionCoordinator: AccountSessionCoordinator
+    private let appSettingsModel: AppSettingsModel?
     @State private var isAuthenticationPresented = false
     @State private var submittedSearchQuery: String?
     init(
         environment: AppEnvironment? = nil,
         accountSessionCoordinator: AccountSessionCoordinator = AccountSessionCoordinator(),
-        systemNowPlayingController: SystemNowPlayingController? = nil
+        systemNowPlayingController: SystemNowPlayingController? = nil,
+        appSettingsModel: AppSettingsModel? = nil
     ) {
         self.accountSessionCoordinator = accountSessionCoordinator
+        self.appSettingsModel = appSettingsModel
         let environment =
             environment
-            ?? .live(accountSessionCoordinator: accountSessionCoordinator)
+            ?? .live(
+                accountSessionCoordinator: accountSessionCoordinator,
+                appSettingsModel: appSettingsModel
+            )
         _windowOwner = State(
             initialValue: AppWindowOwner(
                 environment: environment,
@@ -57,6 +63,7 @@ struct AppRootView: View {
         accountSessionCoordinator: AccountSessionCoordinator = AccountSessionCoordinator()
     ) {
         self.accountSessionCoordinator = accountSessionCoordinator
+        appSettingsModel = nil
         _windowOwner = State(
             initialValue: AppWindowOwner(
                 navigationCoordinator: navigationCoordinator,
@@ -106,6 +113,13 @@ struct AppRootView: View {
         .task {
             authenticationModel.restoreIfNeeded()
             await authenticationModel.waitForCurrentTask()
+            synchronizeBenchmarkAuthentication()
+        }
+        .onChange(of: authenticationModel.sessionPhase) { _, _ in
+            synchronizeBenchmarkAuthentication()
+        }
+        .onChange(of: authenticationModel.state) { _, _ in
+            synchronizeBenchmarkAuthentication()
         }
         .onChange(of: historyAccountScope) { previousScope, scope in
             guard AccountSessionScope.isResolvedChange(from: previousScope, to: scope)
@@ -177,6 +191,9 @@ struct AppRootView: View {
             submittedSearchQuery = nil
         }
         .onDisappear {
+            appSettingsModel?.removeAuthenticationOwner(
+                windowOwner.benchmarkAuthenticationOwnerID
+            )
             navigationCoordinator.resetForWindowClosure()
             browseModel.reset()
             authenticationModel.cancelTransientWork()
@@ -220,6 +237,28 @@ struct AppRootView: View {
 
     private var playerContent: AnyView {
         windowOwner.playerContent
+    }
+
+    private func synchronizeBenchmarkAuthentication() {
+        appSettingsModel?.synchronizeAuthentication(
+            Self.benchmarkAccess(
+                sessionPhase: authenticationModel.sessionPhase,
+                isSigningOut: authenticationModel.isSigningOut
+            ),
+            ownerID: windowOwner.benchmarkAuthenticationOwnerID
+        )
+    }
+
+    static func benchmarkAccess(
+        sessionPhase: AccountSessionPhase,
+        isSigningOut: Bool
+    ) -> PlaybackRouteBenchmarkAccess {
+        if isSigningOut { return .signedOut }
+        return switch sessionPhase {
+        case .unresolved: .resolving
+        case .signedOut: .signedOut
+        case .signedIn: .signedIn
+        }
     }
 
     private var commentActivationAID: Int64? {

--- a/BiliKitMac/App/AppWindowOwner.swift
+++ b/BiliKitMac/App/AppWindowOwner.swift
@@ -9,6 +9,7 @@ import SwiftUI
 /// 尤其是视频、弹幕模型与 `playerContent` 必须共享 `AppEnvironment` 中同一个
 /// `AVPlayerEngine`；分别重建会造成画面、时间线与弹幕指向不同播放项目。
 final class AppWindowOwner {
+    let benchmarkAuthenticationOwnerID = UUID()
     let navigationCoordinator: AppNavigationCoordinator
     let browseModel: GuestBrowseViewModel
     let videoModel: GuestVideoViewModel

--- a/BiliKitMac/App/BiliKitMacApp.swift
+++ b/BiliKitMac/App/BiliKitMacApp.swift
@@ -11,17 +11,23 @@ import SwiftUI
 struct BiliKitMacApp: App {
     @State private var accountSessionCoordinator = AccountSessionCoordinator()
     @State private var systemNowPlayingController = SystemNowPlayingController()
+    @State private var appSettingsModel = AppSettingsModel.live()
 
     var body: some Scene {
         WindowGroup {
             AppRootView(
                 accountSessionCoordinator: accountSessionCoordinator,
-                systemNowPlayingController: systemNowPlayingController
+                systemNowPlayingController: systemNowPlayingController,
+                appSettingsModel: appSettingsModel
             )
             .typesettingLanguage(
                 .explicit(Locale.Language(identifier: "zh-Hans"))
             )
         }
         .defaultSize(width: 1_320, height: 820)
+
+        Settings {
+            PlaybackSourceSettingsView(model: appSettingsModel)
+        }
     }
 }

--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -352,7 +352,8 @@ struct AppEnvironment {
     /// playurl 与 WBI 弹幕分段在明确无本地凭据时仍请求同一个 endpoint。登出还会替换 API 的
     /// ephemeral transport，使旧认证会话中的在途请求失效。
     static func live(
-        accountSessionCoordinator: AccountSessionCoordinator? = nil
+        accountSessionCoordinator: AccountSessionCoordinator? = nil,
+        appSettingsModel: AppSettingsModel? = nil
     ) -> AppEnvironment {
         let requestAuthorizer = BiliCredentialRequestAuthorizer()
         let transportFactory: @Sendable () -> any HTTPTransport = {
@@ -372,6 +373,7 @@ struct AppEnvironment {
             requestAuthorizer: requestAuthorizer,
             transportFactory: transportFactory
         )
+        appSettingsModel?.configureBenchmark(client: api)
         let sessionRegistration = accountSessionCoordinator.map {
             AppEnvironmentSessionRegistration(
                 coordinator: $0,
@@ -394,7 +396,10 @@ struct AppEnvironment {
         let subtitleRepository = BiliSubtitleRepository(client: api)
         let playerEngine = AVPlayerEngine(
             player: player,
-            subtitleUseCase: SubtitleUseCase(repository: subtitleRepository)
+            subtitleUseCase: SubtitleUseCase(repository: subtitleRepository),
+            sourcePreferenceProvider: {
+                appSettingsModel?.playbackSourcePreference ?? .serverDefault
+            }
         )
         let guestRepository = BiliGuestRepository(client: api)
         let commentAssetResolver = BiliCommentAssetResolver()

--- a/BiliKitMac/Settings/AppSettingsModel.swift
+++ b/BiliKitMac/Settings/AppSettingsModel.swift
@@ -1,0 +1,312 @@
+import BiliAPI
+import BiliPlayback
+import Foundation
+import Observation
+
+enum PlaybackRouteBenchmarkState: Sendable, Equatable {
+    case notTested
+    case findingSample
+    case testing(completed: Int, total: Int)
+    case completed
+    case cancelled
+    case sampleUnavailable
+    case authenticationFailure
+    case networkOrProtocolFailure
+
+    var isRunning: Bool {
+        switch self {
+        case .findingSample, .testing: true
+        default: false
+        }
+    }
+}
+
+enum PlaybackRouteBenchmarkAccess: Sendable, Equatable {
+    case resolving, signedOut, signedIn
+    var allowsBenchmark: Bool { self == .signedIn }
+}
+
+@MainActor
+@Observable
+final class AppSettingsModel {
+    static let supportedBenchmarkSampleCounts =
+        CDNBenchmarkSampleDiscoverer.supportedSampleCounts
+    typealias Discover = @Sendable (Int) async throws -> [CDNBenchmarkDiscoveredSample]
+    typealias ResetDiscovery = @Sendable () async -> Void
+    typealias Run =
+        @Sendable (
+            [CDNBenchmarkDiscoveredSample],
+            @escaping @Sendable (Int, Int) async -> Void
+        ) async throws -> [PlaybackRouteMeasurement]
+
+    private(set) var state: PlaybackRouteBenchmarkState = .notTested
+    private(set) var benchmarkAccess: PlaybackRouteBenchmarkAccess
+    private(set) var record: PlaybackSourcePreferenceRecord
+    private(set) var measurements: [PlaybackRouteMeasurement] = []
+    private(set) var benchmarkSampleCount = 1
+    @ObservationIgnored private let store: any PlaybackSourcePreferenceStoring
+    @ObservationIgnored private var discover: Discover
+    @ObservationIgnored private var resetDiscovery: ResetDiscovery
+    @ObservationIgnored private var run: Run
+    @ObservationIgnored private var task: Task<Void, Never>?
+    @ObservationIgnored private var discoveryResetTask: Task<Void, Never>?
+    @ObservationIgnored private var generation = UUID()
+    @ObservationIgnored private var isConfigured = false
+    @ObservationIgnored private var authenticationAccessByOwner:
+        [UUID: PlaybackRouteBenchmarkAccess] = [:]
+
+    init(
+        store: any PlaybackSourcePreferenceStoring,
+        benchmarkAccess: PlaybackRouteBenchmarkAccess = .signedIn,
+        discover: @escaping Discover,
+        resetDiscovery: @escaping ResetDiscovery = {},
+        run: @escaping Run
+    ) {
+        self.store = store
+        self.benchmarkAccess = benchmarkAccess
+        self.discover = discover
+        self.resetDiscovery = resetDiscovery
+        self.run = run
+        record = store.load()
+    }
+
+    static func live() -> AppSettingsModel {
+        AppSettingsModel(
+            store: UserDefaultsPlaybackSourcePreferenceStore(),
+            benchmarkAccess: .resolving,
+            discover: { _ in throw BiliAPIError.authorizationRequired },
+            run: { _, _ in throw BiliAPIError.authorizationRequired }
+        )
+    }
+
+    deinit {
+        task?.cancel()
+        discoveryResetTask?.cancel()
+    }
+
+    func configureBenchmark(client: BiliAPIClient) {
+        guard !isConfigured else { return }
+        isConfigured = true
+        let discoverer = CDNBenchmarkSampleDiscoverer(client: client)
+        let benchmark = BilivideoRouteBenchmark()
+        discover = { try await discoverer.discover(targetCount: $0) }
+        resetDiscovery = { await discoverer.resetSeenSamples() }
+        run = { samples, progress in
+            try await benchmark.benchmarkUnifiedPool(
+                samples: samples.map {
+                    PlaybackRouteBenchmarkSample(
+                        template: $0.videoRepresentation,
+                        headers: $0.mediaHeaders
+                    )
+                },
+                progress: progress
+            )
+        }
+    }
+
+    func synchronizeAuthentication(_ access: PlaybackRouteBenchmarkAccess) {
+        synchronizeAuthentication(access, ownerID: Self.unscopedAuthenticationOwnerID)
+    }
+
+    func synchronizeAuthentication(
+        _ access: PlaybackRouteBenchmarkAccess,
+        ownerID: UUID
+    ) {
+        authenticationAccessByOwner[ownerID] = access
+        applyAuthenticationAccess()
+    }
+
+    func removeAuthenticationOwner(_ ownerID: UUID) {
+        authenticationAccessByOwner[ownerID] = nil
+        applyAuthenticationAccess()
+    }
+
+    private static let unscopedAuthenticationOwnerID = UUID()
+
+    private func applyAuthenticationAccess() {
+        let access: PlaybackRouteBenchmarkAccess
+        if authenticationAccessByOwner.values.contains(.signedOut) {
+            access = .signedOut
+        } else if authenticationAccessByOwner.values.contains(.signedIn) {
+            access = .signedIn
+        } else {
+            access = .resolving
+        }
+        guard access != benchmarkAccess else { return }
+        benchmarkAccess = access
+        if !access.allowsBenchmark {
+            cancelBenchmark(markCancelled: false)
+            scheduleDiscoveryReset()
+            state = .notTested
+            measurements = []
+        }
+    }
+
+    var selection: PlaybackSourceSelection {
+        get { record.selection }
+        set {
+            let updated = PlaybackSourcePreferenceRecord(selection: newValue)
+            record = updated
+            store.save(updated)
+        }
+    }
+
+    var playbackSourcePreference: PlaybackSourcePreference {
+        record.selection.preference
+    }
+
+    func setBenchmarkSampleCount(_ value: Int) {
+        guard !state.isRunning,
+            Self.supportedBenchmarkSampleCounts.contains(value)
+        else { return }
+        benchmarkSampleCount = value
+    }
+
+    static func maximumTrafficBytes(repetitions: Int) -> UInt64? {
+        guard Self.supportedBenchmarkSampleCounts.contains(repetitions) else {
+            return nil
+        }
+        let targetCount = UInt64(PlaybackRouteTarget.allCases.count)
+        let perSample =
+            targetCount
+            * (BilivideoRouteBenchmark.maximumIndexBytes
+                + BilivideoRouteBenchmark.maximumMediaProbeBytes)
+            + BilivideoRouteBenchmark.maximumIndexBytes
+        return UInt64(repetitions) * perSample
+    }
+
+    func startBenchmark() {
+        guard benchmarkAccess.allowsBenchmark else { return }
+        cancelBenchmark(markCancelled: false)
+        let currentGeneration = UUID()
+        let sampleCount = benchmarkSampleCount
+        let pendingDiscoveryReset = discoveryResetTask
+        generation = currentGeneration
+        state = .findingSample
+        measurements = []
+        task = Task { [weak self, discover, run] in
+            do {
+                await pendingDiscoveryReset?.value
+                try Task.checkCancellation()
+                let samples = try await discover(sampleCount)
+                try Task.checkCancellation()
+                guard self?.benchmarkAccess.allowsBenchmark == true else {
+                    throw CancellationError()
+                }
+                guard samples.count == sampleCount else {
+                    self?.applyFailure(
+                        .sampleUnavailable,
+                        generation: currentGeneration
+                    )
+                    return
+                }
+                let result = try await run(samples) {
+                    [weak self] completed, total in
+                    await self?.applyProgress(
+                        completed,
+                        total: total,
+                        generation: currentGeneration
+                    )
+                }
+                try Task.checkCancellation()
+                self?.applyResult(result, generation: currentGeneration)
+            } catch is CancellationError {
+                self?.applyCancellation(generation: currentGeneration)
+            } catch let error as BiliAPIError {
+                let failure: PlaybackRouteBenchmarkState =
+                    switch error {
+                    case .authorizationRequired, .authenticationInvalid,
+                        .authorizationUnavailable:
+                        .authenticationFailure
+                    default:
+                        .networkOrProtocolFailure
+                    }
+                self?.applyFailure(failure, generation: currentGeneration)
+            } catch {
+                self?.applyFailure(
+                    .networkOrProtocolFailure,
+                    generation: currentGeneration
+                )
+            }
+        }
+    }
+
+    func cancelBenchmark(markCancelled: Bool = true) {
+        guard task != nil else { return }
+        generation = UUID()
+        task?.cancel()
+        task = nil
+        if markCancelled { state = .cancelled }
+    }
+
+    func closeSettings() {
+        cancelBenchmark(markCancelled: false)
+        scheduleDiscoveryReset()
+        measurements = []
+        state = .notTested
+    }
+
+    private func applyProgress(_ completed: Int, total: Int, generation: UUID) {
+        guard self.generation == generation else { return }
+        state = .testing(completed: completed, total: total)
+    }
+
+    private func scheduleDiscoveryReset() {
+        discoveryResetTask?.cancel()
+        let resetDiscovery = resetDiscovery
+        discoveryResetTask = Task { await resetDiscovery() }
+    }
+
+    private func applyResult(_ result: [PlaybackRouteMeasurement], generation: UUID) {
+        guard self.generation == generation else { return }
+        task = nil
+        measurements = result.enumerated().sorted { lhs, rhs in
+            let leftSuccess = lhs.element.successfulRuns * rhs.element.totalRuns
+            let rightSuccess = rhs.element.successfulRuns * lhs.element.totalRuns
+            if leftSuccess != rightSuccess {
+                return leftSuccess > rightSuccess
+            }
+            let lhsThroughput = Self.sortableThroughput(lhs.element)
+            let rhsThroughput = Self.sortableThroughput(rhs.element)
+            if lhsThroughput != rhsThroughput {
+                return lhsThroughput > rhsThroughput
+            }
+            let lhsMinimum = Self.sortableMinimum(lhs.element)
+            let rhsMinimum = Self.sortableMinimum(rhs.element)
+            if lhsMinimum != rhsMinimum {
+                return lhsMinimum > rhsMinimum
+            }
+            return lhs.offset < rhs.offset
+        }.map(\.element)
+        state = .completed
+    }
+
+    private static func sortableThroughput(_ result: PlaybackRouteMeasurement) -> Double {
+        guard let throughput = result.effectiveBitsPerSecond,
+            throughput.isFinite, throughput >= 0
+        else { return -.infinity }
+        return throughput
+    }
+
+    private static func sortableMinimum(_ result: PlaybackRouteMeasurement) -> Double {
+        guard let throughput = result.minimumBitsPerSecond,
+            throughput.isFinite, throughput >= 0
+        else { return -.infinity }
+        return throughput
+    }
+
+    private func applyCancellation(generation: UUID) {
+        guard self.generation == generation else { return }
+        task = nil
+        state = .cancelled
+    }
+
+    private func applyFailure(
+        _ failure: PlaybackRouteBenchmarkState,
+        generation: UUID
+    ) {
+        guard self.generation == generation else { return }
+        task = nil
+        state = failure
+    }
+}

--- a/BiliKitMac/Settings/PlaybackSourcePreferenceStore.swift
+++ b/BiliKitMac/Settings/PlaybackSourcePreferenceStore.swift
@@ -1,0 +1,76 @@
+import BiliPlayback
+import Foundation
+
+enum PlaybackSourceSelection: String, Sendable, Equatable, CaseIterable, Identifiable {
+    case serverDefault, serverAkamai, serverBilivideo
+    case tencentOverseas, alibabaOverseas
+    case alibabaMainland, alibabaMainlandB, alibabaMainlandO1
+    case tencentMainland, tencentMainlandB, tencentMainlandO1
+    case huaweiMainland, huaweiMainlandB, huaweiMainlandO1
+    case huawei08C, huawei08H, huawei08CT, huaweiAll, tencentAll
+    case baiduMainland, bda2Mainland
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .serverDefault: "B 站服务端默认"
+        case .serverAkamai: "Akamai（服务端原始）"
+        case .serverBilivideo: "bilivideo（服务端原始）"
+        default: route?.displayName ?? rawValue
+        }
+    }
+
+    var isExperimental: Bool { route != nil }
+
+    var preference: PlaybackSourcePreference {
+        switch self {
+        case .serverDefault: .serverDefault
+        case .serverAkamai: .category(.akamai)
+        case .serverBilivideo: .category(.bilivideo)
+        default:
+            route.map(PlaybackSourcePreference.experimentalBilivideoRoute)
+                ?? .serverDefault
+        }
+    }
+
+    private var route: BilivideoRoute? {
+        BilivideoRoute(rawValue: rawValue)
+    }
+}
+
+struct PlaybackSourcePreferenceRecord: Sendable, Equatable {
+    static let defaults = Self(selection: .serverDefault)
+    let selection: PlaybackSourceSelection
+}
+
+protocol PlaybackSourcePreferenceStoring: AnyObject, Sendable {
+    func load() -> PlaybackSourcePreferenceRecord
+    func save(_ record: PlaybackSourcePreferenceRecord)
+}
+
+final class UserDefaultsPlaybackSourcePreferenceStore:
+    PlaybackSourcePreferenceStoring, @unchecked Sendable
+{
+    private enum Key {
+        static let schema = "playbackSourcePreference.schema"
+        static let selection = "playbackSourcePreference.selection"
+    }
+    private static let schemaVersion = 1
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) { self.defaults = defaults }
+
+    func load() -> PlaybackSourcePreferenceRecord {
+        guard defaults.integer(forKey: Key.schema) == Self.schemaVersion,
+            let raw = defaults.string(forKey: Key.selection),
+            let selection = PlaybackSourceSelection(rawValue: raw)
+        else { return .defaults }
+        return PlaybackSourcePreferenceRecord(selection: selection)
+    }
+
+    func save(_ record: PlaybackSourcePreferenceRecord) {
+        defaults.set(Self.schemaVersion, forKey: Key.schema)
+        defaults.set(record.selection.rawValue, forKey: Key.selection)
+    }
+}

--- a/BiliKitMac/Settings/PlaybackSourceSettingsView.swift
+++ b/BiliKitMac/Settings/PlaybackSourceSettingsView.swift
@@ -1,0 +1,153 @@
+import BiliPlayback
+import Foundation
+import SwiftUI
+
+struct PlaybackSourceSettingsView: View {
+    @Bindable var model: AppSettingsModel
+
+    var body: some View {
+        Form {
+            Section("播放线路") {
+                Picker("新播放优先线路", selection: selection) {
+                    ForEach(PlaybackSourceSelection.allCases) { item in
+                        Text(item.displayName + (item.isExperimental ? "（实验）" : ""))
+                            .tag(item)
+                    }
+                }
+                Text("默认使用 B 站服务端顺序。改选只影响之后新开始的播放，当前播放不会切源或重建。")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                Text("18 条 bilivideo 镜像线路属于实验性能力，可能失效，不保证每个视频都完整可用；不可用时仍回退服务端原始完整候选。")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("线路测速参考") {
+                Picker("不同样本", selection: benchmarkSampleCount) {
+                    ForEach(AppSettingsModel.supportedBenchmarkSampleCounts, id: \.self) {
+                        Text("\($0) 个").tag($0)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .disabled(model.state.isRunning)
+
+                Text("最多约 \(maximumTrafficMiB) MiB；每个样本对 1 条原始 Akamai 与 18 条实验 bilivideo 线路逐条串行测试。")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+
+                if case .testing(let completed, let total) = model.state {
+                    ProgressView(value: Double(completed), total: Double(total)) {
+                        Text("正在测试 \(completed) / \(total) 项")
+                    }
+                } else {
+                    Text(statusText).foregroundStyle(.secondary)
+                }
+
+                ForEach(model.measurements, id: \.target) { result in
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(result.target.displayName)
+                        Text(Self.resultText(result))
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                        if let distribution = Self.sampleDistributionText(result) {
+                            Text(distribution)
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                }
+
+                if model.state.isRunning {
+                    Button("取消测速", role: .cancel) { model.cancelBenchmark() }
+                } else {
+                    Button(model.measurements.isEmpty ? "开始测速" : "重新测速") {
+                        model.startBenchmark()
+                    }
+                    .disabled(!model.benchmarkAccess.allowsBenchmark)
+                }
+            }
+
+            Text(
+                "测速需要登录，Cookie 仅用于 api.bilibili.com 的 playurl 请求，不会发给媒体线路。结果仅存在于当前设置窗口，不会保存、推荐线路或更改手动选择。"
+            )
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+        }
+        .formStyle(.grouped)
+        .frame(minWidth: 560, minHeight: 520)
+        .onDisappear { model.closeSettings() }
+    }
+
+    private var selection: Binding<PlaybackSourceSelection> {
+        Binding(get: { model.selection }, set: { model.selection = $0 })
+    }
+
+    private var benchmarkSampleCount: Binding<Int> {
+        Binding(
+            get: { model.benchmarkSampleCount },
+            set: { model.setBenchmarkSampleCount($0) }
+        )
+    }
+
+    private var maximumTrafficMiB: UInt64 {
+        let bytes =
+            AppSettingsModel.maximumTrafficBytes(repetitions: model.benchmarkSampleCount) ?? 0
+        let mebibyte: UInt64 = 1_024 * 1_024
+        return (bytes + mebibyte - 1) / mebibyte
+    }
+
+    private var statusText: String {
+        if model.benchmarkAccess == .resolving { return "正在确认登录状态…" }
+        if model.benchmarkAccess == .signedOut { return "请先在主窗口登录。" }
+        switch model.state {
+        case .notTested: return "尚未测速。开始后会从不同分区寻找近期、低播放量且足够长的公开视频样本。"
+        case .findingSample: return "正在寻找 \(model.benchmarkSampleCount) 个合格样本…"
+        case .testing: return "正在串行测试…"
+        case .completed: return "测速完成；请根据结果自行选择线路。"
+        case .cancelled: return "测速已取消，线路选择未改变。"
+        case .sampleUnavailable: return "暂时找不到合格样本，请稍后重试。"
+        case .authenticationFailure: return "登录状态已失效或暂时不可用，请重新登录后再试。"
+        case .networkOrProtocolFailure: return "网络或远端协议未能完成测速，未暴露样本或网络详情。"
+        }
+    }
+
+    static func resultText(
+        _ result: PlaybackRouteMeasurement,
+        locale: Locale = .current
+    ) -> String {
+        guard let bits = result.effectiveBitsPerSecond, bits.isFinite, bits >= 0 else {
+            return "不可用 · 0/\(result.totalRuns) 个样本成功"
+        }
+        if result.totalRuns > 1 {
+            let minimum =
+                result.minimumBitsPerSecond.map {
+                    speedText($0, locale: locale)
+                } ?? "—"
+            let median =
+                result.medianBitsPerSecond.map {
+                    speedText($0, locale: locale)
+                } ?? "—"
+            return "综合 \(speedText(bits, locale: locale)) · 最低 \(minimum) · 中位 \(median)"
+                + " · \(result.successfulRuns)/\(result.totalRuns) 个样本成功"
+        }
+        return "最慢片段吞吐 \(speedText(bits, locale: locale))"
+            + " · \(result.successfulRuns)/\(result.totalRuns) 个样本成功"
+    }
+
+    static func sampleDistributionText(
+        _ result: PlaybackRouteMeasurement,
+        locale: Locale = .current
+    ) -> String? {
+        guard result.totalRuns > 1, !result.sampleBitsPerSecond.isEmpty else {
+            return nil
+        }
+        return "匿名样本："
+            + result.sampleBitsPerSecond.map { speedText($0, locale: locale) }
+            .joined(separator: " / ")
+    }
+
+    private static func speedText(_ bits: Double, locale: Locale) -> String {
+        let speed = String(format: "%.1f", locale: locale, bits / 1_000_000)
+        return "\(speed) Mbps"
+    }
+}

--- a/BiliKitMacTests/PlaybackSourceSettingsTests.swift
+++ b/BiliKitMacTests/PlaybackSourceSettingsTests.swift
@@ -1,0 +1,424 @@
+import BiliAPI
+import BiliAuthFeature
+import BiliModels
+import BiliPlayback
+import Foundation
+import Testing
+
+@testable import BiliKit
+
+@Suite(.timeLimit(.minutes(1)))
+struct PlaybackSourceSettingsTests {
+    @Test @MainActor
+    func storePersistsKnownManualRouteAndFallsBackOnDamage() {
+        withIsolatedDefaults { defaults in
+            let store = UserDefaultsPlaybackSourcePreferenceStore(defaults: defaults)
+            store.save(PlaybackSourcePreferenceRecord(selection: .huaweiMainland))
+            #expect(store.load() == PlaybackSourcePreferenceRecord(selection: .huaweiMainland))
+            defaults.set("unknown", forKey: "playbackSourcePreference.selection")
+            #expect(store.load() == .defaults)
+            defaults.set(99, forKey: "playbackSourcePreference.schema")
+            #expect(store.load() == .defaults)
+        }
+    }
+
+    @Test @MainActor
+    func manualSelectionPersistsAndMapsToFuturePlaybackPreference() {
+        let store = MemoryPlaybackSourcePreferenceStore()
+        let model = makeModel(store: store)
+        let oldSnapshot = model.playbackSourcePreference
+        model.selection = .tencentOverseas
+
+        #expect(oldSnapshot == .serverDefault)
+        #expect(model.playbackSourcePreference == .experimentalBilivideoRoute(.tencentOverseas))
+        #expect(store.load().selection == .tencentOverseas)
+    }
+
+    @Test @MainActor
+    func trafficLimitIsDerivedFromNineteenBoundedSerialTargets() {
+        let mebibyte: UInt64 = 1_024 * 1_024
+        #expect(
+            AppSettingsModel.maximumTrafficBytes(repetitions: 1)
+                == 19 * (10 * mebibyte + 256 * 1_024) + 256 * 1_024
+        )
+        #expect(
+            AppSettingsModel.maximumTrafficBytes(repetitions: 3)
+                == 3 * (19 * (10 * mebibyte + 256 * 1_024) + 256 * 1_024)
+        )
+        #expect(AppSettingsModel.maximumTrafficBytes(repetitions: 4) == nil)
+    }
+
+    @Test @MainActor
+    func benchmarkResultNeverChangesManualSelection() async throws {
+        let store = MemoryPlaybackSourcePreferenceStore(
+            record: PlaybackSourcePreferenceRecord(selection: .alibabaMainland)
+        )
+        let model = AppSettingsModel(
+            store: store,
+            discover: { count in Array(repeating: try Self.sample(), count: count) },
+            run: { samples, progress in
+                let attemptCount = PlaybackRouteTarget.allCases.count * samples.count
+                await progress(0, attemptCount)
+                await progress(attemptCount, attemptCount)
+                return [
+                    PlaybackRouteMeasurement(
+                        target: .serverAkamai,
+                        effectiveBitsPerSecond: 8,
+                        successfulRuns: samples.count,
+                        totalRuns: samples.count
+                    )
+                ]
+            }
+        )
+        model.setBenchmarkSampleCount(3)
+        model.startBenchmark()
+        try await waitUntil { model.state == .completed }
+
+        #expect(model.selection == .alibabaMainland)
+        #expect(store.load().selection == .alibabaMainland)
+        #expect(model.measurements.count == 1)
+        #expect(model.measurements.first?.successfulRuns == 3)
+        #expect(model.measurements.first?.totalRuns == 3)
+
+        model.closeSettings()
+        #expect(model.measurements.isEmpty)
+        #expect(model.selection == .alibabaMainland)
+    }
+
+    @Test @MainActor
+    func completedResultsPreferSampleSuccessRateThenHigherThroughput() async throws {
+        let model = AppSettingsModel(
+            store: MemoryPlaybackSourcePreferenceStore(),
+            discover: { count in Array(repeating: try Self.sample(), count: count) },
+            run: { _, _ in
+                [
+                    PlaybackRouteMeasurement(
+                        target: .serverAkamai,
+                        effectiveBitsPerSecond: 90_000_000,
+                        successfulRuns: 2,
+                        totalRuns: 3
+                    ),
+                    PlaybackRouteMeasurement(
+                        target: .bilivideo(.alibabaMainland),
+                        effectiveBitsPerSecond: 20_000_000,
+                        successfulRuns: 3,
+                        totalRuns: 3
+                    ),
+                    PlaybackRouteMeasurement(
+                        target: .bilivideo(.tencentMainland),
+                        effectiveBitsPerSecond: 40_000_000,
+                        successfulRuns: 3,
+                        totalRuns: 3
+                    ),
+                    PlaybackRouteMeasurement(
+                        target: .bilivideo(.huaweiMainland),
+                        effectiveBitsPerSecond: nil,
+                        totalRuns: 3
+                    ),
+                    PlaybackRouteMeasurement(
+                        target: .bilivideo(.tencentOverseas),
+                        effectiveBitsPerSecond: 100_000_000,
+                        successfulRuns: 1,
+                        totalRuns: 3
+                    ),
+                ]
+            }
+        )
+        model.setBenchmarkSampleCount(3)
+        model.startBenchmark()
+        try await waitUntil { model.state == .completed }
+
+        #expect(
+            model.measurements.map(\.target) == [
+                .bilivideo(.tencentMainland),
+                .bilivideo(.alibabaMainland),
+                .serverAkamai,
+                .bilivideo(.tencentOverseas),
+                .bilivideo(.huaweiMainland),
+            ]
+        )
+    }
+
+    @Test @MainActor
+    func throughputTextKeepsOneFractionDigit() {
+        let result = PlaybackRouteMeasurement(
+            target: .serverAkamai,
+            effectiveBitsPerSecond: 12_345_678,
+            successfulRuns: 3,
+            totalRuns: 3
+        )
+
+        #expect(
+            PlaybackSourceSettingsView.resultText(
+                result,
+                locale: Locale(identifier: "en_US_POSIX")
+            ) == "综合 12.3 Mbps · 最低 12.3 Mbps · 中位 12.3 Mbps · 3/3 个样本成功"
+        )
+    }
+
+    @Test @MainActor
+    func singleSampleResultStillShowsSuccessCount() {
+        let result = PlaybackRouteMeasurement(
+            target: .serverAkamai,
+            effectiveBitsPerSecond: 12_345_678,
+            successfulRuns: 1,
+            totalRuns: 1
+        )
+
+        #expect(
+            PlaybackSourceSettingsView.resultText(
+                result,
+                locale: Locale(identifier: "en_US_POSIX")
+            ) == "最慢片段吞吐 12.3 Mbps · 1/1 个样本成功"
+        )
+    }
+
+    @Test @MainActor
+    func signingOutDisablesBenchmarkBeforeConfirmedSessionChanges() {
+        #expect(
+            AppRootView.benchmarkAccess(
+                sessionPhase: .signedIn,
+                isSigningOut: true
+            ) == .signedOut
+        )
+        #expect(
+            AppRootView.benchmarkAccess(
+                sessionPhase: .signedIn,
+                isSigningOut: false
+            ) == .signedIn
+        )
+    }
+
+    @Test @MainActor
+    func authenticationAccessUsesDenyWinsAcrossWindows() {
+        let model = makeModel(store: MemoryPlaybackSourcePreferenceStore())
+        let firstWindow = UUID()
+        let secondWindow = UUID()
+
+        model.synchronizeAuthentication(.signedIn, ownerID: firstWindow)
+        model.synchronizeAuthentication(.signedIn, ownerID: secondWindow)
+        model.synchronizeAuthentication(.signedOut, ownerID: firstWindow)
+        model.synchronizeAuthentication(.signedIn, ownerID: secondWindow)
+        #expect(model.benchmarkAccess == .signedOut)
+
+        model.synchronizeAuthentication(.signedIn, ownerID: firstWindow)
+        #expect(model.benchmarkAccess == .signedIn)
+    }
+
+    @Test @MainActor
+    func newDiscoveryWaitsForLifecycleResetToFinish() async throws {
+        let resetGate = ResetGate()
+        let discovery = InvocationRecorder()
+        let model = AppSettingsModel(
+            store: MemoryPlaybackSourcePreferenceStore(),
+            discover: { _ in
+                await discovery.record()
+                return [try Self.sample()]
+            },
+            resetDiscovery: { await resetGate.wait() },
+            run: { _, _ in [] }
+        )
+
+        model.closeSettings()
+        model.startBenchmark()
+        try await waitUntil { await resetGate.isWaiting }
+        #expect(await discovery.count == 0)
+
+        await resetGate.release()
+        try await waitUntil { await discovery.count == 1 }
+    }
+
+    @Test @MainActor
+    func benchmarkFailureUsesNonIdentifyingProtocolState() async throws {
+        let model = AppSettingsModel(
+            store: MemoryPlaybackSourcePreferenceStore(),
+            discover: { _ in [try Self.sample()] },
+            run: { _, _ in throw BiliAPIError.transportFailure }
+        )
+        model.startBenchmark()
+        try await waitUntil { model.state == .networkOrProtocolFailure }
+
+        #expect(model.measurements.isEmpty)
+        #expect(model.selection == .serverDefault)
+    }
+
+    @Test @MainActor
+    func cancellationStopsWorkAndPreservesSelection() async throws {
+        let cancellation = CancellationRecorder()
+        let invocation = InvocationRecorder()
+        let store = MemoryPlaybackSourcePreferenceStore(
+            record: PlaybackSourcePreferenceRecord(selection: .serverAkamai)
+        )
+        let model = AppSettingsModel(
+            store: store,
+            discover: { _ in
+                await invocation.record()
+                do {
+                    try await Task.sleep(for: .seconds(60))
+                    return []
+                } catch is CancellationError {
+                    await cancellation.markCancelled()
+                    throw CancellationError()
+                }
+            },
+            run: { _, _ in [] }
+        )
+        model.startBenchmark()
+        try await waitUntil { await invocation.count == 1 }
+        model.cancelBenchmark()
+        try await waitUntil { await cancellation.wasCancelled }
+        #expect(model.state == .cancelled)
+        #expect(model.selection == .serverAkamai)
+    }
+
+    @Test @MainActor
+    func ownerDestructionCancelsDiscovery() async throws {
+        let cancellation = CancellationRecorder()
+        let invocation = InvocationRecorder()
+        var model: AppSettingsModel? = AppSettingsModel(
+            store: MemoryPlaybackSourcePreferenceStore(),
+            discover: { _ in
+                await invocation.record()
+                do {
+                    try await Task.sleep(for: .seconds(60))
+                    return []
+                } catch is CancellationError {
+                    await cancellation.markCancelled()
+                    throw CancellationError()
+                }
+            },
+            run: { _, _ in [] }
+        )
+        weak let owner = model
+        model?.startBenchmark()
+        try await waitUntil { await invocation.count == 1 }
+        model = nil
+
+        try await waitUntil { await cancellation.wasCancelled }
+        #expect(owner == nil)
+    }
+
+    @Test @MainActor
+    func signedOutStatePreventsDiscoveryAndLogoutCancelsRunningBenchmark() async throws {
+        let discovery = InvocationRecorder()
+        let cancellation = CancellationRecorder()
+        let reset = InvocationRecorder()
+        let model = AppSettingsModel(
+            store: MemoryPlaybackSourcePreferenceStore(),
+            benchmarkAccess: .signedOut,
+            discover: { _ in
+                await discovery.record()
+                do {
+                    try await Task.sleep(for: .seconds(60))
+                    return []
+                } catch is CancellationError {
+                    await cancellation.markCancelled()
+                    throw CancellationError()
+                }
+            },
+            resetDiscovery: { await reset.record() },
+            run: { _, _ in [] }
+        )
+
+        model.startBenchmark()
+        #expect(await discovery.count == 0)
+
+        model.synchronizeAuthentication(.signedIn)
+        model.startBenchmark()
+        try await waitUntil { await discovery.count == 1 }
+        model.synchronizeAuthentication(.signedOut)
+        try await waitUntil { await cancellation.wasCancelled }
+        try await waitUntil { await reset.count == 1 }
+
+        #expect(model.state == .notTested)
+        #expect(model.measurements.isEmpty)
+    }
+
+    @MainActor
+    private func makeModel(store: MemoryPlaybackSourcePreferenceStore) -> AppSettingsModel {
+        AppSettingsModel(store: store, discover: { _ in [] }, run: { _, _ in [] })
+    }
+
+    private static func sample() throws -> CDNBenchmarkDiscoveredSample {
+        let primaryURL = try #require(
+            URL(string: "https://a.bilivideo.com/v.m4s?t=1")
+        )
+        let backupURL = try #require(
+            URL(string: "https://a.akamaized.net/v.m4s?h=1")
+        )
+        return CDNBenchmarkDiscoveredSample(
+            videoRepresentation: MediaRepresentation(
+                id: 80,
+                kind: .video,
+                codecs: "avc1.640028",
+                mimeType: "video/mp4",
+                bandwidth: 1,
+                videoAttributes: nil,
+                primaryURL: primaryURL,
+                backupURLs: [backupURL],
+                segmentBase: SegmentBase(
+                    initialization: try MediaByteRange(start: 0, endInclusive: 9),
+                    index: try MediaByteRange(start: 10, endInclusive: 19)
+                )
+            ),
+            mediaHeaders: [:]
+        )
+    }
+
+    @MainActor
+    private func withIsolatedDefaults(_ body: (UserDefaults) -> Void) {
+        let name = "PlaybackSourceSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: name) else { return }
+        defaults.removePersistentDomain(forName: name)
+        defer { defaults.removePersistentDomain(forName: name) }
+        body(defaults)
+    }
+
+    @MainActor
+    private func waitUntil(_ condition: () async -> Bool) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while !(await condition()), clock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        #expect(await condition())
+    }
+}
+
+private final class MemoryPlaybackSourcePreferenceStore: PlaybackSourcePreferenceStoring,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var record: PlaybackSourcePreferenceRecord
+    init(record: PlaybackSourcePreferenceRecord = .defaults) { self.record = record }
+    func load() -> PlaybackSourcePreferenceRecord { lock.withLock { record } }
+    func save(_ record: PlaybackSourcePreferenceRecord) { lock.withLock { self.record = record } }
+}
+
+private actor CancellationRecorder {
+    private(set) var wasCancelled = false
+    func markCancelled() { wasCancelled = true }
+}
+
+private actor InvocationRecorder {
+    private(set) var count = 0
+    func record() { count += 1 }
+}
+
+private actor ResetGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private(set) var isWaiting = false
+
+    func wait() async {
+        isWaiting = true
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func release() {
+        continuation?.resume()
+        continuation = nil
+        isWaiting = false
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliAPI/CDN/CDNBenchmarkPlayback.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/CDN/CDNBenchmarkPlayback.swift
@@ -1,0 +1,17 @@
+import BiliModels
+import Foundation
+
+/// 已认证测速发现所需的最小 playurl 投影；不包含音频、断点或账户字段。
+struct CDNBenchmarkPlayback: Sendable, Equatable {
+    let videoRepresentations: [MediaRepresentation]
+    let mediaHeaders: [String: String]
+}
+
+/// playurl 的测速专用解码边界；未声明的音频、语言与断点字段不会被读取。
+struct CDNBenchmarkPlayURLPayload: Decodable, Sendable {
+    let dash: CDNBenchmarkDASHPayload
+}
+
+struct CDNBenchmarkDASHPayload: Decodable, Sendable {
+    let video: [DASHRepresentationPayload]
+}

--- a/Packages/BiliKitCore/Sources/BiliAPI/CDN/CDNBenchmarkSampleDiscoverer.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/CDN/CDNBenchmarkSampleDiscoverer.swift
@@ -1,0 +1,246 @@
+import BiliModels
+import BiliNetworking
+import Foundation
+
+public struct CDNBenchmarkDiscoveredSample: Sendable, Equatable {
+    public let videoRepresentation: MediaRepresentation
+    public let mediaHeaders: [String: String]
+
+    public init(
+        videoRepresentation: MediaRepresentation,
+        mediaHeaders: [String: String]
+    ) {
+        self.videoRepresentation = videoRepresentation
+        self.mediaHeaders = mediaHeaders
+    }
+}
+
+/// 只为已登录用户的显式测速发现近期低播放量公开视频；内容 identity 不越过该 adapter。
+public actor CDNBenchmarkSampleDiscoverer {
+    public static let maximumMetadataCount = 40
+    public static let maximumDetailRequestCount = 8
+    public static let maximumPlaybackRequestCount = 8
+    public static let supportedSampleCounts = 1...3
+
+    private static let regionIDs = [201, 124, 228, 207, 208, 209, 229, 231]
+    private static let pageSize = 5
+    private static let minimumViewCount: Int64 = 20
+    private static let maximumViewCount: Int64 = 9_999
+    private static let minimumAge: TimeInterval = 6 * 60 * 60
+    private static let maximumAge: TimeInterval = 14 * 24 * 60 * 60
+    private static let minimumDuration = 3 * 60
+    private static let minimumQualityID = 64
+    private static let minimumBandwidth = 500_000
+    private static let minimumShortSide = 720
+
+    private let client: BiliAPIClient
+    private let now: @Sendable () -> Date
+    private let regionIDs: [Int]
+    private var seenBVIDs: Set<String> = []
+
+    public init(client: BiliAPIClient) {
+        self.client = client
+        now = Date.init
+        regionIDs = Self.regionIDs
+    }
+
+    init(
+        client: BiliAPIClient,
+        now: @escaping @Sendable () -> Date,
+        regionIDs: [Int] = CDNBenchmarkSampleDiscoverer.regionIDs
+    ) {
+        self.client = client
+        self.now = now
+        self.regionIDs = Array(regionIDs.prefix(Self.maximumPlaybackRequestCount))
+    }
+
+    public func discover(targetCount: Int = 1) async throws -> [CDNBenchmarkDiscoveredSample] {
+        guard Self.supportedSampleCounts.contains(targetCount) else {
+            throw BiliAPIError.invalidRequest
+        }
+        var qualified: [(bvid: String, sample: CDNBenchmarkDiscoveredSample)] = []
+        var uploaderIDs: Set<Int64> = []
+        var metadataCount = 0
+        var detailRequestCount = 0
+        let dateWindow = try dateWindow(at: now())
+
+        for regionID in regionIDs {
+            try Task.checkCancellation()
+            guard qualified.count < targetCount,
+                metadataCount < Self.maximumMetadataCount,
+                detailRequestCount < Self.maximumDetailRequestCount
+            else { break }
+            let submissions = try await client.recentSubmissions(
+                regionID: regionID,
+                pageSize: Self.pageSize,
+                dateFrom: dateWindow.from,
+                dateTo: dateWindow.to
+            )
+            metadataCount += min(submissions.count, Self.pageSize)
+
+            for submission in submissions
+            where isEligible(submission)
+                && !seenBVIDs.contains(submission.bvid)
+                && !uploaderIDs.contains(submission.mid)
+            {
+                try Task.checkCancellation()
+                guard detailRequestCount < Self.maximumDetailRequestCount,
+                    detailRequestCount < Self.maximumPlaybackRequestCount
+                else { break }
+                detailRequestCount += 1
+                do {
+                    let detail = try await client.recentSubmissionDetail(
+                        for: submission.bvid
+                    )
+                    guard
+                        isEligible(
+                            detail,
+                            matching: submission,
+                            regionID: regionID
+                        )
+                    else {
+                        continue
+                    }
+                    try Task.checkCancellation()
+                    let playback = try await client.authenticatedPlaybackForCDNBenchmark(
+                        for: detail.bvid,
+                        cid: detail.cid
+                    )
+                    guard
+                        let video = highestConsumableVideo(
+                            in: playback.videoRepresentations
+                        ), hasComparableOrigins(video)
+                    else {
+                        continue
+                    }
+                    uploaderIDs.insert(detail.owner.mid)
+                    qualified.append(
+                        (
+                            detail.bvid,
+                            CDNBenchmarkDiscoveredSample(
+                                videoRepresentation: video,
+                                mediaHeaders: playback.mediaHeaders.filter {
+                                    $0.key.caseInsensitiveCompare("Cookie") != .orderedSame
+                                        && $0.key.caseInsensitiveCompare("Authorization")
+                                            != .orderedSame
+                                }
+                            )
+                        )
+                    )
+                    break
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch let error as BiliAPIError {
+                    guard Self.isCandidateLocalFailure(error) else { throw error }
+                    continue
+                } catch {
+                    throw error
+                }
+            }
+        }
+        try Task.checkCancellation()
+        if qualified.count == targetCount {
+            seenBVIDs.formUnion(qualified.map(\.bvid))
+        }
+        return qualified.map(\.sample)
+    }
+
+    public func resetSeenSamples() {
+        seenBVIDs.removeAll()
+    }
+
+    private static func isCandidateLocalFailure(_ error: BiliAPIError) -> Bool {
+        switch error {
+        case .httpStatus(404), .apiRejected(code: -404, _), .missingData,
+            .invalidMediaData, .noAVCVideo:
+            true
+        default:
+            false
+        }
+    }
+
+    private func isEligible(_ submission: RecentRankSubmissionPayload) -> Bool {
+        let age = now().timeIntervalSince1970 - TimeInterval(submission.senddate)
+        return submission.bvid.hasPrefix("BV")
+            && submission.bvid.count == 12
+            && submission.mid > 0
+            && (Self.minimumViewCount...Self.maximumViewCount).contains(
+                submission.play.value
+            )
+            && (Self.minimumAge...Self.maximumAge).contains(age)
+            && submission.duration >= Self.minimumDuration
+    }
+
+    private func isEligible(
+        _ detail: RecentSubmissionDetailPayload,
+        matching submission: RecentRankSubmissionPayload,
+        regionID: Int
+    ) -> Bool {
+        let age = now().timeIntervalSince1970 - TimeInterval(detail.pubdate)
+        return detail.bvid == submission.bvid
+            && detail.cid > 0
+            && detail.tid == regionID
+            && detail.owner.mid == submission.mid
+            && detail.duration >= Self.minimumDuration
+            && (Self.minimumAge...Self.maximumAge).contains(age)
+    }
+
+    private func dateWindow(at date: Date) throws -> (from: String, to: String) {
+        var calendar = Calendar(identifier: .gregorian)
+        guard let timeZone = TimeZone(secondsFromGMT: 8 * 60 * 60) else {
+            throw BiliAPIError.invalidRequest
+        }
+        calendar.timeZone = timeZone
+        guard let to = calendar.date(byAdding: .day, value: -1, to: date),
+            let from = calendar.date(byAdding: .day, value: -13, to: to)
+        else {
+            throw BiliAPIError.invalidRequest
+        }
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
+        formatter.dateFormat = "yyyyMMdd"
+        return (formatter.string(from: from), formatter.string(from: to))
+    }
+
+    private func highestConsumableVideo(
+        in videos: [MediaRepresentation]
+    ) -> MediaRepresentation? {
+        videos.filter { video in
+            guard video.codecs.lowercased().hasPrefix("avc"),
+                video.id >= Self.minimumQualityID,
+                let bandwidth = video.bandwidth,
+                bandwidth >= Self.minimumBandwidth,
+                let attributes = video.videoAttributes,
+                min(attributes.width, attributes.height) >= Self.minimumShortSide
+            else { return false }
+            return true
+        }.max { lhs, rhs in
+            let left = (
+                lhs.bandwidth ?? 0,
+                (lhs.videoAttributes?.width ?? 0) * (lhs.videoAttributes?.height ?? 0),
+                lhs.id
+            )
+            let right = (
+                rhs.bandwidth ?? 0,
+                (rhs.videoAttributes?.width ?? 0) * (rhs.videoAttributes?.height ?? 0),
+                rhs.id
+            )
+            return left < right
+        }
+    }
+
+    private func hasComparableOrigins(_ video: MediaRepresentation) -> Bool {
+        let hosts = video.urlCandidates.compactMap { $0.host?.lowercased() }
+        let hasAkamai = hosts.contains {
+            $0 == "akamaized.net" || $0.hasSuffix(".akamaized.net")
+                || $0 == "akamaihd.net" || $0.hasSuffix(".akamaihd.net")
+        }
+        let hasBilivideo = hosts.contains {
+            $0 == "bilivideo.com" || $0.hasSuffix(".bilivideo.com")
+                || $0 == "bilivideo.cn" || $0.hasSuffix(".bilivideo.cn")
+        }
+        return hasAkamai && hasBilivideo
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
@@ -129,6 +129,49 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
         )
     }
 
+    /// 显式线路测速专用的匿名近期投稿读取；只读取固定日期窗口中的有界元数据。
+    func recentSubmissions(
+        regionID: Int,
+        pageSize: Int,
+        dateFrom: String,
+        dateTo: String
+    ) async throws -> [RecentRankSubmissionPayload] {
+        guard regionID > 0, (1...5).contains(pageSize),
+            dateFrom.count == 8, dateFrom.allSatisfy(\.isNumber),
+            dateTo.count == 8, dateTo.allSatisfy(\.isNumber),
+            dateFrom <= dateTo
+        else { throw BiliAPIError.invalidRequest }
+        let payload: RecentRankPayload = try await get(
+            path: "/x/web-interface/newlist_rank",
+            queryItems: [
+                URLQueryItem(name: "main_ver", value: "v3"),
+                URLQueryItem(name: "search_type", value: "video"),
+                URLQueryItem(name: "view_type", value: "hot_rank"),
+                URLQueryItem(name: "copy_right", value: "-1"),
+                URLQueryItem(name: "new_web_tag", value: "1"),
+                URLQueryItem(name: "order", value: "pubdate"),
+                URLQueryItem(name: "cate_id", value: String(regionID)),
+                URLQueryItem(name: "page", value: "1"),
+                URLQueryItem(name: "pagesize", value: String(pageSize)),
+                URLQueryItem(name: "time_from", value: dateFrom),
+                URLQueryItem(name: "time_to", value: dateTo),
+            ],
+            referer: "https://www.bilibili.com/"
+        )
+        return Array((payload.result ?? []).prefix(pageSize))
+    }
+
+    func recentSubmissionDetail(
+        for bvid: String
+    ) async throws -> RecentSubmissionDetailPayload {
+        guard Self.isValidBVID(bvid) else { throw BiliAPIError.invalidRequest }
+        return try await get(
+            path: "/x/web-interface/view",
+            queryItems: [URLQueryItem(name: "bvid", value: bvid)],
+            referer: Self.videoReferer(bvid)
+        )
+    }
+
     public func recommendations(
         after continuation: RecommendationContinuation? = nil
     ) async throws -> RecommendationPage {
@@ -341,6 +384,65 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
         cid: Int64,
         quality: Int = 120
     ) async throws -> VideoPlayback {
+        try await playback(
+            for: bvid,
+            cid: cid,
+            quality: quality,
+            missingCredential: .useAnonymousRequest,
+            includesMachineGeneratedAudio: true
+        )
+    }
+
+    /// 测速样本必须来自当前账户可消费的 playurl；没有凭据时失败而不匿名降级。
+    func authenticatedPlaybackForCDNBenchmark(
+        for bvid: String,
+        cid: Int64,
+        quality: Int = 120
+    ) async throws -> CDNBenchmarkPlayback {
+        guard Self.isValidBVID(bvid), cid > 0, quality > 0 else {
+            throw BiliAPIError.invalidRequest
+        }
+        let playbackSessionEpoch = authenticatedSessionEpoch
+        let referer = Self.videoReferer(bvid)
+        let resolved: AuthorizedResponse<CDNBenchmarkPlayURLPayload> =
+            try await getWithAuthorizationProvenance(
+                path: "/x/player/playurl",
+                queryItems: [
+                    URLQueryItem(name: "bvid", value: bvid),
+                    URLQueryItem(name: "cid", value: String(cid)),
+                    URLQueryItem(name: "qn", value: String(quality)),
+                    URLQueryItem(name: "fnval", value: "976"),
+                    URLQueryItem(name: "fnver", value: "0"),
+                    URLQueryItem(name: "fourk", value: "1"),
+                ],
+                referer: referer,
+                access: .accountRead(
+                    missingCredential: .fail,
+                    mapsAuthenticationInvalidation: true
+                )
+            )
+        try requireAuthenticatedSessionEpoch(playbackSessionEpoch)
+        let video = try resolved.payload.dash.video
+            .filter(\.isAVCVideo)
+            .map { try $0.model(kind: .video) }
+        guard !video.isEmpty else { throw BiliAPIError.noAVCVideo }
+        try requireAuthenticatedSessionEpoch(playbackSessionEpoch)
+        return CDNBenchmarkPlayback(
+            videoRepresentations: video,
+            mediaHeaders: [
+                "Referer": referer,
+                "User-Agent": userAgent,
+            ]
+        )
+    }
+
+    private func playback(
+        for bvid: String,
+        cid: Int64,
+        quality: Int,
+        missingCredential: MissingCredentialBehavior,
+        includesMachineGeneratedAudio: Bool
+    ) async throws -> VideoPlayback {
         guard Self.isValidBVID(bvid), cid > 0, quality > 0 else {
             throw BiliAPIError.invalidRequest
         }
@@ -354,24 +456,16 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
             URLQueryItem(name: "fnver", value: "0"),
             URLQueryItem(name: "fourk", value: "1"),
         ]
-        let resolved: AuthorizedResponse<PlayURLPayload>
-        if requestAuthorizer != nil {
-            resolved = try await getWithAuthorizationProvenance(
+        let resolved: AuthorizedResponse<PlayURLPayload> =
+            try await getWithAuthorizationProvenance(
                 path: "/x/player/playurl",
                 queryItems: queryItems,
                 referer: referer,
                 access: .accountRead(
-                    missingCredential: .useAnonymousRequest,
+                    missingCredential: missingCredential,
                     mapsAuthenticationInvalidation: true
                 )
             )
-        } else {
-            resolved = try await getWithAuthorizationProvenance(
-                path: "/x/player/playurl",
-                queryItems: queryItems,
-                referer: referer
-            )
-        }
         let payload = resolved.payload
 
         let video = try payload.dash.video
@@ -395,15 +489,17 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
         ]
         if resolved.authorizationProvenance == .authenticated {
             try requireAuthenticatedSessionEpoch(playbackSessionEpoch)
-            audioTracks += try await machineGeneratedAudioTracks(
-                catalog: payload.languageCatalog,
-                originalAudio: audio,
-                bvid: bvid,
-                cid: cid,
-                quality: quality,
-                referer: referer,
-                sessionEpoch: playbackSessionEpoch
-            )
+            if includesMachineGeneratedAudio {
+                audioTracks += try await machineGeneratedAudioTracks(
+                    catalog: payload.languageCatalog,
+                    originalAudio: audio,
+                    bvid: bvid,
+                    cid: cid,
+                    quality: quality,
+                    referer: referer,
+                    sessionEpoch: playbackSessionEpoch
+                )
+            }
             try requireAuthenticatedSessionEpoch(playbackSessionEpoch)
         }
 

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/RecentSubmissionPayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/RecentSubmissionPayloads.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+struct RecentRankPayload: Decodable, Sendable {
+    let result: [RecentRankSubmissionPayload]?
+}
+
+struct RecentRankSubmissionPayload: Decodable, Sendable {
+    let bvid: String
+    let duration: Int
+    let senddate: Int64
+    let mid: Int64
+    let play: FlexibleInt64
+}
+
+struct RecentSubmissionDetailPayload: Decodable, Sendable {
+    let bvid: String
+    let cid: Int64
+    let duration: Int
+    let pubdate: Int64
+    let tid: Int
+    let owner: RecentOwnerPayload
+}
+
+struct RecentOwnerPayload: Decodable, Sendable {
+    let mid: Int64
+}
+
+struct FlexibleInt64: Decodable, Sendable {
+    let value: Int64
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(Int64.self) {
+            self.value = value
+            return
+        }
+        let rawValue = try container.decode(String.self)
+        value = Int64(rawValue) ?? -1
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliAuthFeature/Authentication/AuthenticationViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuthFeature/Authentication/AuthenticationViewModel.swift
@@ -93,6 +93,9 @@ public final class AuthenticationViewModel {
         }
     }
 
+    /// 供 App composition 在登出意图开始时立即停止账户相关临时工作。
+    public var isSigningOut: Bool { state == .signingOut }
+
     public var accountPresentationState: AccountPresentationState {
         switch sessionState {
         case .unresolved:

--- a/Packages/BiliKitCore/Sources/BiliNetworking/Range/HTTPBoundedRangeClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliNetworking/Range/HTTPBoundedRangeClient.swift
@@ -1,0 +1,425 @@
+import Foundation
+
+public struct HTTPBoundedRangeResult: Sendable, Equatable {
+    public let contentRange: HTTPContentRange
+    public let body: Data?
+    public let byteCount: UInt64
+    public let requestDurationSeconds: Double
+
+    public init(
+        contentRange: HTTPContentRange,
+        body: Data?,
+        byteCount: UInt64,
+        requestDurationSeconds: Double
+    ) {
+        self.contentRange = contentRange
+        self.body = body
+        self.byteCount = byteCount
+        self.requestDurationSeconds = requestDurationSeconds
+    }
+}
+
+public enum HTTPBoundedRangeError: Error, Sendable, Equatable {
+    case disallowedURL
+    case statusCode(Int)
+    case missingContentRange
+    case invalidContentRange
+    case mismatchedContentRange(expected: HTTPByteRange, actual: HTTPContentRange)
+    case missingContentLength
+    case invalidContentLength
+    case mismatchedContentLength(expected: UInt64, actual: UInt64)
+    case bodyLengthMismatch(expected: UInt64, actual: UInt64)
+    case transport(errorType: String)
+}
+
+public protocol HTTPBoundedRangeFetching: Sendable {
+    func fetch(
+        from url: URL,
+        range: HTTPByteRange,
+        headers: [String: String],
+        collectBody: Bool
+    ) async throws -> HTTPBoundedRangeResult
+
+    func invalidate()
+}
+
+extension HTTPBoundedRangeFetching {
+    public func invalidate() {}
+}
+
+protocol HTTPBoundedRangeTransport: Sendable {
+    func fetch(
+        _ request: URLRequest,
+        expectedRange: HTTPByteRange,
+        collectBody: Bool
+    ) async throws -> HTTPBoundedRangeResult
+
+    func invalidate()
+}
+
+extension HTTPBoundedRangeTransport {
+    func invalidate() {}
+}
+
+/// 单来源、流式且有界的 Range client，供显式媒体测速使用。
+///
+/// transport 在允许正文前即验证 `206`、`Content-Range` 与 `Content-Length`。因此 `200`、
+/// 缺少长度或声明越界的响应会立即取消；正文只计数或按需保留，达到精确上限即停止。
+public struct HTTPBoundedRangeClient: HTTPBoundedRangeFetching, Sendable {
+    private let transport: any HTTPBoundedRangeTransport
+    private let urlPolicy: PublicHTTPSURLPolicy
+
+    public init(
+        requestTimeout: TimeInterval = 15,
+        resourceTimeout: TimeInterval = 30,
+        urlPolicy: PublicHTTPSURLPolicy = PublicHTTPSURLPolicy()
+    ) {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpShouldSetCookies = false
+        configuration.httpCookieStorage = nil
+        configuration.urlCredentialStorage = nil
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.timeoutIntervalForRequest = requestTimeout
+        configuration.timeoutIntervalForResource = resourceTimeout
+        transport = URLSessionBoundedRangeTransport(configuration: configuration)
+        self.urlPolicy = urlPolicy
+    }
+
+    init(
+        transport: any HTTPBoundedRangeTransport,
+        urlPolicy: PublicHTTPSURLPolicy = PublicHTTPSURLPolicy()
+    ) {
+        self.transport = transport
+        self.urlPolicy = urlPolicy
+    }
+
+    public func fetch(
+        from url: URL,
+        range: HTTPByteRange,
+        headers: [String: String] = [:],
+        collectBody: Bool = false
+    ) async throws -> HTTPBoundedRangeResult {
+        guard urlPolicy.allows(url) else {
+            throw HTTPBoundedRangeError.disallowedURL
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        for (name, value) in headers
+        where name.caseInsensitiveCompare("Cookie") != .orderedSame
+            && name.caseInsensitiveCompare("Authorization") != .orderedSame
+            && name.caseInsensitiveCompare("Range") != .orderedSame
+        {
+            request.setValue(value, forHTTPHeaderField: name)
+        }
+        request.setValue(range.headerValue, forHTTPHeaderField: "Range")
+        return try await transport.fetch(
+            request,
+            expectedRange: range,
+            collectBody: collectBody
+        )
+    }
+
+    public func invalidate() {
+        transport.invalidate()
+    }
+}
+
+final class URLSessionBoundedRangeTransport: NSObject, HTTPBoundedRangeTransport,
+    URLSessionDataDelegate, @unchecked Sendable
+{
+    private let configuration: URLSessionConfiguration
+    private let lock = NSLock()
+    private var operations: [Int: BoundedRangeOperation] = [:]
+    private lazy var session: URLSession = {
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        queue.qualityOfService = .userInitiated
+        return URLSession(configuration: configuration, delegate: self, delegateQueue: queue)
+    }()
+
+    init(configuration: URLSessionConfiguration) {
+        self.configuration = configuration
+        super.init()
+    }
+
+    func fetch(
+        _ request: URLRequest,
+        expectedRange: HTTPByteRange,
+        collectBody: Bool
+    ) async throws -> HTTPBoundedRangeResult {
+        let operation = BoundedRangeOperation(
+            expectedRange: expectedRange,
+            collectBody: collectBody
+        )
+        let task = session.dataTask(with: request)
+        lock.withLock { operations[task.taskIdentifier] = operation }
+        return try await withTaskCancellationHandler {
+            try await operation.start(task) { [weak self] in
+                self?.removeOperation(for: task.taskIdentifier)
+            }
+        } onCancel: {
+            operation.cancel()
+        }
+    }
+
+    func invalidate() {
+        let pending = lock.withLock {
+            let pending = Array(operations.values)
+            operations.removeAll()
+            return pending
+        }
+        for operation in pending {
+            operation.cancel()
+        }
+        session.invalidateAndCancel()
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard let operation = operation(for: dataTask.taskIdentifier) else {
+            completionHandler(.cancel)
+            return
+        }
+        operation.receive(response, completionHandler: completionHandler)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive data: Data
+    ) {
+        operation(for: dataTask.taskIdentifier)?.receive(data)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: (any Error)?
+    ) {
+        operation(for: task.taskIdentifier)?.complete(error: error)
+    }
+
+    private func operation(for taskIdentifier: Int) -> BoundedRangeOperation? {
+        lock.withLock { operations[taskIdentifier] }
+    }
+
+    private func removeOperation(for taskIdentifier: Int) {
+        lock.withLock { operations[taskIdentifier] = nil }
+    }
+}
+
+private final class BoundedRangeOperation: @unchecked Sendable {
+    private let lock = NSLock()
+    private let expectedRange: HTTPByteRange
+    private let collectBody: Bool
+    private let clock = ContinuousClock()
+    private var continuation: CheckedContinuation<HTTPBoundedRangeResult, any Error>?
+    private var task: URLSessionDataTask?
+    private var onFinish: (@Sendable () -> Void)?
+    private var startedAt: ContinuousClock.Instant?
+    private var contentRange: HTTPContentRange?
+    private var received: UInt64 = 0
+    private var retained: Data?
+    private var pendingResult: HTTPBoundedRangeResult?
+    private var finished = false
+
+    init(
+        expectedRange: HTTPByteRange,
+        collectBody: Bool
+    ) {
+        self.expectedRange = expectedRange
+        self.collectBody = collectBody
+        retained = collectBody ? Data() : nil
+    }
+
+    func start(
+        _ task: URLSessionDataTask,
+        onFinish: @escaping @Sendable () -> Void
+    ) async throws -> HTTPBoundedRangeResult {
+        try await withCheckedThrowingContinuation { continuation in
+            let shouldStart = lock.withLock {
+                guard !finished else { return false }
+                self.continuation = continuation
+                self.task = task
+                self.onFinish = onFinish
+                startedAt = clock.now
+                return true
+            }
+            if shouldStart {
+                task.resume()
+            } else {
+                task.cancel()
+                continuation.resume(throwing: CancellationError())
+                onFinish()
+            }
+        }
+    }
+
+    func cancel() {
+        finish(.failure(CancellationError()))
+    }
+
+    func receive(
+        _ response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        do {
+            guard let response = response as? HTTPURLResponse else {
+                throw HTTPBoundedRangeError.transport(
+                    errorType: String(reflecting: HTTPClientError.nonHTTPResponse)
+                )
+            }
+            let validated = try validate(response, expectedRange: expectedRange)
+            lock.withLock {
+                contentRange = validated
+            }
+            completionHandler(.allow)
+        } catch {
+            completionHandler(.cancel)
+            finish(.failure(error))
+        }
+    }
+
+    func receive(_ data: Data) {
+        var outcome: Result<HTTPBoundedRangeResult, any Error>?
+        lock.withLock {
+            guard !finished else { return }
+            let next = received + UInt64(data.count)
+            guard next <= expectedRange.length, pendingResult == nil else {
+                outcome = .failure(
+                    HTTPBoundedRangeError.bodyLengthMismatch(
+                        expected: expectedRange.length,
+                        actual: next
+                    )
+                )
+                return
+            }
+            retained?.append(data)
+            received = next
+            guard received == expectedRange.length,
+                let contentRange,
+                let startedAt
+            else { return }
+            let completedAt = clock.now
+            pendingResult =
+                HTTPBoundedRangeResult(
+                    contentRange: contentRange,
+                    body: retained,
+                    byteCount: received,
+                    requestDurationSeconds: max(
+                        durationSeconds(startedAt.duration(to: completedAt)),
+                        .leastNonzeroMagnitude
+                    )
+                )
+        }
+        if let outcome { finish(outcome) }
+    }
+
+    func complete(error: (any Error)?) {
+        if let error {
+            finish(
+                .failure(
+                    HTTPBoundedRangeError.transport(
+                        errorType: String(reflecting: type(of: error))
+                    )
+                )
+            )
+        } else {
+            let completion = lock.withLock {
+                if let pendingResult {
+                    return Result<HTTPBoundedRangeResult, any Error>.success(pendingResult)
+                }
+                return .failure(
+                    HTTPBoundedRangeError.bodyLengthMismatch(
+                        expected: expectedRange.length,
+                        actual: received
+                    )
+                )
+            }
+            finish(completion)
+        }
+    }
+
+    private func finish(_ result: Result<HTTPBoundedRangeResult, any Error>) {
+        let resources = lock.withLock {
+            guard !finished else {
+                return (
+                    nil as CheckedContinuation<HTTPBoundedRangeResult, any Error>?,
+                    nil as URLSessionDataTask?,
+                    nil as (@Sendable () -> Void)?
+                )
+            }
+            finished = true
+            let continuation = self.continuation
+            self.continuation = nil
+            let task = self.task
+            self.task = nil
+            let onFinish = self.onFinish
+            self.onFinish = nil
+            return (continuation, task, onFinish)
+        }
+        resources.1?.cancel()
+        resources.2?()
+        resources.0?.resume(with: result)
+    }
+
+    private func validate(
+        _ response: HTTPURLResponse,
+        expectedRange: HTTPByteRange
+    ) throws -> HTTPContentRange {
+        guard response.statusCode == 206 else {
+            throw HTTPBoundedRangeError.statusCode(response.statusCode)
+        }
+        guard let raw = response.value(forHTTPHeaderField: "Content-Range") else {
+            throw HTTPBoundedRangeError.missingContentRange
+        }
+        let parsed: HTTPContentRange
+        do {
+            parsed = try HTTPContentRange.parse(raw)
+        } catch {
+            throw HTTPBoundedRangeError.invalidContentRange
+        }
+        guard parsed.start == expectedRange.start,
+            parsed.endInclusive == expectedRange.endInclusive
+        else {
+            throw HTTPBoundedRangeError.mismatchedContentRange(
+                expected: expectedRange,
+                actual: parsed
+            )
+        }
+        guard let rawLength = response.value(forHTTPHeaderField: "Content-Length") else {
+            throw HTTPBoundedRangeError.missingContentLength
+        }
+        guard let length = UInt64(rawLength) else {
+            throw HTTPBoundedRangeError.invalidContentLength
+        }
+        guard length == expectedRange.length else {
+            throw HTTPBoundedRangeError.mismatchedContentLength(
+                expected: expectedRange.length,
+                actual: length
+            )
+        }
+        return parsed
+    }
+
+    private func durationSeconds(_ duration: Duration) -> Double {
+        let components = duration.components
+        return Double(components.seconds)
+            + Double(components.attoseconds) / 1_000_000_000_000_000_000
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliPlayback/CDN/BilivideoRouteBenchmark.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/CDN/BilivideoRouteBenchmark.swift
@@ -1,0 +1,440 @@
+import BiliModels
+import BiliNetworking
+import Foundation
+
+public enum PlaybackRouteTarget: Sendable, Equatable, Hashable, CaseIterable {
+    case serverAkamai
+    case bilivideo(BilivideoRoute)
+
+    public static var allCases: [PlaybackRouteTarget] {
+        [.serverAkamai] + BilivideoRoute.allCases.map(Self.bilivideo)
+    }
+
+    public var displayName: String {
+        switch self {
+        case .serverAkamai: "Akamai（服务端原始）"
+        case .bilivideo(let route): route.displayName
+        }
+    }
+}
+
+public struct PlaybackRouteMeasurement: Sendable, Equatable {
+    public let target: PlaybackRouteTarget
+    /// Harmonic mean of successful per-sample conservative throughputs.
+    public let effectiveBitsPerSecond: Double?
+    public let minimumBitsPerSecond: Double?
+    public let medianBitsPerSecond: Double?
+    /// Anonymous per-sample values, sorted from slowest to fastest.
+    public let sampleBitsPerSecond: [Double]
+    public let successfulRuns: Int
+    public let totalRuns: Int
+
+    public init(
+        target: PlaybackRouteTarget,
+        effectiveBitsPerSecond: Double?,
+        minimumBitsPerSecond: Double? = nil,
+        medianBitsPerSecond: Double? = nil,
+        sampleBitsPerSecond: [Double] = [],
+        successfulRuns: Int = 1,
+        totalRuns: Int = 1
+    ) {
+        self.target = target
+        self.effectiveBitsPerSecond = effectiveBitsPerSecond
+        self.minimumBitsPerSecond = minimumBitsPerSecond ?? effectiveBitsPerSecond
+        self.medianBitsPerSecond = medianBitsPerSecond ?? effectiveBitsPerSecond
+        self.sampleBitsPerSecond = sampleBitsPerSecond
+        self.successfulRuns = effectiveBitsPerSecond == nil ? 0 : successfulRuns
+        self.totalRuns = totalRuns
+    }
+
+    public var succeeded: Bool { effectiveBitsPerSecond != nil }
+}
+
+public struct PlaybackRouteBenchmarkSample: Sendable, Equatable {
+    public let template: MediaRepresentation
+    public let headers: [String: String]
+
+    public init(template: MediaRepresentation, headers: [String: String]) {
+        self.template = template
+        self.headers = headers
+    }
+}
+
+public enum BilivideoRouteBenchmarkError: Error, Sendable, Equatable {
+    case incompleteCandidatePool
+    case invalidProbeRange
+    case invalidRepetitionCount(Int)
+}
+
+private struct CanonicalProbe: Sendable {
+    let index: SegmentIndex
+    let completeLength: Int64
+    let probeRanges: [HTTPByteRange]
+}
+
+private struct RouteProbeResult<Target: Hashable & Sendable>: Sendable {
+    let target: Target
+    let effectiveBitsPerSecond: Double?
+    let minimumBitsPerSecond: Double?
+    let medianBitsPerSecond: Double?
+    let sampleBitsPerSecond: [Double]
+    let successfulRuns: Int
+    let totalRuns: Int
+}
+
+public actor BilivideoRouteBenchmark {
+    public static let maximumMediaProbeBytes: UInt64 = 10 * 1_024 * 1_024
+    public static let maximumIndexBytes: UInt64 = 256 * 1_024
+    public static let requestTimeout: TimeInterval = 10
+    public static let resourceTimeout: TimeInterval = 30
+    public static let supportedRepetitions = 1...3
+
+    private let makeRangeFetcher: @Sendable () -> any HTTPBoundedRangeFetching
+
+    public init() {
+        makeRangeFetcher = {
+            HTTPBoundedRangeClient(
+                requestTimeout: BilivideoRouteBenchmark.requestTimeout,
+                resourceTimeout: BilivideoRouteBenchmark.resourceTimeout
+            )
+        }
+    }
+
+    init(rangeFetcher: any HTTPBoundedRangeFetching) {
+        makeRangeFetcher = { rangeFetcher }
+    }
+
+    /// Measures distinct anonymous samples once each.
+    ///
+    /// The original bilivideo URL establishes
+    /// canonical SIDX truth; the 19 measured targets then share one credential-free session.
+    public func benchmarkUnifiedPool(
+        samples: [PlaybackRouteBenchmarkSample],
+        progress: @escaping @Sendable (Int, Int) async -> Void = { _, _ in }
+    ) async throws -> [PlaybackRouteMeasurement] {
+        guard Self.supportedRepetitions.contains(samples.count) else {
+            throw BilivideoRouteBenchmarkError.invalidRepetitionCount(samples.count)
+        }
+        let targets = PlaybackRouteTarget.allCases
+        var values = Dictionary(uniqueKeysWithValues: targets.map { ($0, [Double]()) })
+        let totalAttempts = targets.count * samples.count
+        let measurementFetcher = makeRangeFetcher()
+        defer { measurementFetcher.invalidate() }
+        await progress(0, totalAttempts)
+
+        for (sampleIndex, sample) in samples.enumerated() {
+            try Task.checkCancellation()
+            let candidates = try unifiedCandidates(for: sample.template)
+            let canonical = try await canonicalProbe(
+                template: sample.template,
+                sourceURL: try serverBilivideoURL(for: sample.template),
+                headers: sample.headers
+            )
+            let offset = sampleIndex * max(1, targets.count / samples.count)
+            let result = try await probeSample(
+                rotated(candidates, by: offset),
+                template: sample.template,
+                headers: sample.headers,
+                canonical: canonical,
+                rangeFetcher: measurementFetcher,
+                progressBase: sampleIndex * targets.count,
+                totalAttempts: totalAttempts,
+                progress: progress
+            )
+            for (target, value) in result {
+                values[target, default: []].append(value)
+            }
+        }
+
+        return aggregate(values, totalRuns: samples.count, order: targets).map {
+            PlaybackRouteMeasurement(
+                target: $0.target,
+                effectiveBitsPerSecond: $0.effectiveBitsPerSecond,
+                minimumBitsPerSecond: $0.minimumBitsPerSecond,
+                medianBitsPerSecond: $0.medianBitsPerSecond,
+                sampleBitsPerSecond: $0.sampleBitsPerSecond,
+                successfulRuns: $0.successfulRuns,
+                totalRuns: $0.totalRuns
+            )
+        }
+    }
+
+    public func benchmarkUnifiedPool(
+        template: MediaRepresentation,
+        headers: [String: String],
+        repetitions: Int = 1,
+        progress: @escaping @Sendable (Int, Int) async -> Void = { _, _ in }
+    ) async throws -> [PlaybackRouteMeasurement] {
+        try await benchmarkUnifiedPool(
+            samples: Array(
+                repeating: PlaybackRouteBenchmarkSample(template: template, headers: headers),
+                count: repetitions
+            ),
+            progress: progress
+        )
+    }
+
+    private func probeSample<Target: Hashable & Sendable>(
+        _ candidates: [(Target, URL)],
+        template: MediaRepresentation,
+        headers: [String: String],
+        canonical: CanonicalProbe,
+        rangeFetcher: any HTTPBoundedRangeFetching,
+        progressBase: Int,
+        totalAttempts: Int,
+        progress: @escaping @Sendable (Int, Int) async -> Void
+    ) async throws -> [Target: Double] {
+        let indexRange = try HTTPByteRange(
+            start: template.segmentBase.index.start,
+            endInclusive: template.segmentBase.index.endInclusive
+        )
+        let initializationRange = try HTTPByteRange(
+            start: template.segmentBase.initialization.start,
+            endInclusive: template.segmentBase.initialization.endInclusive
+        )
+        guard indexRange.length <= Self.maximumIndexBytes,
+            initializationRange.length < Self.maximumMediaProbeBytes
+        else { throw BilivideoRouteBenchmarkError.invalidProbeRange }
+        let parser = SIDXParser()
+        var values: [Target: Double] = [:]
+
+        for (candidateIndex, candidate) in candidates.enumerated() {
+            try Task.checkCancellation()
+            do {
+                let indexResult = try await rangeFetcher.fetch(
+                    from: candidate.1,
+                    range: indexRange,
+                    headers: headers,
+                    collectBody: true
+                )
+                guard let body = indexResult.body,
+                    let completeLength = indexResult.contentRange.completeLength,
+                    initializationRange.endInclusive < completeLength
+                else { throw BilivideoRouteBenchmarkError.invalidProbeRange }
+                let index = try parser.parse(body, boxStartOffset: UInt64(indexRange.start))
+                guard index == canonical.index,
+                    completeLength == canonical.completeLength
+                else { throw BilivideoRouteBenchmarkError.invalidProbeRange }
+
+                let initializationResult = try await rangeFetcher.fetch(
+                    from: candidate.1,
+                    range: initializationRange,
+                    headers: headers,
+                    collectBody: false
+                )
+                guard initializationResult.byteCount == initializationRange.length,
+                    initializationResult.contentRange.completeLength
+                        == canonical.completeLength
+                else {
+                    throw BilivideoRouteBenchmarkError.invalidProbeRange
+                }
+
+                var throughputs: [Double] = []
+                for probeRange in canonical.probeRanges {
+                    try Task.checkCancellation()
+                    let mediaResult = try await rangeFetcher.fetch(
+                        from: candidate.1,
+                        range: probeRange,
+                        headers: headers,
+                        collectBody: false
+                    )
+                    guard mediaResult.byteCount == probeRange.length,
+                        mediaResult.contentRange.completeLength
+                            == canonical.completeLength,
+                        mediaResult.requestDurationSeconds.isFinite,
+                        mediaResult.requestDurationSeconds > 0
+                    else { throw BilivideoRouteBenchmarkError.invalidProbeRange }
+                    throughputs.append(
+                        Double(mediaResult.byteCount) * 8
+                            / mediaResult.requestDurationSeconds
+                    )
+                }
+                guard let conservative = throughputs.min() else {
+                    throw BilivideoRouteBenchmarkError.invalidProbeRange
+                }
+                values[candidate.0] = conservative
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {}
+            await progress(progressBase + candidateIndex + 1, totalAttempts)
+        }
+        return values
+    }
+
+    private func canonicalProbe(
+        template: MediaRepresentation,
+        sourceURL: URL,
+        headers: [String: String]
+    ) async throws -> CanonicalProbe {
+        let indexRange = try HTTPByteRange(
+            start: template.segmentBase.index.start,
+            endInclusive: template.segmentBase.index.endInclusive
+        )
+        let initializationRange = try HTTPByteRange(
+            start: template.segmentBase.initialization.start,
+            endInclusive: template.segmentBase.initialization.endInclusive
+        )
+        guard indexRange.length <= Self.maximumIndexBytes,
+            initializationRange.length < Self.maximumMediaProbeBytes
+        else { throw BilivideoRouteBenchmarkError.invalidProbeRange }
+
+        let canonicalFetcher = makeRangeFetcher()
+        defer { canonicalFetcher.invalidate() }
+        let result = try await canonicalFetcher.fetch(
+            from: sourceURL,
+            range: indexRange,
+            headers: headers,
+            collectBody: true
+        )
+        guard let body = result.body,
+            let completeLength = result.contentRange.completeLength,
+            initializationRange.endInclusive < completeLength
+        else { throw BilivideoRouteBenchmarkError.invalidProbeRange }
+        let index = try SIDXParser().parse(
+            body,
+            boxStartOffset: UInt64(indexRange.start)
+        )
+        return CanonicalProbe(
+            index: index,
+            completeLength: completeLength,
+            probeRanges: try spreadProbeRanges(
+                index.references,
+                completeLength: completeLength,
+                maximumBytes: Self.maximumMediaProbeBytes - initializationRange.length
+            )
+        )
+    }
+
+    private func spreadProbeRanges(
+        _ references: [SegmentReference],
+        completeLength: Int64,
+        maximumBytes: UInt64
+    ) throws -> [HTTPByteRange] {
+        guard references.count >= 2,
+            references.allSatisfy({
+                $0.byteRange.start >= 0
+                    && $0.byteRange.endInclusive >= $0.byteRange.start
+                    && $0.byteRange.endInclusive < completeLength
+            })
+        else { throw BilivideoRouteBenchmarkError.invalidProbeRange }
+
+        let last = references.count - 1
+        let anchors = [
+            0, last, references.count / 2, references.count / 4,
+            3 * references.count / 4,
+        ]
+        let priority = anchors + references.indices.filter { !anchors.contains($0) }
+        var selected: [HTTPByteRange] = []
+        var selectedIndices: Set<Int> = []
+        var totalBytes: UInt64 = 0
+        for index in priority where selectedIndices.insert(index).inserted {
+            let range = references[index].byteRange
+            let length = UInt64(range.endInclusive - range.start + 1)
+            guard length <= maximumBytes,
+                totalBytes <= maximumBytes - length
+            else { continue }
+            selected.append(
+                try HTTPByteRange(start: range.start, endInclusive: range.endInclusive)
+            )
+            totalBytes += length
+        }
+        guard selected.count >= 2, totalBytes <= maximumBytes else {
+            throw BilivideoRouteBenchmarkError.invalidProbeRange
+        }
+        return selected.sorted { $0.start < $1.start }
+    }
+
+    private func unifiedCandidates(
+        for template: MediaRepresentation
+    ) throws -> [(PlaybackRouteTarget, URL)] {
+        let bilivideoTemplate = try serverBilivideoURL(for: template)
+        guard
+            let akamaiURL = template.urlCandidates.first(where: {
+                PlaybackSourceClassifier.category(for: $0) == .akamai
+            })
+        else { throw BilivideoRouteBenchmarkError.incompleteCandidatePool }
+        let candidates =
+            [(PlaybackRouteTarget.serverAkamai, akamaiURL)]
+            + BilivideoRoute.allCases.compactMap { route in
+                route.replacingHost(in: bilivideoTemplate).map {
+                    (PlaybackRouteTarget.bilivideo(route), $0)
+                }
+            }
+        guard candidates.count == PlaybackRouteTarget.allCases.count else {
+            throw BilivideoRouteBenchmarkError.incompleteCandidatePool
+        }
+        return candidates
+    }
+
+    private func serverBilivideoURL(for template: MediaRepresentation) throws -> URL {
+        guard
+            let url = template.urlCandidates.first(where: {
+                PlaybackSourceClassifier.category(for: $0) == .bilivideo
+            })
+        else { throw BilivideoRouteBenchmarkError.incompleteCandidatePool }
+        return url
+    }
+
+    private func aggregate<Target: Hashable & Sendable>(
+        _ values: [Target: [Double]],
+        totalRuns: Int,
+        order: [Target]
+    ) -> [RouteProbeResult<Target>] {
+        order.map { target in
+            let successful = values[target, default: []]
+                .filter { $0.isFinite && $0 > 0 }
+                .sorted()
+            return RouteProbeResult(
+                target: target,
+                effectiveBitsPerSecond: harmonicMean(successful),
+                minimumBitsPerSecond: successful.first,
+                medianBitsPerSecond: median(successful),
+                sampleBitsPerSecond: successful,
+                successfulRuns: successful.count,
+                totalRuns: totalRuns
+            )
+        }.sorted { lhs, rhs in
+            let leftSuccess = lhs.successfulRuns * rhs.totalRuns
+            let rightSuccess = rhs.successfulRuns * lhs.totalRuns
+            if leftSuccess != rightSuccess { return leftSuccess > rightSuccess }
+            switch (lhs.effectiveBitsPerSecond, rhs.effectiveBitsPerSecond) {
+            case (let .some(left), let .some(right)) where left != right:
+                return left > right
+            case (.some, .none): return true
+            case (.none, .some): return false
+            default: break
+            }
+            switch (lhs.minimumBitsPerSecond, rhs.minimumBitsPerSecond) {
+            case (let .some(left), let .some(right)) where left != right:
+                return left > right
+            case (.some, .none): return true
+            case (.none, .some): return false
+            default:
+                return (order.firstIndex(of: lhs.target) ?? .max)
+                    < (order.firstIndex(of: rhs.target) ?? .max)
+            }
+        }
+    }
+
+    private func harmonicMean(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        let reciprocalSum = values.reduce(0) { $0 + 1 / $1 }
+        guard reciprocalSum.isFinite, reciprocalSum > 0 else { return nil }
+        return Double(values.count) / reciprocalSum
+    }
+
+    private func median(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        let middle = values.count / 2
+        if values.count.isMultiple(of: 2) {
+            return (values[middle - 1] + values[middle]) / 2
+        }
+        return values[middle]
+    }
+
+    private func rotated<Element>(_ values: [Element], by rawOffset: Int) -> [Element] {
+        guard !values.isEmpty else { return [] }
+        let offset = rawOffset % values.count
+        return Array(values[offset...]) + Array(values[..<offset])
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliPlayback/CDN/PlaybackSourcePreference.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/CDN/PlaybackSourcePreference.swift
@@ -1,0 +1,163 @@
+import BiliModels
+import Foundation
+
+public enum PlaybackSourceCategory: String, Sendable, Equatable, CaseIterable {
+    case akamai
+    case bilivideo
+}
+
+public enum BilivideoRoute: String, Sendable, Equatable, Hashable, CaseIterable {
+    case tencentOverseas
+    case alibabaOverseas
+    case alibabaMainland
+    case alibabaMainlandB
+    case alibabaMainlandO1
+    case tencentMainland
+    case tencentMainlandB
+    case tencentMainlandO1
+    case huaweiMainland
+    case huaweiMainlandB
+    case huaweiMainlandO1
+    case huawei08C
+    case huawei08H
+    case huawei08CT
+    case huaweiAll
+    case tencentAll
+    case baiduMainland
+    case bda2Mainland
+
+    public var displayName: String {
+        switch self {
+        case .tencentOverseas: "腾讯海外 COSOV"
+        case .alibabaOverseas: "阿里海外 ALIOV"
+        case .alibabaMainland: "阿里 ALI"
+        case .alibabaMainlandB: "阿里 ALIB"
+        case .alibabaMainlandO1: "阿里 ALIO1"
+        case .tencentMainland: "腾讯 COS"
+        case .tencentMainlandB: "腾讯 COSB"
+        case .tencentMainlandO1: "腾讯 COSO1"
+        case .huaweiMainland: "华为 HW"
+        case .huaweiMainlandB: "华为 HWB"
+        case .huaweiMainlandO1: "华为 HWO1"
+        case .huawei08C: "华为 08C"
+        case .huawei08H: "华为 08H"
+        case .huawei08CT: "华为 08CT"
+        case .huaweiAll: "华为 TF 全域"
+        case .tencentAll: "腾讯 TX 全域"
+        case .baiduMainland: "百度 BOS"
+        case .bda2Mainland: "UPCDN BDA2（大陆）"
+        }
+    }
+
+    public var host: String {
+        switch self {
+        case .tencentOverseas: "upos-sz-mirrorcosov.bilivideo.com"
+        case .alibabaOverseas: "upos-sz-mirroraliov.bilivideo.com"
+        case .alibabaMainland: "upos-sz-mirrorali.bilivideo.com"
+        case .alibabaMainlandB: "upos-sz-mirroralib.bilivideo.com"
+        case .alibabaMainlandO1: "upos-sz-mirroralio1.bilivideo.com"
+        case .tencentMainland: "upos-sz-mirrorcos.bilivideo.com"
+        case .tencentMainlandB: "upos-sz-mirrorcosb.bilivideo.com"
+        case .tencentMainlandO1: "upos-sz-mirrorcoso1.bilivideo.com"
+        case .huaweiMainland: "upos-sz-mirrorhw.bilivideo.com"
+        case .huaweiMainlandB: "upos-sz-mirrorhwb.bilivideo.com"
+        case .huaweiMainlandO1: "upos-sz-mirrorhwo1.bilivideo.com"
+        case .huawei08C: "upos-sz-mirror08c.bilivideo.com"
+        case .huawei08H: "upos-sz-mirror08h.bilivideo.com"
+        case .huawei08CT: "upos-sz-mirror08ct.bilivideo.com"
+        case .huaweiAll: "upos-tf-all-hw.bilivideo.com"
+        case .tencentAll: "upos-tf-all-tx.bilivideo.com"
+        case .baiduMainland: "upos-sz-mirrorbos.bilivideo.com"
+        case .bda2Mainland: "upos-sz-upcdnbda2.bilivideo.com"
+        }
+    }
+
+    /// 保留服务端 URL 的 scheme、path、query 与签名字节，只替换已核实的 bilivideo authority。
+    public func replacingHost(in template: URL) -> URL? {
+        guard template.scheme?.lowercased() == "https",
+            template.user == nil,
+            template.password == nil,
+            PlaybackSourceClassifier.category(for: template) == .bilivideo
+        else { return nil }
+        let original = template.absoluteString
+        guard let separator = original.range(of: "://") else { return nil }
+        let authorityStart = separator.upperBound
+        let suffixStart =
+            original[authorityStart...].firstIndex {
+                $0 == "/" || $0 == "?" || $0 == "#"
+            } ?? original.endIndex
+        return URL(string: "https://\(host)\(original[suffixStart...])")
+    }
+}
+
+public enum PlaybackSourcePreference: Sendable, Equatable {
+    case serverDefault
+    case category(PlaybackSourceCategory)
+    case experimentalBilivideoRoute(BilivideoRoute)
+}
+
+public enum PlaybackSourceClassifier {
+    public static func category(for url: URL) -> PlaybackSourceCategory? {
+        guard let host = url.host?.lowercased() else { return nil }
+        if host == "akamaized.net" || host.hasSuffix(".akamaized.net")
+            || host == "akamaihd.net" || host.hasSuffix(".akamaihd.net")
+        {
+            return .akamai
+        }
+        if host == "bilivideo.com" || host.hasSuffix(".bilivideo.com")
+            || host == "bilivideo.cn" || host.hasSuffix(".bilivideo.cn")
+        {
+            return .bilivideo
+        }
+        return nil
+    }
+}
+
+public enum PlaybackSourceOrdering {
+    public static func applying(
+        _ preference: PlaybackSourcePreference,
+        to representation: MediaRepresentation
+    ) -> MediaRepresentation {
+        guard representation.kind == .video else { return representation }
+        let original = representation.urlCandidates
+        let reordered: [URL]
+        switch preference {
+        case .serverDefault:
+            return representation
+        case .category(let category):
+            guard
+                original.contains(where: {
+                    PlaybackSourceClassifier.category(for: $0) == category
+                })
+            else { return representation }
+            reordered =
+                original.filter {
+                    PlaybackSourceClassifier.category(for: $0) == category
+                }
+                + original.filter {
+                    PlaybackSourceClassifier.category(for: $0) != category
+                }
+        case .experimentalBilivideoRoute(let route):
+            guard
+                let template = original.first(where: {
+                    PlaybackSourceClassifier.category(for: $0) == .bilivideo
+                }), let routed = route.replacingHost(in: template)
+            else { return representation }
+            reordered = [routed] + original.filter { $0 != routed }
+        }
+        guard reordered != original, let primary = reordered.first else {
+            return representation
+        }
+        return MediaRepresentation(
+            id: representation.id,
+            kind: representation.kind,
+            codecs: representation.codecs,
+            mimeType: representation.mimeType,
+            bandwidth: representation.bandwidth,
+            videoAttributes: representation.videoAttributes,
+            primaryURL: primary,
+            backupURLs: Array(reordered.dropFirst()),
+            segmentBase: representation.segmentBase
+        )
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
@@ -134,6 +134,7 @@ public final class AVPlayerEngine:
 
     private let bridge: DASHToHLSBridge
     private let subtitleUseCase: SubtitleUseCase?
+    private let sourcePreferenceProvider: @MainActor @Sendable () -> PlaybackSourcePreference
     private let eventContinuation: AsyncStream<PlayerEvent>.Continuation
     private let failureEvents: AsyncStream<PlaybackFailureEvent>
     private let failureContinuation: AsyncStream<PlaybackFailureEvent>.Continuation
@@ -155,11 +156,16 @@ public final class AVPlayerEngine:
     public init(
         player: AVPlayer = AVPlayer(),
         bridge: DASHToHLSBridge = DASHToHLSBridge(),
-        subtitleUseCase: SubtitleUseCase? = nil
+        subtitleUseCase: SubtitleUseCase? = nil,
+        sourcePreferenceProvider:
+            @escaping @MainActor @Sendable () -> PlaybackSourcePreference = {
+                .serverDefault
+            }
     ) {
         self.player = player
         self.bridge = bridge
         self.subtitleUseCase = subtitleUseCase
+        self.sourcePreferenceProvider = sourcePreferenceProvider
         if subtitleUseCase != nil {
             player.appliesMediaSelectionCriteriaAutomatically = false
         }
@@ -325,7 +331,11 @@ public final class AVPlayerEngine:
         intent: PlaybackLoadIntent,
         generation: UUID
     ) async throws {
-        let videos = try selectedVideos(for: request)
+        // 每次新 load 只在准备前读取一次；设置变化不会触碰当前 AVPlayerItem。
+        let sourcePreference = sourcePreferenceProvider()
+        let videos = try selectedVideos(for: request).map {
+            PlaybackSourceOrdering.applying(sourcePreference, to: $0)
+        }
         let audioTracks = try selectedAudioTracks(for: request)
         try Task.checkCancellation()
 

--- a/Packages/BiliKitCore/Tests/BiliAPITests/CDNBenchmarkSampleDiscovererTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/CDNBenchmarkSampleDiscovererTests.swift
@@ -1,0 +1,492 @@
+import BiliNetworking
+import Foundation
+import Testing
+
+@testable import BiliAPI
+
+@Suite(.timeLimit(.minutes(1)))
+struct CDNBenchmarkSampleDiscovererTests {
+    @Test
+    func usesAuthenticationOnlyForHighQualityPlayURLAndKeepsDiscoveryBounded() async throws {
+        let now: Int64 = 1_700_100_000
+        let rankResponse = HTTPResponse(
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"],
+            body: Data(
+                #"{"code":0,"data":{"result":[{"bvid":"BV1FixtureB2","duration":600,"senddate":1700074800,"mid":20002,"play":"50000"},{"bvid":"BV1FixtureA1","duration":300,"senddate":1700074800,"mid":10001,"play":"120"}]}}"#
+                    .utf8
+            )
+        )
+        let detailResponse = HTTPResponse(
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"],
+            body: Data(
+                #"{"code":0,"data":{"bvid":"BV1FixtureA1","cid":900001,"duration":300,"pubdate":1700074800,"tid":201,"owner":{"mid":10001}}}"#
+                    .utf8
+            )
+        )
+        let transport = DiscoveryRecordingTransport(
+            responses: [rankResponse, detailResponse, try fixtureResponse("playurl")]
+        )
+        let client = BiliAPIClient(
+            transport: transport,
+            requestAuthorizer: DiscoveryAuthorizer()
+        )
+        let discoverer = CDNBenchmarkSampleDiscoverer(
+            client: client,
+            now: { Date(timeIntervalSince1970: TimeInterval(now)) },
+            regionIDs: [201]
+        )
+
+        let samples = try await discoverer.discover()
+
+        #expect(samples.count == 1)
+        let sample = try #require(samples.first)
+        #expect(sample.videoRepresentation.kind == .video)
+        #expect(sample.mediaHeaders["Cookie"] == nil)
+        let requests = await transport.requests
+        #expect(
+            requests.map(\.url.path) == [
+                "/x/web-interface/newlist_rank",
+                "/x/web-interface/view",
+                "/x/player/playurl",
+            ]
+        )
+        #expect(requests[0].headers["Cookie"] == nil)
+        #expect(requests[1].headers["Cookie"] == nil)
+        #expect(requests[2].headers["Cookie"] == "SIGNED_IN_FIXTURE")
+        #expect(requests.allSatisfy { $0.headers["Authorization"] == nil })
+        #expect(sample.videoRepresentation.id == 64)
+        #expect(sample.videoRepresentation.bandwidth == 800_000)
+        let query = try #require(
+            URLComponents(url: requests[0].url, resolvingAgainstBaseURL: false)?.queryItems
+        )
+        #expect(query.contains(URLQueryItem(name: "order", value: "pubdate")))
+        #expect(query.contains(URLQueryItem(name: "cate_id", value: "201")))
+        #expect(query.contains(URLQueryItem(name: "page", value: "1")))
+        #expect(query.contains(URLQueryItem(name: "pagesize", value: "5")))
+        let dateFrom = try #require(query.first(where: { $0.name == "time_from" })?.value)
+        let dateTo = try #require(query.first(where: { $0.name == "time_to" })?.value)
+        #expect(dateFrom == "20231102")
+        #expect(dateTo == "20231115")
+    }
+
+    @Test
+    func cancellationStopsBeforeAnotherDiscoveryRequest() async throws {
+        let transport = BlockingDiscoveryTransport()
+        let discoverer = CDNBenchmarkSampleDiscoverer(
+            client: BiliAPIClient(
+                transport: transport,
+                requestAuthorizer: DiscoveryAuthorizer()
+            ),
+            now: Date.init,
+            regionIDs: [1, 3, 4]
+        )
+        let task = Task { try await discoverer.discover() }
+        try await waitUntil { await transport.requests.count == 1 }
+        task.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(await transport.requests.count == 1)
+    }
+
+    @Test
+    func cancellationAfterFinalPlayURLDoesNotMarkSampleAsSeen() async throws {
+        let now: Int64 = 1_700_100_000
+        let rank = jsonResponse(
+            #"{"code":0,"data":{"result":[{"bvid":"BV1FixtureA1","duration":300,"senddate":1700074800,"mid":10001,"play":120}]}}"#
+        )
+        let detail = jsonResponse(
+            #"{"code":0,"data":{"bvid":"BV1FixtureA1","cid":900001,"duration":300,"pubdate":1700074800,"tid":201,"owner":{"mid":10001}}}"#
+        )
+        let transport = CancellingFinalPlayURLTransport(
+            responses: [
+                rank, detail, try fixtureResponse("playurl"),
+                rank, detail, try fixtureResponse("playurl"),
+            ]
+        )
+        let discoverer = CDNBenchmarkSampleDiscoverer(
+            client: BiliAPIClient(
+                transport: transport,
+                requestAuthorizer: DiscoveryAuthorizer()
+            ),
+            now: { Date(timeIntervalSince1970: TimeInterval(now)) },
+            regionIDs: [201]
+        )
+
+        let cancelled = Task { try await discoverer.discover() }
+        await #expect(throws: CancellationError.self) { try await cancelled.value }
+        #expect(try await discoverer.discover().count == 1)
+    }
+
+    @Test
+    func rejectedDetailUsesNextCandidateWithoutExceedingBoundedRequestChain() async throws {
+        let now: Int64 = 1_700_100_000
+        let rank = jsonResponse(
+            #"{"code":0,"data":{"result":[{"bvid":"BV1FixtureA1","duration":300,"senddate":1700074800,"mid":10001,"play":120},{"bvid":"BV1FixtureB2","duration":360,"senddate":1700074800,"mid":10002,"play":140}]}}"#
+        )
+        let mismatchedDetail = jsonResponse(
+            #"{"code":0,"data":{"bvid":"BV1FixtureA1","cid":900001,"duration":300,"pubdate":1700074800,"tid":999,"owner":{"mid":10001}}}"#
+        )
+        let acceptedDetail = jsonResponse(
+            #"{"code":0,"data":{"bvid":"BV1FixtureB2","cid":900002,"duration":360,"pubdate":1700074800,"tid":201,"owner":{"mid":10002}}}"#
+        )
+        let transport = DiscoveryRecordingTransport(
+            responses: [
+                rank,
+                mismatchedDetail,
+                acceptedDetail,
+                try fixtureResponse("playurl"),
+            ]
+        )
+        let discoverer = CDNBenchmarkSampleDiscoverer(
+            client: BiliAPIClient(
+                transport: transport,
+                requestAuthorizer: DiscoveryAuthorizer()
+            ),
+            now: { Date(timeIntervalSince1970: TimeInterval(now)) },
+            regionIDs: [201]
+        )
+
+        let samples = try await discoverer.discover()
+
+        #expect(samples.count == 1)
+        #expect(
+            await transport.requests.map(\.url.path) == [
+                "/x/web-interface/newlist_rank",
+                "/x/web-interface/view",
+                "/x/web-interface/view",
+                "/x/player/playurl",
+            ]
+        )
+    }
+
+    @Test
+    func stopsImmediatelyAfterOneQualifiedSample() async throws {
+        let now: Int64 = 1_700_100_000
+        let rank = jsonResponse(
+            #"{"code":0,"data":{"result":[{"bvid":"BV1FixtureA1","duration":300,"senddate":1700074800,"mid":10001,"play":120},{"bvid":"BV1FixtureB2","duration":360,"senddate":1700074800,"mid":10002,"play":140}]}}"#
+        )
+        let firstDetail = jsonResponse(
+            #"{"code":0,"data":{"bvid":"BV1FixtureA1","cid":900001,"duration":300,"pubdate":1700074800,"tid":201,"owner":{"mid":10001}}}"#
+        )
+        let transport = DiscoveryRecordingTransport(
+            responses: [
+                rank,
+                firstDetail,
+                try fixtureResponse("playurl"),
+                jsonResponse(#"{"code":0,"data":{"result":[]}}"#),
+            ]
+        )
+        let discoverer = CDNBenchmarkSampleDiscoverer(
+            client: BiliAPIClient(
+                transport: transport,
+                requestAuthorizer: DiscoveryAuthorizer()
+            ),
+            now: { Date(timeIntervalSince1970: TimeInterval(now)) },
+            regionIDs: [201, 124]
+        )
+
+        let samples = try await discoverer.discover()
+
+        #expect(samples.count == 1)
+        #expect(
+            await transport.requests.map(\.url.path) == [
+                "/x/web-interface/newlist_rank",
+                "/x/web-interface/view",
+                "/x/player/playurl",
+            ]
+        )
+    }
+
+    @Test
+    func qualifiedAVCDoesNotRequireAnAudioRepresentation() async throws {
+        let now: Int64 = 1_700_100_000
+        let transport = DiscoveryRecordingTransport(
+            responses: [
+                jsonResponse(
+                    #"{"code":0,"data":{"result":[{"bvid":"BV1FixtureA1","duration":300,"senddate":1700074800,"mid":10001,"play":120}]}}"#
+                ),
+                jsonResponse(
+                    #"{"code":0,"data":{"bvid":"BV1FixtureA1","cid":900001,"duration":300,"pubdate":1700074800,"tid":201,"owner":{"mid":10001}}}"#
+                ),
+                try fixtureResponse("playurl", removesAudio: true),
+            ]
+        )
+        let discoverer = CDNBenchmarkSampleDiscoverer(
+            client: BiliAPIClient(
+                transport: transport,
+                requestAuthorizer: DiscoveryAuthorizer()
+            ),
+            now: { Date(timeIntervalSince1970: TimeInterval(now)) },
+            regionIDs: [201]
+        )
+
+        let samples = try await discoverer.discover()
+
+        #expect(samples.count == 1)
+        #expect(samples.first?.videoRepresentation.kind == .video)
+    }
+
+    @Test
+    func requestedSampleCountUsesDifferentRegionsAndUploaders() async throws {
+        let now: Int64 = 1_700_100_000
+        let firstRank = jsonResponse(
+            #"{"code":0,"data":{"result":[{"bvid":"BV1FixtureA1","duration":300,"senddate":1700074800,"mid":10001,"play":120}]}}"#
+        )
+        let secondRank = jsonResponse(
+            #"{"code":0,"data":{"result":[{"bvid":"BV1FixtureB2","duration":360,"senddate":1700074800,"mid":10002,"play":140}]}}"#
+        )
+        let transport = DiscoveryRecordingTransport(
+            responses: [
+                firstRank,
+                jsonResponse(
+                    #"{"code":0,"data":{"bvid":"BV1FixtureA1","cid":900001,"duration":300,"pubdate":1700074800,"tid":201,"owner":{"mid":10001}}}"#
+                ),
+                try fixtureResponse("playurl"),
+                secondRank,
+                jsonResponse(
+                    #"{"code":0,"data":{"bvid":"BV1FixtureB2","cid":900002,"duration":360,"pubdate":1700074800,"tid":124,"owner":{"mid":10002}}}"#
+                ),
+                try fixtureResponse("playurl"),
+            ]
+        )
+        let discoverer = CDNBenchmarkSampleDiscoverer(
+            client: BiliAPIClient(
+                transport: transport,
+                requestAuthorizer: DiscoveryAuthorizer()
+            ),
+            now: { Date(timeIntervalSince1970: TimeInterval(now)) },
+            regionIDs: [201, 124]
+        )
+
+        let samples = try await discoverer.discover(targetCount: 2)
+
+        #expect(samples.count == 2)
+        #expect(
+            await transport.requests.map(\.url.path) == [
+                "/x/web-interface/newlist_rank",
+                "/x/web-interface/view",
+                "/x/player/playurl",
+                "/x/web-interface/newlist_rank",
+                "/x/web-interface/view",
+                "/x/player/playurl",
+            ]
+        )
+    }
+
+    @Test
+    func resettingDiscoveryLifecycleAllowsTheSameAnonymousCandidateAgain() async throws {
+        let now: Int64 = 1_700_100_000
+        let rank = jsonResponse(
+            #"{"code":0,"data":{"result":[{"bvid":"BV1FixtureA1","duration":300,"senddate":1700074800,"mid":10001,"play":120}]}}"#
+        )
+        let detail = jsonResponse(
+            #"{"code":0,"data":{"bvid":"BV1FixtureA1","cid":900001,"duration":300,"pubdate":1700074800,"tid":201,"owner":{"mid":10001}}}"#
+        )
+        let transport = DiscoveryRecordingTransport(
+            responses: [
+                rank, detail, try fixtureResponse("playurl"),
+                rank, detail, try fixtureResponse("playurl"),
+            ]
+        )
+        let discoverer = CDNBenchmarkSampleDiscoverer(
+            client: BiliAPIClient(
+                transport: transport,
+                requestAuthorizer: DiscoveryAuthorizer()
+            ),
+            now: { Date(timeIntervalSince1970: TimeInterval(now)) },
+            regionIDs: [201]
+        )
+
+        #expect(try await discoverer.discover().count == 1)
+        await discoverer.resetSeenSamples()
+        #expect(try await discoverer.discover().count == 1)
+        #expect(await transport.requests.count == 6)
+    }
+
+    @Test
+    func rejectsAnonymousQualityManifestEvenWhenOriginsAreComparable() async throws {
+        let now: Int64 = 1_700_100_000
+        let transport = DiscoveryRecordingTransport(
+            responses: [
+                jsonResponse(
+                    #"{"code":0,"data":{"result":[{"bvid":"BV1FixtureA1","duration":300,"senddate":1700074800,"mid":10001,"play":120}]}}"#
+                ),
+                jsonResponse(
+                    #"{"code":0,"data":{"bvid":"BV1FixtureA1","cid":900001,"duration":300,"pubdate":1700074800,"tid":201,"owner":{"mid":10001}}}"#
+                ),
+                try fixtureResponse("playurl", promotesAVCToHighQuality: false),
+            ]
+        )
+        let discoverer = CDNBenchmarkSampleDiscoverer(
+            client: BiliAPIClient(
+                transport: transport,
+                requestAuthorizer: DiscoveryAuthorizer()
+            ),
+            now: { Date(timeIntervalSince1970: TimeInterval(now)) },
+            regionIDs: [201]
+        )
+
+        let samples = try await discoverer.discover()
+
+        #expect(samples.isEmpty)
+        #expect(await transport.requests.count == 3)
+    }
+
+    @Test
+    func missingCredentialDoesNotFallBackToAnonymousPlayURL() async throws {
+        let now: Int64 = 1_700_100_000
+        let transport = DiscoveryRecordingTransport(
+            responses: [
+                jsonResponse(
+                    #"{"code":0,"data":{"result":[{"bvid":"BV1FixtureA1","duration":300,"senddate":1700074800,"mid":10001,"play":120}]}}"#
+                ),
+                jsonResponse(
+                    #"{"code":0,"data":{"bvid":"BV1FixtureA1","cid":900001,"duration":300,"pubdate":1700074800,"tid":201,"owner":{"mid":10001}}}"#
+                ),
+                try fixtureResponse("playurl"),
+            ]
+        )
+        let discoverer = CDNBenchmarkSampleDiscoverer(
+            client: BiliAPIClient(transport: transport),
+            now: { Date(timeIntervalSince1970: TimeInterval(now)) },
+            regionIDs: [201]
+        )
+
+        await #expect(throws: BiliAPIError.authorizationRequired) {
+            try await discoverer.discover()
+        }
+        #expect(
+            await transport.requests.map(\.url.path) == [
+                "/x/web-interface/newlist_rank",
+                "/x/web-interface/view",
+            ]
+        )
+    }
+
+    private func fixtureResponse(
+        _ name: String,
+        promotesAVCToHighQuality: Bool = true,
+        removesAudio: Bool = false
+    ) throws -> HTTPResponse {
+        let url = try #require(
+            Bundle.module.url(
+                forResource: name,
+                withExtension: "json",
+                subdirectory: "Fixtures"
+            )
+        )
+        var body = try Data(contentsOf: url)
+        if name == "playurl", var text = String(data: body, encoding: .utf8) {
+            if promotesAVCToHighQuality {
+                text = text.replacingOccurrences(
+                    of: "\"id\": 32",
+                    with: "\"id\": 64"
+                ).replacingOccurrences(
+                    of: "\"bandwidth\": 500000",
+                    with: "\"bandwidth\": 800000"
+                )
+            }
+            text = text.replacingOccurrences(
+                of: "https://media.example.invalid/video-avc-primary.m4s",
+                with: "https://upos-sz-mirrorhw.bilivideo.com/video-avc-primary.m4s"
+            ).replacingOccurrences(
+                of: "https://backup.example.invalid/video-avc.m4s",
+                with: "https://upos-hz-mirrorakam.akamaized.net/video-avc.m4s"
+            )
+            body = Data(text.utf8)
+        }
+        if removesAudio,
+            var root = try JSONSerialization.jsonObject(with: body) as? [String: Any],
+            var data = root["data"] as? [String: Any],
+            var dash = data["dash"] as? [String: Any]
+        {
+            dash.removeValue(forKey: "audio")
+            data["dash"] = dash
+            root["data"] = data
+            body = try JSONSerialization.data(withJSONObject: root)
+        }
+        return HTTPResponse(
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"],
+            body: body
+        )
+    }
+
+    private func jsonResponse(_ value: String) -> HTTPResponse {
+        HTTPResponse(
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"],
+            body: Data(value.utf8)
+        )
+    }
+
+    private func waitUntil(_ condition: () async -> Bool) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while !(await condition()), clock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        #expect(await condition())
+    }
+}
+
+private actor DiscoveryRecordingTransport: HTTPTransport {
+    private var responses: [HTTPResponse]
+    private(set) var requests: [HTTPRequest] = []
+
+    init(responses: [HTTPResponse]) { self.responses = responses }
+
+    func send(_ request: HTTPRequest) async throws -> HTTPResponse {
+        requests.append(request)
+        guard !responses.isEmpty else { throw DiscoveryTransportError.noResponse }
+        return responses.removeFirst()
+    }
+}
+
+private actor BlockingDiscoveryTransport: HTTPTransport {
+    private(set) var requests: [HTTPRequest] = []
+
+    func send(_ request: HTTPRequest) async throws -> HTTPResponse {
+        requests.append(request)
+        try await Task.sleep(for: .seconds(60))
+        throw DiscoveryTransportError.noResponse
+    }
+}
+
+private actor CancellingFinalPlayURLTransport: HTTPTransport {
+    private var responses: [HTTPResponse]
+    private var didCancel = false
+
+    init(responses: [HTTPResponse]) { self.responses = responses }
+
+    func send(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard !responses.isEmpty else { throw DiscoveryTransportError.noResponse }
+        let response = responses.removeFirst()
+        if request.url.path == "/x/player/playurl", !didCancel {
+            didCancel = true
+            withUnsafeCurrentTask { $0?.cancel() }
+        }
+        return response
+    }
+}
+
+private enum DiscoveryTransportError: Error {
+    case noResponse
+}
+
+private struct DiscoveryAuthorizer: HTTPRequestAuthorizing {
+    func authorize(_ request: HTTPRequest) async throws -> HTTPRequest {
+        var headers = request.headers
+        headers["Cookie"] = "SIGNED_IN_FIXTURE"
+        return HTTPRequest(
+            url: request.url,
+            method: request.method,
+            headers: headers,
+            body: request.body
+        )
+    }
+}

--- a/Packages/BiliKitCore/Tests/BiliNetworkingTests/HTTPBoundedRangeClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliNetworkingTests/HTTPBoundedRangeClientTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import Testing
+
+@testable import BiliNetworking
+
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct HTTPBoundedRangeClientTests {
+    @Test
+    func rejectsHTTP200WithoutWaitingForDeclaredFullBodyAndCancelsTask() async throws {
+        RangeStreamingURLProtocol.state.configure(
+            statusCode: 200,
+            headers: ["Content-Length": "104857600"],
+            body: Data(repeating: 0xaa, count: 1_024),
+            keepsBodyPending: true
+        )
+        let client = makeClient()
+
+        await #expect(throws: HTTPBoundedRangeError.statusCode(200)) {
+            try await client.fetch(
+                from: URL(string: "https://cdn.example/video")!,
+                range: try HTTPByteRange(start: 0, endInclusive: 1_023),
+                headers: [:],
+                collectBody: false
+            )
+        }
+        try await waitUntil { RangeStreamingURLProtocol.state.wasStopped }
+        #expect(RangeStreamingURLProtocol.state.deliveredBodyBytes < 100 * 1_024 * 1_024)
+    }
+
+    @Test
+    func acceptsOnlyExact206ContentRangeLengthAndDiscardsBodyWhenRequested() async throws {
+        RangeStreamingURLProtocol.state.configure(
+            statusCode: 206,
+            headers: [
+                "Content-Range": "bytes 10-12/100",
+                "Content-Length": "3",
+            ],
+            body: Data([1, 2, 3]),
+            keepsBodyPending: false
+        )
+        let result = try await makeClient().fetch(
+            from: URL(string: "https://cdn.example/video")!,
+            range: try HTTPByteRange(start: 10, endInclusive: 12),
+            headers: ["Cookie": "must-not-leave", "Referer": "https://www.bilibili.com/"],
+            collectBody: false
+        )
+
+        #expect(result.byteCount == 3)
+        #expect(result.body == nil)
+        #expect(result.requestDurationSeconds > 0)
+        #expect(
+            RangeStreamingURLProtocol.state.lastRequest?.value(forHTTPHeaderField: "Range")
+                == "bytes=10-12"
+        )
+        #expect(
+            RangeStreamingURLProtocol.state.lastRequest?.value(forHTTPHeaderField: "Cookie") == nil
+        )
+    }
+
+    @Test
+    func sharedSessionAcceptsSequentialExactRanges() async throws {
+        let client = makeClient()
+        RangeStreamingURLProtocol.state.configure(
+            statusCode: 206,
+            headers: ["Content-Range": "bytes 0-2/100", "Content-Length": "3"],
+            body: Data([1, 2, 3]),
+            keepsBodyPending: false
+        )
+        let first = try await client.fetch(
+            from: URL(string: "https://cdn.example/video")!,
+            range: try HTTPByteRange(start: 0, endInclusive: 2),
+            headers: [:],
+            collectBody: false
+        )
+
+        RangeStreamingURLProtocol.state.configure(
+            statusCode: 206,
+            headers: ["Content-Range": "bytes 3-5/100", "Content-Length": "3"],
+            body: Data([4, 5, 6]),
+            keepsBodyPending: false
+        )
+        let second = try await client.fetch(
+            from: URL(string: "https://cdn.example/video")!,
+            range: try HTTPByteRange(start: 3, endInclusive: 5),
+            headers: [:],
+            collectBody: false
+        )
+        client.invalidate()
+
+        #expect(first.byteCount == 3)
+        #expect(second.byteCount == 3)
+    }
+
+    @Test
+    func rejectsMismatchedContentLengthWithoutReadingBody() async throws {
+        RangeStreamingURLProtocol.state.configure(
+            statusCode: 206,
+            headers: [
+                "Content-Range": "bytes 0-2/100",
+                "Content-Length": "4",
+            ],
+            body: Data([1, 2, 3, 4]),
+            keepsBodyPending: true
+        )
+
+        await #expect(
+            throws: HTTPBoundedRangeError.mismatchedContentLength(expected: 3, actual: 4)
+        ) {
+            try await makeClient().fetch(
+                from: URL(string: "https://cdn.example/video")!,
+                range: try HTTPByteRange(start: 0, endInclusive: 2),
+                headers: [:],
+                collectBody: true
+            )
+        }
+    }
+
+    @Test
+    func hugeRetainedRangeFailsByProtocolWithoutIntegerTrap() async throws {
+        RangeStreamingURLProtocol.state.configure(
+            statusCode: 200,
+            headers: ["Content-Length": "0"],
+            body: Data(),
+            keepsBodyPending: false
+        )
+
+        await #expect(throws: HTTPBoundedRangeError.statusCode(200)) {
+            try await makeClient().fetch(
+                from: URL(string: "https://cdn.example/video")!,
+                range: try HTTPByteRange(start: 0, endInclusive: .max),
+                headers: [:],
+                collectBody: true
+            )
+        }
+    }
+
+    private func makeClient() -> HTTPBoundedRangeClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RangeStreamingURLProtocol.self]
+        return HTTPBoundedRangeClient(
+            transport: URLSessionBoundedRangeTransport(configuration: configuration)
+        )
+    }
+
+    private func waitUntil(_ condition: () -> Bool) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while !condition(), clock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        #expect(condition())
+    }
+}
+
+private final class RangeStreamingURLProtocol: URLProtocol, @unchecked Sendable {
+    static let state = RangeStreamingURLProtocolState()
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let configuration = Self.state.begin(request: request)
+        guard let url = request.url,
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: configuration.statusCode,
+                httpVersion: "HTTP/1.1",
+                headerFields: configuration.headers
+            )
+        else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if configuration.keepsBodyPending {
+            DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(50)) {
+                [weak self] in
+                guard let self, !Self.state.wasStopped else { return }
+                Self.state.markDelivered(configuration.body.count)
+                client?.urlProtocol(self, didLoad: configuration.body)
+                client?.urlProtocolDidFinishLoading(self)
+            }
+            return
+        }
+        Self.state.markDelivered(configuration.body.count)
+        client?.urlProtocol(self, didLoad: configuration.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {
+        Self.state.markStopped()
+    }
+}
+
+private struct RangeProtocolConfiguration {
+    let statusCode: Int
+    let headers: [String: String]
+    let body: Data
+    let keepsBodyPending: Bool
+}
+
+private final class RangeStreamingURLProtocolState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var configuration = RangeProtocolConfiguration(
+        statusCode: 500,
+        headers: [:],
+        body: Data(),
+        keepsBodyPending: false
+    )
+    private var stopped = false
+    private var delivered = 0
+    private var capturedRequest: URLRequest?
+
+    var wasStopped: Bool { lock.withLock { stopped } }
+    var deliveredBodyBytes: Int { lock.withLock { delivered } }
+    var lastRequest: URLRequest? { lock.withLock { capturedRequest } }
+
+    func configure(
+        statusCode: Int,
+        headers: [String: String],
+        body: Data,
+        keepsBodyPending: Bool
+    ) {
+        lock.withLock {
+            configuration = RangeProtocolConfiguration(
+                statusCode: statusCode,
+                headers: headers,
+                body: body,
+                keepsBodyPending: keepsBodyPending
+            )
+            stopped = false
+            delivered = 0
+            capturedRequest = nil
+        }
+    }
+
+    func begin(request: URLRequest) -> RangeProtocolConfiguration {
+        lock.withLock {
+            capturedRequest = request
+            return configuration
+        }
+    }
+
+    func markStopped() { lock.withLock { stopped = true } }
+    func markDelivered(_ count: Int) { lock.withLock { delivered += count } }
+}

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/PlaybackRouteBenchmarkTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/PlaybackRouteBenchmarkTests.swift
@@ -1,0 +1,478 @@
+import BiliModels
+import BiliNetworking
+import Foundation
+import Testing
+
+@testable import BiliPlayback
+
+struct PlaybackRouteBenchmarkTests {
+    @Test
+    func routeCatalogContainsTheReviewedResolvableUPOSHosts() {
+        let expectedHosts: Set<String> = [
+            "upos-sz-mirrorali.bilivideo.com",
+            "upos-sz-mirroralib.bilivideo.com",
+            "upos-sz-mirroralio1.bilivideo.com",
+            "upos-sz-mirrorcos.bilivideo.com",
+            "upos-sz-mirrorcosb.bilivideo.com",
+            "upos-sz-mirrorcoso1.bilivideo.com",
+            "upos-sz-mirrorhw.bilivideo.com",
+            "upos-sz-mirrorhwb.bilivideo.com",
+            "upos-sz-mirrorhwo1.bilivideo.com",
+            "upos-sz-mirror08c.bilivideo.com",
+            "upos-sz-mirror08h.bilivideo.com",
+            "upos-sz-mirror08ct.bilivideo.com",
+            "upos-tf-all-hw.bilivideo.com",
+            "upos-tf-all-tx.bilivideo.com",
+            "upos-sz-mirroraliov.bilivideo.com",
+            "upos-sz-mirrorcosov.bilivideo.com",
+            "upos-sz-mirrorbos.bilivideo.com",
+            "upos-sz-upcdnbda2.bilivideo.com",
+        ]
+
+        #expect(Set(BilivideoRoute.allCases.map(\.host)) == expectedHosts)
+        #expect(!expectedHosts.contains("upos-sz-mirrorhwov.bilivideo.com"))
+    }
+
+    @Test
+    func eachRouteHasAnExactTenMiBMediaCap() {
+        let minimumCompletedBitsPerSecond =
+            Double(BilivideoRouteBenchmark.maximumMediaProbeBytes) * 8
+            / BilivideoRouteBenchmark.resourceTimeout
+        #expect(BilivideoRouteBenchmark.maximumMediaProbeBytes == 10 * 1_024 * 1_024)
+        #expect(minimumCompletedBitsPerSecond < 3_000_000)
+    }
+
+    @Test
+    func routeReplacementKeepsSignedSuffixByteForByte() throws {
+        let source = try #require(
+            URL(
+                string:
+                    "https://upos-sz-mirrorhw.bilivideo.com/upgcxcode/a%2Fb.m4s?deadline=1&token=a%2Bb%2Fz&n=hello+world"
+            )
+        )
+
+        let result = try #require(
+            BilivideoRoute.tencentOverseas.replacingHost(in: source)
+        )
+
+        #expect(result.host == BilivideoRoute.tencentOverseas.host)
+        #expect(
+            result.absoluteString
+                == "https://upos-sz-mirrorcosov.bilivideo.com/upgcxcode/a%2Fb.m4s?deadline=1&token=a%2Bb%2Fz&n=hello+world"
+        )
+    }
+
+    @Test
+    func routeReplacementRejectsAkamaiTemplate() throws {
+        let source = try #require(
+            URL(
+                string: "https://upos-hz-mirrorakam.akamaized.net/video.m4s?hdnts=secret"
+            )
+        )
+        #expect(BilivideoRoute.tencentMainland.replacingHost(in: source) == nil)
+    }
+
+    @Test
+    func manualRouteAddsExperimentalFirstAndKeepsOriginalCandidatesExact() throws {
+        let original = try makeRepresentation(includesAkamai: true)
+        let result = PlaybackSourceOrdering.applying(
+            .experimentalBilivideoRoute(.tencentOverseas),
+            to: original
+        )
+
+        #expect(result.primaryURL.host == BilivideoRoute.tencentOverseas.host)
+        #expect(Array(result.urlCandidates.dropFirst()) == original.urlCandidates)
+        #expect(result.primaryURL.path == original.primaryURL.path)
+        #expect(result.primaryURL.query == original.primaryURL.query)
+    }
+
+    @Test
+    func manualRouteDoesNotChangeAudio() throws {
+        let video = try makeRepresentation(includesAkamai: true)
+        let audio = MediaRepresentation(
+            id: video.id,
+            kind: .audio,
+            codecs: video.codecs,
+            mimeType: video.mimeType,
+            bandwidth: video.bandwidth,
+            videoAttributes: nil,
+            primaryURL: video.primaryURL,
+            backupURLs: video.backupURLs,
+            segmentBase: video.segmentBase
+        )
+        #expect(
+            PlaybackSourceOrdering.applying(
+                .experimentalBilivideoRoute(.huaweiMainland),
+                to: audio
+            ) == audio
+        )
+    }
+
+    @Test
+    func serverDefaultAndMissingCategoryKeepExactCandidateOrder() throws {
+        let original = try makeRepresentation()
+        #expect(
+            PlaybackSourceOrdering.applying(.serverDefault, to: original)
+                == original
+        )
+        #expect(
+            PlaybackSourceOrdering.applying(.category(.akamai), to: original)
+                == original
+        )
+    }
+
+    @Test
+    func originalCategoryPreferenceUsesStablePartition() throws {
+        let original = try makeRepresentation(includesAkamai: true)
+        let result = PlaybackSourceOrdering.applying(
+            .category(.akamai),
+            to: original
+        )
+        #expect(result.urlCandidates.last == original.primaryURL)
+        #expect(Set(result.urlCandidates) == Set(original.urlCandidates))
+    }
+
+    @Test
+    func unifiedPoolUsesOriginalAkamaiAndGeneratesOnlyBilivideoRoutes() async throws {
+        let fetcher = RouteBenchmarkRangeFetcher()
+        let runner = BilivideoRouteBenchmark(rangeFetcher: fetcher)
+        let representation = try makeRepresentation(includesAkamai: true)
+
+        let results = try await runner.benchmarkUnifiedPool(
+            template: representation,
+            headers: [:]
+        )
+        let calls = await fetcher.calls
+
+        let candidateCount = PlaybackRouteTarget.allCases.count
+        #expect(results.count == candidateCount)
+        #expect(calls.count == 1 + candidateCount * 4)
+        #expect(calls[0].host == "upos-sz-mirrordefault.bilivideo.com")
+        #expect(calls[1..<5].allSatisfy { $0.host == "upos-hz-mirrorakam.akamaized.net" })
+        #expect(calls.dropFirst(5).allSatisfy { $0.host.hasSuffix(".bilivideo.com") })
+        #expect(
+            calls.dropFirst().allSatisfy {
+                $0.host != "upos-sz-mirrordefault.bilivideo.com"
+            }
+        )
+    }
+
+    @Test
+    func repeatedBenchmarkAveragesSuccessfulThroughputAndExpandsProgress() async throws {
+        let fetcher = RouteBenchmarkRangeFetcher(mediaDurationsByRun: [1, 1, 3, 3])
+        let progress = RouteBenchmarkProgressRecorder()
+        let runner = BilivideoRouteBenchmark(rangeFetcher: fetcher)
+        let repetitions = 2
+
+        let results = try await runner.benchmarkUnifiedPool(
+            template: makeRepresentation(includesAkamai: true),
+            headers: [:],
+            repetitions: repetitions
+        ) { completed, total in
+            await progress.record(completed: completed, total: total)
+        }
+
+        let candidateCount = PlaybackRouteTarget.allCases.count
+        let mediaBits = Double(4 * 1_024 * 1_024) * 8
+        let expectedAverage = 2 / (1 / (mediaBits / 1) + 1 / (mediaBits / 3))
+        #expect(await fetcher.calls.count == repetitions * (1 + candidateCount * 4))
+        #expect(
+            await progress.latest == (candidateCount * repetitions, candidateCount * repetitions)
+        )
+        #expect(
+            results.allSatisfy { result in
+                result.successfulRuns == repetitions
+                    && result.totalRuns == repetitions
+                    && abs((result.effectiveBitsPerSecond ?? 0) - expectedAverage) < 0.001
+            }
+        )
+    }
+
+    @Test
+    func failedRoundIsExcludedFromAverageButKeptInSuccessCount() async throws {
+        let akamaiHost = "upos-hz-mirrorakam.akamaized.net"
+        let fetcher = RouteBenchmarkRangeFetcher(
+            mediaDurationsByRun: [1, 1, 2, 2, 3, 3],
+            failedMediaRun: (host: akamaiHost, index: 2)
+        )
+        let results = try await BilivideoRouteBenchmark(rangeFetcher: fetcher)
+            .benchmarkUnifiedPool(
+                template: makeRepresentation(includesAkamai: true),
+                headers: [:],
+                repetitions: 3
+            )
+        let result = try #require(results.first(where: { $0.target == .serverAkamai }))
+        let mediaBits = Double(4 * 1_024 * 1_024) * 8
+
+        #expect(result.target == .serverAkamai)
+        #expect(result.successfulRuns == 2)
+        #expect(result.totalRuns == 3)
+        #expect(
+            abs(
+                (result.effectiveBitsPerSecond ?? 0) - 2
+                    / (1 / (mediaBits / 1) + 1 / (mediaBits / 3))
+            )
+                < 0.001
+        )
+    }
+
+    @Test
+    func unsupportedRepetitionCountFailsBeforeNetwork() async throws {
+        let fetcher = RouteBenchmarkRangeFetcher()
+        let runner = BilivideoRouteBenchmark(rangeFetcher: fetcher)
+
+        await #expect(throws: BilivideoRouteBenchmarkError.invalidRepetitionCount(4)) {
+            try await runner.benchmarkUnifiedPool(
+                template: makeRepresentation(includesAkamai: true),
+                headers: [:],
+                repetitions: 4
+            )
+        }
+        #expect(await fetcher.calls.isEmpty)
+    }
+
+    @Test
+    func probeUsesSpreadWholeSIDXReferencesWithoutExceedingTenMiB() async throws {
+        let completeLength: Int64 = 20_000_000
+        let fetcher = RouteBenchmarkRangeFetcher(completeLength: completeLength)
+        let runner = BilivideoRouteBenchmark(rangeFetcher: fetcher)
+
+        let results = try await runner.benchmarkUnifiedPool(
+            template: makeRepresentation(includesAkamai: true),
+            headers: [:]
+        )
+        let calls = await fetcher.calls
+        let mediaCalls = calls.filter { $0.range.start >= 108 }
+        let expectedMediaRanges = [
+            try HTTPByteRange(start: 108, endInclusive: 4_194_411),
+            try HTTPByteRange(start: 8_388_716, endInclusive: 12_583_019),
+        ]
+
+        #expect(results.allSatisfy { $0.succeeded })
+        #expect(
+            mediaCalls.allSatisfy {
+                expectedMediaRanges.contains($0.range)
+                    && $0.range.length <= BilivideoRouteBenchmark.maximumMediaProbeBytes
+            }
+        )
+        for candidateIndex in PlaybackRouteTarget.allCases.indices {
+            let candidateStart = 1 + candidateIndex * 4
+            let bodyCalls = calls[(candidateStart + 1)..<(candidateStart + 4)]
+            #expect(
+                bodyCalls.map(\.range.length).reduce(0, +)
+                    <= BilivideoRouteBenchmark.maximumMediaProbeBytes
+            )
+        }
+        #expect(calls.allSatisfy { $0.range.endInclusive < completeLength })
+    }
+
+    @Test
+    func candidateWithDifferentParsedSIDXLayoutIsUnavailableBeforeMediaRequests() async throws {
+        let mismatchedHost = BilivideoRoute.huaweiMainlandB.host
+        let fetcher = RouteBenchmarkRangeFetcher(mismatchedIndexHost: mismatchedHost)
+        let runner = BilivideoRouteBenchmark(rangeFetcher: fetcher)
+
+        let results = try await runner.benchmarkUnifiedPool(
+            template: makeRepresentation(includesAkamai: true),
+            headers: [:]
+        )
+        let mismatched = results.first(where: {
+            $0.target == .bilivideo(.huaweiMainlandB)
+        })
+        let mismatchedCalls = await fetcher.calls.filter { $0.host == mismatchedHost }
+        let expectedIndexRange = try HTTPByteRange(start: 40, endInclusive: 107)
+
+        #expect(mismatched?.succeeded == false)
+        #expect(mismatchedCalls.count == 1)
+        #expect(mismatchedCalls.first?.range == expectedIndexRange)
+    }
+
+    @Test(arguments: [false, true])
+    func candidateWithDriftingCompleteLengthIsUnavailable(
+        mismatchOnlyForMedia: Bool
+    ) async throws {
+        let mismatchedHost = BilivideoRoute.huaweiMainlandB.host
+        let fetcher = RouteBenchmarkRangeFetcher(
+            mismatchedCompleteLengthHost: mismatchedHost,
+            mismatchOnlyForMedia: mismatchOnlyForMedia
+        )
+
+        let results = try await BilivideoRouteBenchmark(rangeFetcher: fetcher)
+            .benchmarkUnifiedPool(
+                template: makeRepresentation(includesAkamai: true),
+                headers: [:]
+            )
+        let result = results.first {
+            $0.target == .bilivideo(.huaweiMainlandB)
+        }
+        let calls = await fetcher.calls.filter { $0.host == mismatchedHost }
+
+        #expect(result?.succeeded == false)
+        #expect(calls.count == (mismatchOnlyForMedia ? 3 : 2))
+    }
+
+    @Test
+    func oversizedIndexIsRejectedBeforeAnyNetworkRequest() async throws {
+        let fetcher = RouteBenchmarkRangeFetcher()
+        let runner = BilivideoRouteBenchmark(rangeFetcher: fetcher)
+        let base = try makeRepresentation(includesAkamai: true)
+        let oversized = MediaRepresentation(
+            id: base.id,
+            kind: base.kind,
+            codecs: base.codecs,
+            mimeType: base.mimeType,
+            bandwidth: base.bandwidth,
+            videoAttributes: base.videoAttributes,
+            primaryURL: base.primaryURL,
+            backupURLs: base.backupURLs,
+            segmentBase: SegmentBase(
+                initialization: try MediaByteRange(start: 0, endInclusive: 39),
+                index: try MediaByteRange(
+                    start: 40,
+                    endInclusive: 40
+                        + Int64(BilivideoRouteBenchmark.maximumIndexBytes)
+                )
+            )
+        )
+
+        await #expect(throws: BilivideoRouteBenchmarkError.invalidProbeRange) {
+            try await runner.benchmarkUnifiedPool(template: oversized, headers: [:])
+        }
+        #expect(await fetcher.calls.isEmpty)
+    }
+
+    private func makeRepresentation(includesAkamai: Bool = false) throws -> MediaRepresentation {
+        let akamai = try #require(
+            URL(string: "https://upos-hz-mirrorakam.akamaized.net/video.m4s?hdnts=original")
+        )
+        return MediaRepresentation(
+            id: 80,
+            kind: .video,
+            codecs: "avc1.640028",
+            mimeType: "video/mp4",
+            bandwidth: 8_000_000,
+            videoAttributes: try VideoRepresentationAttributes(
+                width: 1_920,
+                height: 1_080,
+                frameRate: 60
+            ),
+            primaryURL: try #require(
+                URL(
+                    string:
+                        "https://upos-sz-mirrordefault.bilivideo.com/video.m4s?token=original"
+                )
+            ),
+            backupURLs: includesAkamai ? [akamai] : [],
+            segmentBase: SegmentBase(
+                initialization: try MediaByteRange(start: 0, endInclusive: 39),
+                index: try MediaByteRange(start: 40, endInclusive: 107)
+            )
+        )
+    }
+}
+
+private actor RouteBenchmarkRangeFetcher: HTTPBoundedRangeFetching {
+    private static let indexBody: Data = {
+        let hexadecimal =
+            "00000044736964780000000000000001000003e8000000000000000000000003"
+            + "00400000000007d0900000000040000000000bb81000000a"
+            + "0040000000000fa01000000a"
+        return Data(
+            stride(from: 0, to: hexadecimal.count, by: 2).compactMap { offset in
+                let start = hexadecimal.index(hexadecimal.startIndex, offsetBy: offset)
+                let end = hexadecimal.index(start, offsetBy: 2)
+                return UInt8(hexadecimal[start..<end], radix: 16)
+            }
+        )
+    }()
+
+    struct Call: Sendable {
+        let host: String
+        let range: HTTPByteRange
+    }
+
+    private(set) var calls: [Call] = []
+    private let completeLength: Int64
+    private let mismatchedIndexHost: String?
+    private let mismatchedCompleteLengthHost: String?
+    private let mismatchOnlyForMedia: Bool
+    private let mediaDurationsByRun: [Double]?
+    private let failedMediaRun: (host: String, index: Int)?
+    private var mediaRequestCounts: [String: Int] = [:]
+
+    init(
+        completeLength: Int64 = 32 * 1_024 * 1_024,
+        mismatchedIndexHost: String? = nil,
+        mismatchedCompleteLengthHost: String? = nil,
+        mismatchOnlyForMedia: Bool = false,
+        mediaDurationsByRun: [Double]? = nil,
+        failedMediaRun: (host: String, index: Int)? = nil
+    ) {
+        self.completeLength = completeLength
+        self.mismatchedIndexHost = mismatchedIndexHost
+        self.mismatchedCompleteLengthHost = mismatchedCompleteLengthHost
+        self.mismatchOnlyForMedia = mismatchOnlyForMedia
+        self.mediaDurationsByRun = mediaDurationsByRun
+        self.failedMediaRun = failedMediaRun
+    }
+
+    func fetch(
+        from url: URL,
+        range: HTTPByteRange,
+        headers: [String: String],
+        collectBody: Bool
+    ) async throws -> HTTPBoundedRangeResult {
+        let host = url.host ?? ""
+        calls.append(Call(host: host, range: range))
+        let isMedia = range.start >= 108
+        let routeIndex =
+            BilivideoRoute.allCases.firstIndex(where: {
+                $0.host == host
+            }) ?? 0
+        let requestDuration: Double
+        if isMedia, let mediaDurationsByRun, !mediaDurationsByRun.isEmpty {
+            let runIndex = mediaRequestCounts[host, default: 0]
+            mediaRequestCounts[host] = runIndex + 1
+            if failedMediaRun?.host == host, failedMediaRun?.index == runIndex {
+                throw RouteBenchmarkFixtureError.failedRound
+            }
+            requestDuration = mediaDurationsByRun[min(runIndex, mediaDurationsByRun.count - 1)]
+        } else {
+            requestDuration =
+                Double(
+                    BilivideoRoute.allCases.count - routeIndex
+                ) / 10
+        }
+        var body = Self.indexBody
+        if collectBody, host == mismatchedIndexHost {
+            body[19] = 0xe9
+        }
+        let responseCompleteLength =
+            host == mismatchedCompleteLengthHost
+                && !collectBody
+                && (isMedia || !mismatchOnlyForMedia)
+            ? completeLength + 1 : completeLength
+        return HTTPBoundedRangeResult(
+            contentRange: try HTTPContentRange(
+                start: range.start,
+                endInclusive: range.endInclusive,
+                completeLength: responseCompleteLength
+            ),
+            body: collectBody ? body : nil,
+            byteCount: range.length,
+            requestDurationSeconds: requestDuration
+        )
+    }
+}
+
+private enum RouteBenchmarkFixtureError: Error {
+    case failedRound
+}
+
+private actor RouteBenchmarkProgressRecorder {
+    private(set) var latest = (0, 0)
+
+    func record(completed: Int, total: Int) {
+        latest = (completed, total)
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -144,11 +144,27 @@ BiliKit 是 macOS-first 的原生第三方 B 站浏览与播放客户端。v1 �
 - [`validation/semantic-audio-hls-stage7-2026-08-09.md`](./validation/semantic-audio-hls-stage7-2026-08-09.md)
 - [`adr/0002-loopback-http-playback-bridge.md`](./adr/0002-loopback-http-playback-bridge.md)
 
+### 已实现、用户批准的真实大流量验收待完成：手动播放线路与测速参考
+
+- 原生设置默认保持服务端候选顺序；用户可为之后的新播放手动选择原始 Akamai、原始 bilivideo 或
+  18 条明确标注的实验 bilivideo 路线。当前 item、音频/AI 音轨、时间线、字幕、弹幕与 Now Playing
+  不受设置变化影响。
+- 实验候选只由服务端原始 bilivideo URL 替换固定 host 生成，SIDX 成功后继续沿用同一 `sourceURL`；
+  不从 Akamai 派生、不跨 CDN 拼接 Range，也不把实验线路变成播放依赖。
+- 已登录用户可显式选择 1–3 个不同分区与投稿者的匿名样本，并对 19 路严格串行测速；原始 bilivideo
+  建立独立基准，测量路线共享无凭据连接池并轮换起点。单路每样本 SIDX 上限为 256 KiB，init 与分散的
+  完整媒体片段合计最多 10 MiB，总硬上限为 195/390/585 MiB。结果按完整样本成功率、调和平均吞吐和
+  最低吞吐排序，并临时显示中位数、匿名分布及成功数；不保存、不推荐、不自动改选。
+- 自动契约与 App build 关闭后，仍需用户另行批准一次真实 19 路验收，并真人检查完成态视觉、
+  VoiceOver/FKA 与不同网络/时间/内容温度；在此之前不声称所有实验线路现场可用。
+
+决策见 [`adr/0011-explicit-playback-route-preference-and-benchmark.md`](./adr/0011-explicit-playback-route-preference-and-benchmark.md)。
+
 ## 4. 唯一当前阶段：原生播放侧栏与只读评论
 
 当前阶段在已经生产化的原生播放侧栏和真实选择链上接入只读评论。评论读取使用与其他公开
 Browse 一致的登录增强语义：本地有凭据时携带短生命周期 Cookie 取得属地等增强字段，明确
-无凭据时仍匿名读取。旧 spike 只提供性能与交互边界；生产视觉、数据状态和生命周期按当前
+无凭据时仍匿名读取。旧原型只提供性能与交互边界；生产视觉、数据状态和生命周期按当前
 AppKit 架构重写。
 
 ### 用户结果

--- a/docs/adr/0002-loopback-http-playback-bridge.md
+++ b/docs/adr/0002-loopback-http-playback-bridge.md
@@ -36,6 +36,9 @@ M1 的 DASH→HLS bridge 使用进程内 loopback HTTP server，而不是用 Res
 10. 同一 HLS AUDIO rendition group 以默认原声的 SIDX 起始时间为 canonical；按各自 timescale
     归一化后起点不一致的可选 AI 音轨在注册 route 与生成 master 前丢弃，不能把仅有菜单项
     当作同内容、可无缝切换的证明。
+11. 用户线路偏好只在新播放进入 SIDX 准备前读取一次，并只调整视频候选。实验 bilivideo 候选
+    只能由 playurl 原始 bilivideo URL 替换已核实 host 生成；一旦 SIDX 成功，记录的
+    `sourceURL` 继续作为该 representation 的 init、media 与 loopback 唯一远端来源。
 
 不使用非公开的 AVFoundation header 注入选项。若未来 Apple 提供正式、可验证的替代 API，再通过新 ADR 调整。
 

--- a/docs/adr/0011-explicit-playback-route-preference-and-benchmark.md
+++ b/docs/adr/0011-explicit-playback-route-preference-and-benchmark.md
@@ -1,0 +1,63 @@
+# ADR 0011：显式播放线路偏好与有界测速参考
+
+- 状态：已接受
+- 日期：2026-08-22
+- 关联：ADR 0002、ADR 0005、`security/M3-threat-model.md`、`security/M4-data-privacy.md`
+
+## 背景
+
+playurl 会返回多个完整媒体候选。不同网络下某一来源可能不可用或持续吞吐不足，但一次样本不能代表
+未来所有视频，播放中自动换源还会破坏同一 fMP4 的字节一致性、时间线和现有单一播放器 owner。
+因此本能力只允许用户为之后的新播放手动选择线路，并提供一次显式、有界、临时的测速参考。
+
+## 决策
+
+### 手动偏好
+
+- 原生 Settings scene 提供服务端默认、服务端原始 Akamai、服务端原始 bilivideo，以及固定的 18 条
+  实验性 bilivideo 镜像线路；默认永远是服务端顺序。
+- UserDefaults 只保存 schema version 与稳定 route identifier。未知、损坏或已删除值回退服务端默认。
+- 每次新 `AVPlayerEngine.load` 只读取一次偏好。只变换视频 representation；音频和 AI 音轨保持服务端
+  顺序。改选不重建当前 item，也不改变 timeline、seek、字幕、弹幕或 Now Playing。
+- 原始类别只稳定重排 playurl 返回的完整候选。实验线路只从原始 bilivideo 候选生成：保留 scheme、
+  path、query 与签名，只替换为 catalog 中的 bilivideo host；不从 Akamai 派生或迁移 `hdnts`。
+- 缺少所选类别或 bilivideo 模板时保持服务端顺序。实验候选 SIDX 失败后仍可回退原始完整候选；SIDX
+  成功的 `sourceURL` 继续固定给 init、media 与 loopback Range，不跨来源拼接字节。
+
+### 显式测速
+
+- 只有已登录用户在 Settings 点击后才开始。用户选择 1–3 个不同样本；匿名且有界地扫描固定分区近期
+  投稿，最多读取 40 条元数据、8 个详情和 8 个 playurl 候选，并限定不同分区与投稿者。样本必须低播放
+  量、足时长、含可消费 AVC，且同时有原始 Akamai/bilivideo；达到所需数量立即停止。测速 playurl
+  capability 只映射视频，不要求或测试音频；同一设置窗口内不重复使用已经测过的稿件。
+- Cookie 只由现有 authorizer 注入精确 `GET https://api.bilibili.com:443/x/player/playurl`；样本发现
+  元数据匿名。映射后的媒体 headers 会去除 Cookie/Authorization，媒体 client 使用 ephemeral、无
+  credential、无缓存、拒绝 redirect 的专用 session。
+- 每个样本的原始 bilivideo 先由独立 client 建立 SIDX、完整长度与可测区间基准。测试池固定为一条服务端
+  原始 Akamai 与 18 条实验 bilivideo 路线，全部共享另一个无凭据 ephemeral session；样本和路线严格
+  串行，并在不同样本轮换路线起点，避免固定顺序偏差。
+- 每条路线先读取最多 256 KiB SIDX，验证布局与完整长度，再读取 init 与至少两个完整、连续且分散选取的
+  SIDX references；单路线每个样本的 init 与媒体正文合计最多 10 MiB。每段吞吐都从请求开始计时，单个
+  样本采用最慢媒体段作为该路线的保守值。
+- 正文前必须是 206、精确 Content-Range 与精确 Content-Length。200、redirect、越界、过长、断流、
+  超时、布局漂移或取消立即停止当前请求。媒体正文只计数并立即丢弃。
+- 每个样本的硬上限为 `256 KiB + 19 × (256 KiB + 10 MiB) = 195 MiB`，UI 显示约
+  195/390/585 MiB。
+  持续吞吐使用从请求开始到精确正文完成的总耗时，因此包含连接、回源、TTFB 与传输。
+- 每条线路按完整样本成功率优先排序，再以成功样本保守值的调和平均吞吐、最低值排序；同时展示中位数、
+  匿名样本分布与成功次数/总数，吞吐保留一位小数。结果只存在于当前设置窗口；关闭、取消、登出或
+  owner 销毁会取消请求并隔离旧 generation。
+
+## 不采用
+
+- 不自动写入测速最快线路，不排序成推荐，也不做后台、定时或播放中学习。
+- 不用固定 BVID、热门样本、用户输入 BVID、无限扫描或一次样本推断未来视频。
+- 不测试音频/AI 音轨，不保存样本身份、完整 URL、query、host/IP 诊断、原始 metrics 或媒体字节。
+- 不在缓冲中重建 item，不修改 loopback 单来源契约，不增加播放器、seek/rate、Now Playing 或队列 owner。
+- 不加入实验性的持续大流量对比模式；生产测速只使用上述可证明的 195/390/585 MiB 上限。
+
+## 验证边界
+
+自动测试固定 route 存储回退、URL 变换、候选顺序、单来源固定、认证/匿名边界、19 路串行、流量上限、
+SIDX/init/分散完整 reference、严格 Range 协议、取消/generation、成功率与聚合排序及不自动改选。一次真实 19 路大流量
+验收、完成态视觉、VoiceOver/FKA 及不同网络/时间/内容温度仍须用户另行批准后执行。

--- a/docs/security/M3-threat-model.md
+++ b/docs/security/M3-threat-model.md
@@ -110,6 +110,11 @@ Apple 将 Keychain 定位为替 App 安全存储小块秘密数据的加密数�
 - Cookie 在各 API 响应边界终止。`VideoPlayback.mediaHeaders`、媒体 CDN、图片、字幕正文
   与 loopback Range server 不得得到 Cookie；登录状态变化继续关闭当前播放，不在
   当前 item 上热换授权结果。
+- 用户显式线路测速复用同一精确 playurl GET 授权边界，但缺少凭据时必须失败，且不请求 AI 音轨。
+  Cookie 在 playurl 映射边界终止；后续 SIDX/媒体 Range 由无 credential、无 Cookie、拒绝 redirect
+  的专用 ephemeral client 读取。原始 bilivideo 只由独立 client 建立结构基准，19 条测量路线共享另一
+  client 并严格串行；任何路线都必须通过自身的 SIDX 与长度校验，不采信另一 host 的响应。取消、
+  Settings 关闭、登出和 owner 销毁必须停止后续请求。
 - 同一已授权 playurl 响应中的 `last_play_cid` 与 `last_play_time` 只映射为当前进程内存中的
   断点候选；匿名 provenance 必须丢弃这两个字段。候选只能匹配已解析的正 CID，位置按毫秒
   转换并由分 P 时长裁剪；不写入本地存储，不因此增加写请求，也不向媒体链路传播账户信息。

--- a/docs/security/M4-data-privacy.md
+++ b/docs/security/M4-data-privacy.md
@@ -21,6 +21,8 @@ Cookie、token、二维码 key 和 refresh token 继续只由 `BiliAuth` 管理�
 - 切换视频/分 P、关闭详情或替换播放项目时，以 identity/generation 取消旧请求并清空呈现状态；
 - 登出时取消已授权请求并清除所有由登录态取得的内存字幕/弹幕数据；
 - UserDefaults 只允许保存字号、透明度、密度、屏蔽开关、播放器音量、静音和首选倍速等非内容偏好，不保存 BVID、CID、播放位置、正文、字幕选择或远端 URL；
+- 播放线路偏好只保存版本化的稳定 route identifier；不保存完整 URL、query、BVID/CID、标题、作者、
+  IP、Referer、测速结果或原始指标。未知 schema/route 必须回退服务端默认；
 - 日志、崩溃诊断和探针只输出阶段、状态、Content-Type、字节数、字段名、计数和非内容
   的枚举分类。AI 音轨语言目录、语义轨和系统选择结果只存在于当前播放会话内存。
 
@@ -76,6 +78,11 @@ Cookie、token、二维码 key 和 refresh token 继续只由 `BiliAuth` 管理�
   `BiliAPI` 私有 builder 限制精确 path/query、由 `BiliAuth` 独立复核 API origin 与 GET。语言目录、语言标题、所选媒体 URL
   和原始响应不持久化；多音轨只进入当前 `PlaybackManifest`、loopback routes 与同一个
   `AVPlayerItem`。系统 media selection 是当前唯一选择 UI，自定义音轨 UI 尚未加入。
+- 显式线路测速的近期投稿发现保持匿名且有界；不同分区、投稿者与当前设置窗口已测稿件的去重集合只
+  存在于 discoverer 内存，并在关闭 Settings 或账户退出时清除。只有精确 playurl GET 可通过现有
+  authorizer 得到 Cookie；该 capability 只映射视频候选，不读取音频或断点字段。原始 bilivideo 基准与
+  测量连接池使用相互独立的 ephemeral client；二者均无 Cookie/credential/cache 并拒绝 redirect。
+  Settings 关闭、取消、登出或 owner 销毁时取消，结果、样本 identity 与去重集合均不得持久化或进入日志。
 - 播放侧栏 UP 主签名只允许账户读取 `GET https://api.bilibili.com/x/web-interface/card`；query
   只能包含正 `mid` 与固定 `photo=false`。响应 `data.card.mid` 必须与请求值一致，redirect、
   HTTP／业务失败、解码失败与空白签名均只隐藏签名行。仅本地明确无凭据时匿名；凭据故障


### PR DESCRIPTION
## 变化

- 增加原生 Settings scene，提供服务端默认、原始 Akamai、原始 bilivideo 与 18 条实验性 bilivideo 手动线路；只持久化版本化稳定标识，异常值回退服务端默认。
- 每次新播放只读取一次偏好快照，仅调整视频候选；实验候选只由服务端原始 bilivideo URL 替换固定 host 生成，SIDX 成功后继续固定同一 sourceURL。
- 增加登录态显式参考测速：发现 1～3 个不同分区和投稿者的匿名低播放量样本，对原始 Akamai 与 18 条实验线路严格串行测量。
- 原始 bilivideo 使用独立 client 建立 canonical SIDX/长度基准；测量线路共享无凭据 ephemeral session，严格验证 206、Content-Range、Content-Length、完整长度与正文上限。
- 每样本硬流量上限为 195 MiB；结果按完整样本成功率、调和平均吞吐、最低吞吐排序，吞吐保留一位小数并展示成功次数、中位数和匿名分布。
- 关闭设置、取消、登出或 owner 销毁会取消请求并隔离旧 generation；多窗口认证采用 deny-wins，临时样本身份随设置窗口或账户生命周期清除。
- 同步 ADR、威胁模型、隐私边界与 ROADMAP。

## 原因

不同网络下服务端媒体候选的可用性和持续吞吐可能不同，但自动选路、播放中换源或跨 CDN 拼接 Range 会破坏 fMP4 字节一致性和当前播放器生命周期。本变更只提供未来播放的显式手动偏好和用户主动触发的有界参考，不作自动推荐或后台学习。

## 用户影响

- 默认行为保持 B 站服务端候选顺序。
- 改选只影响之后新开始的播放；当前 item、时间线、seek、字幕、弹幕、AI 音轨、Now Playing、远程控制及快捷键不变。
- 测速结果不持久化、不自动改变线路；单次约 195 MiB，最多三样本约 585 MiB。

## 实际验证

- `sh Scripts/run-quality-gates.sh app` 通过。
- Swift Package：586 项测试、59 个 suites 通过。
- 全部 BiliKitMacTests 通过；签名 Keychain smoke 按 Gate 设计跳过。
- Agent 并行审查并复核 BiliNetworking/BiliPlayback、BiliAPI/认证隐私、Settings/App 集成与 #85/#86 冲突面，最终均为 GO。
- 额外定向验证覆盖 video-only playurl、命中即停、取消与样本清理、多窗口 deny-wins、reset barrier、canonical 长度漂移、超大 Range 安全失败及单样本成功次数。

## 未覆盖边界

- 未自行运行真实 195/390/585 MiB 测速。
- 真实 19 线路可用性、完成态视觉、VoiceOver/FKA，以及不同网络、时间和内容温度仍需另行人工验收。
- 未执行下载、缓存、区域解锁、后台学习、自动选路或持续大流量对比。