### PR TITLE
feat(playback): 增加实验性响度均一化

### DIFF
--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -399,6 +399,13 @@ struct AppEnvironment {
             subtitleUseCase: SubtitleUseCase(repository: subtitleRepository),
             sourcePreferenceProvider: {
                 appSettingsModel?.playbackSourcePreference ?? .serverDefault
+            },
+            loudnessNormalizationEnabledProvider: {
+                if #available(macOS 26.0, *) {
+                    appSettingsModel?.loudnessNormalizationEnabled ?? false
+                } else {
+                    false
+                }
             }
         )
         let guestRepository = BiliGuestRepository(client: api)

--- a/BiliKitMac/Settings/AppSettingsModel.swift
+++ b/BiliKitMac/Settings/AppSettingsModel.swift
@@ -145,7 +145,22 @@ final class AppSettingsModel {
     var selection: PlaybackSourceSelection {
         get { record.selection }
         set {
-            let updated = PlaybackSourcePreferenceRecord(selection: newValue)
+            let updated = PlaybackSourcePreferenceRecord(
+                selection: newValue,
+                loudnessNormalizationEnabled: record.loudnessNormalizationEnabled
+            )
+            record = updated
+            store.save(updated)
+        }
+    }
+
+    var loudnessNormalizationEnabled: Bool {
+        get { record.loudnessNormalizationEnabled }
+        set {
+            let updated = PlaybackSourcePreferenceRecord(
+                selection: record.selection,
+                loudnessNormalizationEnabled: newValue
+            )
             record = updated
             store.save(updated)
         }

--- a/BiliKitMac/Settings/PlaybackSourcePreferenceStore.swift
+++ b/BiliKitMac/Settings/PlaybackSourcePreferenceStore.swift
@@ -1,4 +1,5 @@
 import BiliPlayback
+import CoreFoundation
 import Foundation
 
 enum PlaybackSourceSelection: String, Sendable, Equatable, CaseIterable, Identifiable {
@@ -40,8 +41,17 @@ enum PlaybackSourceSelection: String, Sendable, Equatable, CaseIterable, Identif
 }
 
 struct PlaybackSourcePreferenceRecord: Sendable, Equatable {
-    static let defaults = Self(selection: .serverDefault)
+    static let defaults = Self(selection: .serverDefault, loudnessNormalizationEnabled: false)
     let selection: PlaybackSourceSelection
+    let loudnessNormalizationEnabled: Bool
+
+    init(
+        selection: PlaybackSourceSelection,
+        loudnessNormalizationEnabled: Bool = false
+    ) {
+        self.selection = selection
+        self.loudnessNormalizationEnabled = loudnessNormalizationEnabled
+    }
 }
 
 protocol PlaybackSourcePreferenceStoring: AnyObject, Sendable {
@@ -55,6 +65,7 @@ final class UserDefaultsPlaybackSourcePreferenceStore:
     private enum Key {
         static let schema = "playbackSourcePreference.schema"
         static let selection = "playbackSourcePreference.selection"
+        static let loudnessNormalizationEnabled = "playback.loudnessNormalization.enabled"
     }
     private static let schemaVersion = 1
     private let defaults: UserDefaults
@@ -66,11 +77,29 @@ final class UserDefaultsPlaybackSourcePreferenceStore:
             let raw = defaults.string(forKey: Key.selection),
             let selection = PlaybackSourceSelection(rawValue: raw)
         else { return .defaults }
-        return PlaybackSourcePreferenceRecord(selection: selection)
+        let storedEnabled = defaults.object(
+            forKey: Key.loudnessNormalizationEnabled
+        )
+        let enabled =
+            if let number = storedEnabled as? NSNumber,
+                CFGetTypeID(number) == CFBooleanGetTypeID()
+            {
+                number.boolValue
+            } else {
+                false
+            }
+        return PlaybackSourcePreferenceRecord(
+            selection: selection,
+            loudnessNormalizationEnabled: enabled
+        )
     }
 
     func save(_ record: PlaybackSourcePreferenceRecord) {
         defaults.set(Self.schemaVersion, forKey: Key.schema)
         defaults.set(record.selection.rawValue, forKey: Key.selection)
+        defaults.set(
+            record.loudnessNormalizationEnabled,
+            forKey: Key.loudnessNormalizationEnabled
+        )
     }
 }

--- a/BiliKitMac/Settings/PlaybackSourceSettingsView.swift
+++ b/BiliKitMac/Settings/PlaybackSourceSettingsView.swift
@@ -7,6 +7,21 @@ struct PlaybackSourceSettingsView: View {
 
     var body: some View {
         Form {
+            if #available(macOS 26.0, *) {
+                Section("音频") {
+                    Toggle(
+                        "响度均一化",
+                        isOn: loudnessNormalizationEnabled
+                    )
+                    Text("实验性功能，仅适用于 macOS 26。只影响下一次新播放，当前播放不会改变或重建。")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Text("此功能依赖系统未文档化的 HLS 音频处理行为，可能随系统更新失效；失效或缺少安全元数据时保持原始响度。")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             Section("播放线路") {
                 Picker("新播放优先线路", selection: selection) {
                     ForEach(PlaybackSourceSelection.allCases) { item in
@@ -80,6 +95,13 @@ struct PlaybackSourceSettingsView: View {
 
     private var selection: Binding<PlaybackSourceSelection> {
         Binding(get: { model.selection }, set: { model.selection = $0 })
+    }
+
+    private var loudnessNormalizationEnabled: Binding<Bool> {
+        Binding(
+            get: { model.loudnessNormalizationEnabled },
+            set: { model.loudnessNormalizationEnabled = $0 }
+        )
     }
 
     private var benchmarkSampleCount: Binding<Int> {

--- a/BiliKitMacTests/PlaybackSourceSettingsTests.swift
+++ b/BiliKitMacTests/PlaybackSourceSettingsTests.swift
@@ -35,6 +35,44 @@ struct PlaybackSourceSettingsTests {
     }
 
     @Test @MainActor
+    func loudnessSettingDefaultsOffPersistsAndFallsBackOffWhenDamaged() {
+        withIsolatedDefaults { defaults in
+            let store = UserDefaultsPlaybackSourcePreferenceStore(
+                defaults: defaults
+            )
+            store.save(.defaults)
+            #expect(!store.load().loudnessNormalizationEnabled)
+
+            store.save(
+                PlaybackSourcePreferenceRecord(
+                    selection: .serverAkamai,
+                    loudnessNormalizationEnabled: true
+                )
+            )
+            #expect(store.load().loudnessNormalizationEnabled)
+            defaults.set(
+                "damaged",
+                forKey: "playback.loudnessNormalization.enabled"
+            )
+            #expect(!store.load().loudnessNormalizationEnabled)
+            #expect(store.load().selection == .serverAkamai)
+        }
+    }
+
+    @Test @MainActor
+    func loudnessSettingDoesNotRewriteCurrentPreferenceSnapshot() {
+        let store = MemoryPlaybackSourcePreferenceStore()
+        let model = makeModel(store: store)
+        let oldSnapshot = model.loudnessNormalizationEnabled
+
+        model.loudnessNormalizationEnabled = true
+
+        #expect(!oldSnapshot)
+        #expect(model.loudnessNormalizationEnabled)
+        #expect(store.load().loudnessNormalizationEnabled)
+    }
+
+    @Test @MainActor
     func trafficLimitIsDerivedFromNineteenBoundedSerialTargets() {
         let mebibyte: UInt64 = 1_024 * 1_024
         #expect(

--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
@@ -455,6 +455,7 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
             URLQueryItem(name: "fnval", value: "976"),
             URLQueryItem(name: "fnver", value: "0"),
             URLQueryItem(name: "fourk", value: "1"),
+            URLQueryItem(name: "voice_balance", value: "1"),
         ]
         let resolved: AuthorizedResponse<PlayURLPayload> =
             try await getWithAuthorizationProvenance(
@@ -484,6 +485,7 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
                 role: .original,
                 isDefault: true,
                 isAutoselect: true,
+                loudnessMetadata: payload.volume?.model,
                 representations: audio
             )
         ]
@@ -551,6 +553,7 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
                     URLQueryItem(name: "fnver", value: "0"),
                     URLQueryItem(name: "fourk", value: "1"),
                     URLQueryItem(name: "cur_language", value: languageTag),
+                    URLQueryItem(name: "voice_balance", value: "1"),
                 ],
                 referer: referer,
                 access: .accountRead(
@@ -588,6 +591,7 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
                     role: .machineGenerated,
                     isDefault: false,
                     isAutoselect: true,
+                    loudnessMetadata: payload.volume?.model,
                     representations: representations
                 )
             )

--- a/Packages/BiliKitCore/Sources/BiliAPI/Remote/PlaybackEndpointPayloads.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Remote/PlaybackEndpointPayloads.swift
@@ -4,6 +4,7 @@ import Foundation
 
 struct PlayURLPayload: Decodable, Sendable {
     let dash: DASHPayload
+    let volume: PlaybackVolumePayload?
     let currentLanguage: String?
     let currentProductionType: Int?
     let languageCatalog: AudioLanguageCatalogPayload?
@@ -12,6 +13,7 @@ struct PlayURLPayload: Decodable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case dash
+        case volume
         case currentLanguage = "cur_language"
         case currentProductionType = "cur_production_type"
         case languageCatalog = "language"
@@ -22,6 +24,7 @@ struct PlayURLPayload: Decodable, Sendable {
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         dash = try container.decode(DASHPayload.self, forKey: .dash)
+        volume = try? container.decode(PlaybackVolumePayload.self, forKey: .volume)
         currentLanguage = try? container.decode(
             String.self,
             forKey: .currentLanguage
@@ -44,6 +47,47 @@ struct PlayURLPayload: Decodable, Sendable {
             lastPlayedCID: lastPlayCID,
             positionMilliseconds: lastPlayTime
         )
+    }
+}
+
+struct PlaybackVolumePayload: Decodable, Sendable {
+    let measuredIntegrated: Double
+    let measuredLoudnessRange: Double
+    let measuredTruePeak: Double
+    let measuredThreshold: Double
+    let targetIntegrated: Double
+    let targetTruePeak: Double
+
+    private enum CodingKeys: String, CodingKey {
+        case measuredIntegrated = "measured_i"
+        case measuredLoudnessRange = "measured_lra"
+        case measuredTruePeak = "measured_tp"
+        case measuredThreshold = "measured_threshold"
+        case targetIntegrated = "target_i"
+        case targetTruePeak = "target_tp"
+    }
+
+    var model: PlaybackLoudnessMetadata? {
+        guard Self.valid(measuredIntegrated, in: -100...0),
+            Self.valid(measuredLoudnessRange, in: 0...100),
+            Self.valid(measuredTruePeak, in: -100...20),
+            Self.valid(measuredThreshold, in: -100...0),
+            Self.valid(targetIntegrated, in: -70 ... -5),
+            Self.valid(targetTruePeak, in: -20...0),
+            measuredThreshold <= measuredIntegrated
+        else { return nil }
+        return PlaybackLoudnessMetadata(
+            measuredIntegratedLUFS: measuredIntegrated,
+            measuredLoudnessRangeLU: measuredLoudnessRange,
+            measuredTruePeakDBTP: measuredTruePeak,
+            measuredThresholdLUFS: measuredThreshold,
+            targetIntegratedLUFS: targetIntegrated,
+            targetTruePeakDBTP: targetTruePeak
+        )
+    }
+
+    private static func valid(_ value: Double, in range: ClosedRange<Double>) -> Bool {
+        value.isFinite && range.contains(value)
     }
 }
 

--- a/Packages/BiliKitCore/Sources/BiliModels/Playback/PlaybackManifest.swift
+++ b/Packages/BiliKitCore/Sources/BiliModels/Playback/PlaybackManifest.swift
@@ -40,6 +40,34 @@ public enum MediaKind: String, Sendable, Equatable {
     case audio
 }
 
+/// 服务端对一条语义音轨给出的静态 BS.1770 响度测量与目标。
+///
+/// 这里不保存 endpoint 专属的 offset 或场景参数；所有值仍会在播放策略边界再次校验。
+public struct PlaybackLoudnessMetadata: Sendable, Equatable {
+    public let measuredIntegratedLUFS: Double
+    public let measuredLoudnessRangeLU: Double
+    public let measuredTruePeakDBTP: Double
+    public let measuredThresholdLUFS: Double
+    public let targetIntegratedLUFS: Double
+    public let targetTruePeakDBTP: Double
+
+    public init(
+        measuredIntegratedLUFS: Double,
+        measuredLoudnessRangeLU: Double,
+        measuredTruePeakDBTP: Double,
+        measuredThresholdLUFS: Double,
+        targetIntegratedLUFS: Double,
+        targetTruePeakDBTP: Double
+    ) {
+        self.measuredIntegratedLUFS = measuredIntegratedLUFS
+        self.measuredLoudnessRangeLU = measuredLoudnessRangeLU
+        self.measuredTruePeakDBTP = measuredTruePeakDBTP
+        self.measuredThresholdLUFS = measuredThresholdLUFS
+        self.targetIntegratedLUFS = targetIntegratedLUFS
+        self.targetTruePeakDBTP = targetTruePeakDBTP
+    }
+}
+
 public struct VideoRepresentationAttributes: Sendable, Equatable {
     public let width: Int
     public let height: Int
@@ -123,6 +151,7 @@ public struct PlaybackAudioTrack: Sendable, Equatable, Identifiable {
     public let role: Role
     public let isDefault: Bool
     public let isAutoselect: Bool
+    public let loudnessMetadata: PlaybackLoudnessMetadata?
     public let representations: [MediaRepresentation]
 
     public init(
@@ -132,6 +161,7 @@ public struct PlaybackAudioTrack: Sendable, Equatable, Identifiable {
         role: Role,
         isDefault: Bool,
         isAutoselect: Bool,
+        loudnessMetadata: PlaybackLoudnessMetadata? = nil,
         representations: [MediaRepresentation]
     ) {
         self.id = id
@@ -140,6 +170,7 @@ public struct PlaybackAudioTrack: Sendable, Equatable, Identifiable {
         self.role = role
         self.isDefault = isDefault
         self.isAutoselect = isAutoselect
+        self.loudnessMetadata = loudnessMetadata
         self.representations = representations
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Audio/LoudnessNormalizationPolicy.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Audio/LoudnessNormalizationPolicy.swift
@@ -1,0 +1,56 @@
+import BiliModels
+import Foundation
+
+/// 把一条完整语义音轨的静态响度元数据转换为透明的线性 PCM 增益。
+public struct LoudnessNormalizationPolicy: Sendable {
+    public static let maximumBoostDB = 6.0
+    public static let maximumAttenuationDB = -12.0
+
+    public init() {}
+
+    public func linearGain(for metadata: PlaybackLoudnessMetadata?) -> Float {
+        guard let metadata,
+            Self.isValid(metadata)
+        else { return 1 }
+
+        let wantedDB =
+            metadata.targetIntegratedLUFS - metadata.measuredIntegratedLUFS
+        let peakSafeDB =
+            metadata.targetTruePeakDBTP - metadata.measuredTruePeakDBTP
+        let gainDB = max(
+            min(wantedDB, peakSafeDB, Self.maximumBoostDB),
+            Self.maximumAttenuationDB
+        )
+        let gain = pow(10, gainDB / 20)
+        guard gain.isFinite, gain > 0, gain <= 2 else { return 1 }
+        return Float(gain)
+    }
+
+    private static func isValid(_ value: PlaybackLoudnessMetadata) -> Bool {
+        valid(value.measuredIntegratedLUFS, in: -100...0)
+            && valid(value.measuredLoudnessRangeLU, in: 0...100)
+            && valid(value.measuredTruePeakDBTP, in: -100...20)
+            && valid(value.measuredThresholdLUFS, in: -100...0)
+            && valid(value.targetIntegratedLUFS, in: -70 ... -5)
+            && valid(value.targetTruePeakDBTP, in: -20...0)
+            && value.measuredThresholdLUFS <= value.measuredIntegratedLUFS
+    }
+
+    private static func valid(_ value: Double, in range: ClosedRange<Double>) -> Bool {
+        value.isFinite && range.contains(value)
+    }
+}
+
+enum LoudnessNormalizationRuntimePolicy {
+    static var isSupported: Bool {
+        if #available(macOS 26.0, *) { true } else { false }
+    }
+
+    static func shouldInstall(
+        enabled: Bool,
+        hasMetadata: Bool,
+        runtimeSupportsTap: Bool = isSupported
+    ) -> Bool {
+        runtimeSupportsTap && enabled && hasMetadata
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Audio/LoudnessProcessingTap.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Audio/LoudnessProcessingTap.swift
@@ -1,0 +1,237 @@
+@preconcurrency import AVFoundation
+import AudioToolbox
+import Foundation
+import MediaToolbox
+import Synchronization
+
+final class LoudnessProcessingTap: @unchecked Sendable {
+    static let rampDurationSeconds = 0.150
+
+    private let state: State
+    private let tap: MTAudioProcessingTap
+
+    private init(state: State, tap: MTAudioProcessingTap) {
+        self.state = state
+        self.tap = tap
+    }
+
+    static func make(initialGain: Float) -> LoudnessProcessingTap? {
+        guard initialGain.isFinite, initialGain > 0 else { return nil }
+        let state = State(initialGain: initialGain)
+        let retainedState = Unmanaged.passRetained(state)
+        var callbacks = MTAudioProcessingTapCallbacks(
+            version: kMTAudioProcessingTapCallbacksVersion_0,
+            clientInfo: retainedState.toOpaque(),
+            init: { _, clientInfo, storageOut in
+                storageOut.pointee = clientInfo
+            },
+            finalize: { tap in
+                Unmanaged<State>.fromOpaque(
+                    MTAudioProcessingTapGetStorage(tap)
+                ).release()
+            },
+            prepare: { tap, _, format in
+                LoudnessProcessingTap.state(for: tap).prepare(format.pointee)
+            },
+            unprepare: { tap in
+                LoudnessProcessingTap.state(for: tap).unprepare()
+            },
+            process: process
+        )
+        var createdTap: MTAudioProcessingTap?
+        let status = MTAudioProcessingTapCreate(
+            kCFAllocatorDefault,
+            &callbacks,
+            kMTAudioProcessingTapCreationFlag_PostEffects,
+            &createdTap
+        )
+        guard status == noErr, let createdTap else {
+            retainedState.release()
+            return nil
+        }
+        return LoudnessProcessingTap(state: state, tap: createdTap)
+    }
+
+    func makeAudioMix() -> AVAudioMix {
+        let parameters = AVMutableAudioMixInputParameters()
+        parameters.audioTapProcessor = tap
+        let mix = AVMutableAudioMix()
+        mix.inputParameters = [parameters]
+        return mix
+    }
+
+    func setTargetGain(_ gain: Float) {
+        state.setTargetGain(gain)
+    }
+}
+
+extension LoudnessProcessingTap {
+    final class State: @unchecked Sendable {
+        private let targetGainBits: Atomic<UInt32>
+        private var formatIsSupported = false
+        private var sampleRate = 0.0
+        private var currentGain: Float
+        private var rampStartGain: Float
+        private var rampTargetGain: Float
+        private var rampFrameCount = 0
+        private var rampFrameIndex = 0
+
+        init(initialGain: Float) {
+            targetGainBits = Atomic(initialGain.bitPattern)
+            currentGain = initialGain
+            rampStartGain = initialGain
+            rampTargetGain = initialGain
+        }
+
+        func setTargetGain(_ gain: Float) {
+            guard gain.isFinite, gain > 0 else { return }
+            targetGainBits.store(gain.bitPattern, ordering: .releasing)
+        }
+
+        func prepare(_ format: AudioStreamBasicDescription) {
+            sampleRate = format.mSampleRate
+            let flags = format.mFormatFlags
+            let isFloat = flags & kAudioFormatFlagIsFloat != 0
+            let isBigEndian = flags & kAudioFormatFlagIsBigEndian != 0
+            let isPacked = flags & kAudioFormatFlagIsPacked != 0
+            let isNonInterleaved =
+                flags & kAudioFormatFlagIsNonInterleaved != 0
+            let expectedBytesPerFrame =
+                UInt32(MemoryLayout<Float>.size)
+                * (isNonInterleaved ? 1 : format.mChannelsPerFrame)
+            formatIsSupported =
+                format.mFormatID == kAudioFormatLinearPCM
+                && isFloat
+                && !isBigEndian
+                && isPacked
+                && format.mBitsPerChannel == 32
+                && format.mChannelsPerFrame > 0
+                && format.mFramesPerPacket == 1
+                && format.mBytesPerFrame == expectedBytesPerFrame
+                && format.mBytesPerPacket == expectedBytesPerFrame
+                && sampleRate.isFinite
+                && sampleRate > 0
+            resetToTarget()
+        }
+
+        func unprepare() {
+            formatIsSupported = false
+            sampleRate = 0
+            resetToTarget()
+        }
+
+        func resetToTarget() {
+            let target = targetGain()
+            currentGain = target
+            rampStartGain = target
+            rampTargetGain = target
+            rampFrameCount = 0
+            rampFrameIndex = 0
+        }
+
+        func process(
+            buffers: UnsafeMutablePointer<AudioBufferList>,
+            frameCount: Int,
+            discontinuity: Bool
+        ) {
+            guard formatIsSupported, frameCount > 0 else { return }
+            if discontinuity { resetToTarget() }
+
+            let target = targetGain()
+            if target != rampTargetGain {
+                rampStartGain = currentGain
+                rampTargetGain = target
+                rampFrameCount = max(
+                    1,
+                    Int(
+                        (sampleRate * LoudnessProcessingTap.rampDurationSeconds)
+                            .rounded()
+                    )
+                )
+                rampFrameIndex = 0
+            }
+
+            let bufferList = UnsafeMutableAudioBufferListPointer(buffers)
+            for frame in 0..<frameCount {
+                let gain = gainForCurrentFrame()
+                for bufferIndex in bufferList.indices {
+                    let buffer = bufferList[bufferIndex]
+                    let channels = Int(buffer.mNumberChannels)
+                    guard channels > 0, let data = buffer.mData else { continue }
+                    let availableSamples = Int(buffer.mDataByteSize) / MemoryLayout<Float>.size
+                    let firstSample = frame * channels
+                    guard firstSample >= 0,
+                        firstSample < availableSamples,
+                        channels <= availableSamples - firstSample
+                    else { continue }
+                    let samples = data.assumingMemoryBound(to: Float.self)
+                    for channel in 0..<channels {
+                        samples[firstSample + channel] *= gain
+                    }
+                }
+                advanceRamp(appliedGain: gain)
+            }
+        }
+
+        private func targetGain() -> Float {
+            Float(
+                bitPattern: targetGainBits.load(ordering: .acquiring)
+            )
+        }
+
+        private func gainForCurrentFrame() -> Float {
+            guard rampFrameCount > 0, rampFrameIndex < rampFrameCount else {
+                return rampTargetGain
+            }
+            let progress = Float(rampFrameIndex + 1) / Float(rampFrameCount)
+            return rampStartGain + (rampTargetGain - rampStartGain) * progress
+        }
+
+        private func advanceRamp(appliedGain: Float) {
+            currentGain = appliedGain
+            guard rampFrameCount > 0 else {
+                return
+            }
+            rampFrameIndex += 1
+            if rampFrameIndex >= rampFrameCount {
+                currentGain = rampTargetGain
+                rampFrameCount = 0
+                rampFrameIndex = 0
+            }
+        }
+    }
+
+    static func state(for tap: MTAudioProcessingTap) -> State {
+        Unmanaged<State>.fromOpaque(
+            MTAudioProcessingTapGetStorage(tap)
+        ).takeUnretainedValue()
+    }
+
+    static let process: MTAudioProcessingTapProcessCallback = {
+        tap,
+        requestedFrames,
+        _,
+        buffers,
+        framesOut,
+        flagsOut in
+        var sourceFlags = MTAudioProcessingTapFlags()
+        var sourceFrames = CMItemCount(0)
+        let status = MTAudioProcessingTapGetSourceAudio(
+            tap,
+            requestedFrames,
+            buffers,
+            &sourceFlags,
+            nil,
+            &sourceFrames
+        )
+        framesOut.pointee = sourceFrames
+        flagsOut.pointee = sourceFlags
+        guard status == noErr, sourceFrames > 0 else { return }
+        state(for: tap).process(
+            buffers: buffers,
+            frameCount: Int(sourceFrames),
+            discontinuity:
+                sourceFlags & kMTAudioProcessingTapFlag_StartOfStream != 0
+        )
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
@@ -120,6 +120,24 @@ struct TransportSeekOperationState: Sendable {
     }
 }
 
+struct AudioSelectionOperationState: Sendable {
+    private(set) var currentID: UUID?
+
+    mutating func begin(makeID: () -> UUID = UUID.init) -> UUID {
+        let id = makeID()
+        currentID = id
+        return id
+    }
+
+    func matches(_ id: UUID) -> Bool {
+        currentID == id
+    }
+
+    mutating func invalidate() {
+        currentID = nil
+    }
+}
+
 @MainActor
 /// AVPlayer、DASH→HLS 会话与统一播放时间线的唯一资源 owner。
 ///
@@ -135,6 +153,7 @@ public final class AVPlayerEngine:
     private let bridge: DASHToHLSBridge
     private let subtitleUseCase: SubtitleUseCase?
     private let sourcePreferenceProvider: @MainActor @Sendable () -> PlaybackSourcePreference
+    private let loudnessNormalizationEnabledProvider: @MainActor @Sendable () -> Bool
     private let eventContinuation: AsyncStream<PlayerEvent>.Continuation
     private let failureEvents: AsyncStream<PlaybackFailureEvent>
     private let failureContinuation: AsyncStream<PlaybackFailureEvent>.Continuation
@@ -152,6 +171,11 @@ public final class AVPlayerEngine:
     private var subtitleToggleOperationID: UUID?
     private var lastSubtitleSelection: NativeSubtitleSelectionPreference?
     private var transportSeek = TransportSeekOperationState()
+    private var loudnessTap: LoudnessProcessingTap?
+    private var loudnessAudioTracks: [PlaybackAudioTrack] = []
+    private var audioSelectionObserver: (any NSObjectProtocol)?
+    private var audioSelectionTask: Task<Void, Never>?
+    private var audioSelectionOperation = AudioSelectionOperationState()
 
     public init(
         player: AVPlayer = AVPlayer(),
@@ -160,12 +184,17 @@ public final class AVPlayerEngine:
         sourcePreferenceProvider:
             @escaping @MainActor @Sendable () -> PlaybackSourcePreference = {
                 .serverDefault
+            },
+        loudnessNormalizationEnabledProvider:
+            @escaping @MainActor @Sendable () -> Bool = {
+                false
             }
     ) {
         self.player = player
         self.bridge = bridge
         self.subtitleUseCase = subtitleUseCase
         self.sourcePreferenceProvider = sourcePreferenceProvider
+        self.loudnessNormalizationEnabledProvider = loudnessNormalizationEnabledProvider
         if subtitleUseCase != nil {
             player.appliesMediaSelectionCriteriaAutomatically = false
         }
@@ -193,6 +222,10 @@ public final class AVPlayerEngine:
     deinit {
         loadTask?.cancel()
         readinessTask?.cancel()
+        audioSelectionTask?.cancel()
+        if let audioSelectionObserver {
+            NotificationCenter.default.removeObserver(audioSelectionObserver)
+        }
         preparedAsset?.stop()
         if let subtitleUseCase, let subtitleIdentity {
             let previousReset = subtitleResetTask
@@ -333,6 +366,8 @@ public final class AVPlayerEngine:
     ) async throws {
         // 每次新 load 只在准备前读取一次；设置变化不会触碰当前 AVPlayerItem。
         let sourcePreference = sourcePreferenceProvider()
+        let loudnessNormalizationEnabled =
+            loudnessNormalizationEnabledProvider()
         let videos = try selectedVideos(for: request).map {
             PlaybackSourceOrdering.applying(sourcePreference, to: $0)
         }
@@ -350,6 +385,7 @@ public final class AVPlayerEngine:
         loadTask = nil
         readinessTask?.cancel()
         readinessTask = nil
+        clearLoudnessNormalization()
         preparedAsset?.stop()
         preparedAsset = nil
         player.pause()
@@ -390,6 +426,25 @@ public final class AVPlayerEngine:
             loadTask = nil
             preparedAsset = prepared
             let item = AVPlayerItem(url: prepared.url)
+            if LoudnessNormalizationRuntimePolicy.shouldInstall(
+                enabled: loudnessNormalizationEnabled,
+                hasMetadata: audioTracks.contains {
+                    $0.track.loudnessMetadata != nil
+                }
+            ),
+                let defaultTrack = audioTracks.first(where: {
+                    $0.track.isDefault
+                }),
+                let tap = LoudnessProcessingTap.make(
+                    initialGain: LoudnessNormalizationPolicy().linearGain(
+                        for: defaultTrack.track.loudnessMetadata
+                    )
+                )
+            {
+                loudnessTap = tap
+                loudnessAudioTracks = audioTracks.map(\.track)
+                item.audioMix = tap.makeAudioMix()
+            }
             player.replaceCurrentItem(with: item)
             timeline.installObservers(for: item)
             let readinessTask = Task {
@@ -403,11 +458,19 @@ public final class AVPlayerEngine:
             }
             self.readinessTask = nil
             timeline.markReady(duration: item.duration)
+            beginObservingAudioSelection(for: item, generation: generation)
+            let audioSelectionOperationID = audioSelectionOperation.begin()
+            await updateSelectedAudioGain(
+                for: item,
+                generation: generation,
+                operationID: audioSelectionOperationID
+            )
             emit(.stateChanged(.ready))
         } catch is CancellationError {
             if loadGeneration == generation {
                 loadTask = nil
                 readinessTask = nil
+                clearLoudnessNormalization()
                 activeSeekOperationID = nil
                 preparedAsset?.stop()
                 preparedAsset = nil
@@ -421,6 +484,7 @@ public final class AVPlayerEngine:
             if loadGeneration == generation {
                 loadTask = nil
                 readinessTask = nil
+                clearLoudnessNormalization()
                 activeSeekOperationID = nil
                 preparedAsset?.stop()
                 preparedAsset = nil
@@ -450,6 +514,7 @@ public final class AVPlayerEngine:
         loadTask = nil
         readinessTask?.cancel()
         readinessTask = nil
+        clearLoudnessNormalization()
         preparedAsset?.stop()
         preparedAsset = nil
         player.replaceCurrentItem(with: nil)
@@ -846,6 +911,7 @@ public final class AVPlayerEngine:
         loadTask = nil
         readinessTask?.cancel()
         readinessTask = nil
+        clearLoudnessNormalization()
         player.pause()
         player.replaceCurrentItem(with: nil)
         preparedAsset?.stop()
@@ -1029,6 +1095,7 @@ public final class AVPlayerEngine:
         loadTask = nil
         readinessTask?.cancel()
         readinessTask = nil
+        clearLoudnessNormalization()
         player.pause()
         player.replaceCurrentItem(with: nil)
         preparedAsset?.stop()
@@ -1038,6 +1105,137 @@ public final class AVPlayerEngine:
             PlaybackFailureEvent(identity: identity, intent: intent)
         )
         emit(.failed(message: "PlaybackItemFailed"))
+    }
+
+    private func beginObservingAudioSelection(
+        for item: AVPlayerItem,
+        generation: UUID
+    ) {
+        guard loudnessTap != nil else { return }
+        audioSelectionObserver = NotificationCenter.default.addObserver(
+            forName: AVPlayerItem.mediaSelectionDidChangeNotification,
+            object: item,
+            queue: .main
+        ) { [weak self, weak item] _ in
+            guard let item else { return }
+            Task { @MainActor [weak self, weak item] in
+                guard let self, let item,
+                    self.loadGeneration == generation,
+                    self.player.currentItem === item
+                else { return }
+                self.audioSelectionTask?.cancel()
+                let operationID = self.audioSelectionOperation.begin()
+                let task = Task { @MainActor [weak self, weak item] in
+                    guard let self, let item else { return }
+                    await self.updateSelectedAudioGain(
+                        for: item,
+                        generation: generation,
+                        operationID: operationID
+                    )
+                }
+                self.audioSelectionTask = task
+            }
+        }
+    }
+
+    private func updateSelectedAudioGain(
+        for item: AVPlayerItem,
+        generation: UUID,
+        operationID: UUID
+    ) async {
+        guard let loudnessTap,
+            isCurrentAudioSelectionOperation(
+                operationID,
+                generation: generation,
+                item: item,
+                tap: loudnessTap
+            )
+        else { return }
+
+        let group: AVMediaSelectionGroup?
+        do {
+            group = try await item.asset.loadMediaSelectionGroup(for: .audible)
+        } catch {
+            guard
+                isCurrentAudioSelectionOperation(
+                    operationID,
+                    generation: generation,
+                    item: item,
+                    tap: loudnessTap
+                )
+            else { return }
+            loudnessTap.setTargetGain(1)
+            return
+        }
+
+        guard
+            isCurrentAudioSelectionOperation(
+                operationID,
+                generation: generation,
+                item: item,
+                tap: loudnessTap
+            )
+        else { return }
+
+        let metadata: PlaybackLoudnessMetadata?
+        if let group,
+            let option = item.currentMediaSelection.selectedMediaOption(in: group)
+        {
+            let matches = loudnessAudioTracks.filter {
+                Self.matches($0, option: option)
+            }
+            metadata = matches.count == 1 ? matches[0].loudnessMetadata : nil
+        } else {
+            metadata = nil
+        }
+        loudnessTap.setTargetGain(
+            LoudnessNormalizationPolicy().linearGain(for: metadata)
+        )
+    }
+
+    private func isCurrentAudioSelectionOperation(
+        _ operationID: UUID,
+        generation: UUID,
+        item: AVPlayerItem,
+        tap: LoudnessProcessingTap
+    ) -> Bool {
+        !Task.isCancelled
+            && audioSelectionOperation.matches(operationID)
+            && loadGeneration == generation
+            && player.currentItem === item
+            && loudnessTap === tap
+    }
+
+    private static func matches(
+        _ track: PlaybackAudioTrack,
+        option: AVMediaSelectionOption
+    ) -> Bool {
+        let expectedLanguage = (track.languageTag ?? "und")
+            .replacingOccurrences(of: "_", with: "-")
+            .lowercased()
+        let actualLanguage = (option.locale?.identifier ?? "und")
+            .replacingOccurrences(of: "_", with: "-")
+            .lowercased()
+        let characteristic = AVMediaCharacteristic(
+            rawValue:
+                track.role == .original
+                ? "public.original-content" : "public.machine-generated"
+        )
+        return option.displayName == track.displayName
+            && actualLanguage == expectedLanguage
+            && option.hasMediaCharacteristic(characteristic)
+    }
+
+    private func clearLoudnessNormalization() {
+        audioSelectionTask?.cancel()
+        audioSelectionTask = nil
+        audioSelectionOperation.invalidate()
+        if let audioSelectionObserver {
+            NotificationCenter.default.removeObserver(audioSelectionObserver)
+        }
+        audioSelectionObserver = nil
+        loudnessAudioTracks = []
+        loudnessTap = nil
     }
 
     private func invalidateTransportSeek() {

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
@@ -1,9 +1,10 @@
-import BiliAPI
 import BiliApplication
 import BiliModels
 import BiliNetworking
 import Foundation
 import Testing
+
+@testable import BiliAPI
 
 struct BiliAPIClientTests {
     @Test
@@ -870,6 +871,103 @@ struct BiliAPIClientTests {
         #expect(queryItems?.contains(URLQueryItem(name: "fnval", value: "976")) == true)
         #expect(queryItems?.contains(URLQueryItem(name: "fourk", value: "1")) == true)
         #expect(queryItems?.contains(URLQueryItem(name: "cid", value: "900001")) == true)
+        #expect(
+            queryItems?.contains(
+                URLQueryItem(name: "voice_balance", value: "1")
+            ) == true
+        )
+    }
+
+    @Test
+    func playURLBindsLoudnessMetadataToEachSemanticTrackResponse() async throws {
+        let originalVolume = loudnessVolume(measuredI: -20, measuredTP: -4)
+        let aiVolume = loudnessVolume(measuredI: -11, measuredTP: -0.5)
+        let transport = RecordingTransport(
+            responses: [
+                try semanticAudioResponse(
+                    audioPath: "original-audio.m4s",
+                    languageCatalog: [
+                        "support": true,
+                        "items": [
+                            [
+                                "lang": "en",
+                                "title": "English（AI）",
+                                "production_type": 2,
+                            ],
+                            [
+                                "lang": "ja",
+                                "title": "日本語（AI）",
+                                "production_type": 2,
+                            ],
+                        ],
+                    ],
+                    volume: originalVolume
+                ),
+                try semanticAudioResponse(
+                    audioPath: "ai-en-audio.m4s",
+                    currentLanguage: "en",
+                    currentProductionType: 2,
+                    volume: aiVolume
+                ),
+                try semanticAudioResponse(
+                    audioPath: "ai-ja-audio.m4s",
+                    currentLanguage: "ja",
+                    currentProductionType: 2
+                ),
+            ]
+        )
+        let client = BiliAPIClient(
+            transport: transport,
+            requestAuthorizer: RecordingRequestAuthorizer()
+        )
+
+        let playback = try await client.playback(
+            for: "BV1FixtureA1",
+            cid: 900_001
+        )
+
+        #expect(playback.manifest.audioTracks.count == 3)
+        let original = playback.manifest.audioTracks[0]
+        let englishAI = playback.manifest.audioTracks[1]
+        let japaneseAI = playback.manifest.audioTracks[2]
+        #expect(original.loudnessMetadata?.measuredIntegratedLUFS == -20)
+        #expect(englishAI.loudnessMetadata?.measuredIntegratedLUFS == -11)
+        #expect(japaneseAI.loudnessMetadata == nil)
+        #expect(original.loudnessMetadata != englishAI.loudnessMetadata)
+        let requests = await transport.capturedRequests()
+        #expect(
+            requests.allSatisfy { request in
+                URLComponents(
+                    url: request.url,
+                    resolvingAgainstBaseURL: false
+                )?.queryItems?.contains(
+                    URLQueryItem(name: "voice_balance", value: "1")
+                ) == true
+            }
+        )
+    }
+
+    @Test(arguments: [
+        #"{"measured_i":-20,"measured_lra":3,"measured_tp":-4,"measured_threshold":-30,"target_i":-14,"target_tp":-1}"#,
+        #"{"measured_i":-20,"measured_lra":3,"measured_tp":-4,"measured_threshold":-30,"target_i":-14}"#,
+        #"{"measured_i":null,"measured_lra":3,"measured_tp":-4,"measured_threshold":-30,"target_i":-14,"target_tp":-1}"#,
+        #"{"measured_i":"bad","measured_lra":3,"measured_tp":-4,"measured_threshold":-30,"target_i":-14,"target_tp":-1}"#,
+        #"{"measured_i":-200,"measured_lra":3,"measured_tp":-4,"measured_threshold":-30,"target_i":-14,"target_tp":-1}"#,
+        #"{"measured_i":1e400,"measured_lra":3,"measured_tp":-4,"measured_threshold":-30,"target_i":-14,"target_tp":-1}"#,
+    ])
+    func loudnessPayloadRequiresACompleteFiniteBoundedGroup(_ source: String) {
+        let payload = try? JSONDecoder().decode(
+            PlaybackVolumePayload.self,
+            from: Data(source.utf8)
+        )
+
+        if source.hasPrefix(#"{"measured_i":-20,"#)
+            && source.contains(#""target_tp":-1"#)
+        {
+            #expect(payload?.model?.measuredIntegratedLUFS == -20)
+        } else {
+            #expect(payload?.model == nil)
+        }
     }
 
     @Test
@@ -1768,7 +1866,8 @@ struct BiliAPIClientTests {
         audioPath: String,
         languageCatalog: [String: Any]? = nil,
         currentLanguage: String? = nil,
-        currentProductionType: Int? = nil
+        currentProductionType: Int? = nil,
+        volume: [String: Any]? = nil
     ) throws -> HTTPResponse {
         var data: [String: Any] = [
             "dash": [
@@ -1817,6 +1916,9 @@ struct BiliAPIClientTests {
         if let currentProductionType {
             data["cur_production_type"] = currentProductionType
         }
+        if let volume {
+            data["volume"] = volume
+        }
         return HTTPResponse(
             statusCode: 200,
             headers: ["Content-Type": "application/json"],
@@ -1825,6 +1927,22 @@ struct BiliAPIClientTests {
                 options: [.sortedKeys]
             )
         )
+    }
+
+    private func loudnessVolume(
+        measuredI: Double,
+        measuredTP: Double
+    ) -> [String: Any] {
+        [
+            "measured_i": measuredI,
+            "measured_lra": 3,
+            "measured_tp": measuredTP,
+            "measured_threshold": measuredI - 10,
+            "target_i": -14,
+            "target_tp": -1,
+            "target_offset": 99,
+            "multi_scene_args": "ignored",
+        ]
     }
 }
 

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/AVPlayerTimelineAdapterTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/AVPlayerTimelineAdapterTests.swift
@@ -119,6 +119,23 @@ struct AVPlayerTimelineAdapterTests {
     }
 
     @Test
+    func audioSelectionOperationRejectsCancelledOrReplacedWork() {
+        var state = AudioSelectionOperationState()
+        let firstID = UUID()
+        let replacementID = UUID()
+
+        let first = state.begin { firstID }
+        #expect(state.matches(first))
+
+        let replacement = state.begin { replacementID }
+        #expect(!state.matches(first))
+        #expect(state.matches(replacement))
+
+        state.invalidate()
+        #expect(!state.matches(replacement))
+    }
+
+    @Test
     @MainActor
     func completedTransportSeekAdvancesDiscontinuityWithoutResuming() {
         let player = AVPlayer()

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoudnessNormalizationPolicyTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoudnessNormalizationPolicyTests.swift
@@ -1,0 +1,224 @@
+import AudioToolbox
+import Foundation
+import Testing
+
+@testable import BiliModels
+@testable import BiliPlayback
+
+struct LoudnessNormalizationPolicyTests {
+    private let policy = LoudnessNormalizationPolicy()
+
+    @Test
+    func appliesLoudnessDifferenceAndDBConversion() {
+        let gain = policy.linearGain(
+            for: metadata(measuredI: -17, measuredTP: -5)
+        )
+
+        #expect(abs(gain - Float(pow(10, 3.0 / 20))) < 0.0001)
+    }
+
+    @Test
+    func truePeakAndProductCapsConstrainBoost() {
+        let peakLimited = policy.linearGain(
+            for: metadata(measuredI: -30, measuredTP: -2)
+        )
+        let productLimited = policy.linearGain(
+            for: metadata(measuredI: -30, measuredTP: -20)
+        )
+
+        #expect(abs(peakLimited - Float(pow(10, 1.0 / 20))) < 0.0001)
+        #expect(abs(productLimited - Float(pow(10, 6.0 / 20))) < 0.0001)
+    }
+
+    @Test
+    func attenuationCapAndInvalidMetadataFallBackSafely() {
+        let attenuated = policy.linearGain(
+            for: metadata(measuredI: -1, measuredTP: -20)
+        )
+        let invalid = PlaybackLoudnessMetadata(
+            measuredIntegratedLUFS: .nan,
+            measuredLoudnessRangeLU: 3,
+            measuredTruePeakDBTP: -2,
+            measuredThresholdLUFS: -30,
+            targetIntegratedLUFS: -14,
+            targetTruePeakDBTP: -1
+        )
+
+        #expect(abs(attenuated - Float(pow(10, -12.0 / 20))) < 0.0001)
+        #expect(policy.linearGain(for: invalid) == 1)
+        #expect(policy.linearGain(for: nil) == 1)
+    }
+
+    @Test
+    func runtimePolicyRequiresMacOS26SettingAndMetadata() {
+        #expect(
+            !LoudnessNormalizationRuntimePolicy.shouldInstall(
+                enabled: true,
+                hasMetadata: true,
+                runtimeSupportsTap: false
+            )
+        )
+        #expect(
+            !LoudnessNormalizationRuntimePolicy.shouldInstall(
+                enabled: false,
+                hasMetadata: true,
+                runtimeSupportsTap: true
+            )
+        )
+        #expect(
+            !LoudnessNormalizationRuntimePolicy.shouldInstall(
+                enabled: true,
+                hasMetadata: false,
+                runtimeSupportsTap: true
+            )
+        )
+        #expect(
+            LoudnessNormalizationRuntimePolicy.shouldInstall(
+                enabled: true,
+                hasMetadata: true,
+                runtimeSupportsTap: true
+            )
+        )
+    }
+
+    @Test
+    func float32ProcessorHandlesInterleavedAndBoundedBuffers() {
+        let state = LoudnessProcessingTap.State(initialGain: 2)
+        state.prepare(floatFormat(sampleRate: 10, channels: 2, interleaved: true))
+        var samples: [Float] = [1, -1, 0.5, -0.5, 7]
+        samples.withUnsafeMutableBytes { bytes in
+            var bufferList = AudioBufferList(
+                mNumberBuffers: 1,
+                mBuffers: AudioBuffer(
+                    mNumberChannels: 2,
+                    mDataByteSize: 4 * UInt32(MemoryLayout<Float>.size),
+                    mData: bytes.baseAddress
+                )
+            )
+            state.process(buffers: &bufferList, frameCount: 3, discontinuity: false)
+        }
+
+        #expect(samples == [2, -2, 1, -1, 7])
+    }
+
+    @Test
+    func float32ProcessorHandlesNonInterleavedRampAndUnsupportedFormat() {
+        let state = LoudnessProcessingTap.State(initialGain: 1)
+        state.prepare(floatFormat(sampleRate: 10, channels: 2, interleaved: false))
+        state.setTargetGain(2)
+        var left: [Float] = [1, 1]
+        var right: [Float] = [1, 1]
+        withUnsafeMutablePointer(to: &left) { leftArray in
+            withUnsafeMutablePointer(to: &right) { rightArray in
+                leftArray.pointee.withUnsafeMutableBytes { leftBytes in
+                    rightArray.pointee.withUnsafeMutableBytes { rightBytes in
+                        let size =
+                            MemoryLayout<AudioBufferList>.size
+                            + MemoryLayout<AudioBuffer>.size
+                        let storage = UnsafeMutableRawPointer.allocate(
+                            byteCount: size,
+                            alignment: MemoryLayout<AudioBufferList>.alignment
+                        )
+                        defer { storage.deallocate() }
+                        let list = storage.assumingMemoryBound(
+                            to: AudioBufferList.self
+                        )
+                        list.pointee.mNumberBuffers = 2
+                        let buffers = UnsafeMutableAudioBufferListPointer(list)
+                        buffers[0] = AudioBuffer(
+                            mNumberChannels: 1,
+                            mDataByteSize: UInt32(leftBytes.count),
+                            mData: leftBytes.baseAddress
+                        )
+                        buffers[1] = AudioBuffer(
+                            mNumberChannels: 1,
+                            mDataByteSize: UInt32(rightBytes.count),
+                            mData: rightBytes.baseAddress
+                        )
+                        state.process(
+                            buffers: list,
+                            frameCount: 2,
+                            discontinuity: false
+                        )
+                    }
+                }
+            }
+        }
+        #expect(abs(left[0] - 1.5) < 0.001)
+        #expect(left == right)
+
+        let unsupported = LoudnessProcessingTap.State(initialGain: 2)
+        var format = floatFormat(sampleRate: 10, channels: 1, interleaved: true)
+        format.mBitsPerChannel = 16
+        unsupported.prepare(format)
+        var untouched: [Float] = [1]
+        untouched.withUnsafeMutableBytes { bytes in
+            var list = AudioBufferList(
+                mNumberBuffers: 1,
+                mBuffers: AudioBuffer(
+                    mNumberChannels: 1,
+                    mDataByteSize: UInt32(bytes.count),
+                    mData: bytes.baseAddress
+                )
+            )
+            unsupported.process(buffers: &list, frameCount: 1, discontinuity: false)
+        }
+        #expect(untouched == [1])
+    }
+
+    @Test
+    func discontinuityResetsAnInFlightRampToTheLatestTarget() {
+        let state = LoudnessProcessingTap.State(initialGain: 1)
+        state.prepare(floatFormat(sampleRate: 48_000, channels: 1, interleaved: true))
+        state.setTargetGain(2)
+        var samples: [Float] = [1]
+        samples.withUnsafeMutableBytes { bytes in
+            var list = AudioBufferList(
+                mNumberBuffers: 1,
+                mBuffers: AudioBuffer(
+                    mNumberChannels: 1,
+                    mDataByteSize: UInt32(bytes.count),
+                    mData: bytes.baseAddress
+                )
+            )
+            state.process(buffers: &list, frameCount: 1, discontinuity: true)
+        }
+
+        #expect(samples == [2])
+    }
+
+    private func metadata(
+        measuredI: Double,
+        measuredTP: Double
+    ) -> PlaybackLoudnessMetadata {
+        PlaybackLoudnessMetadata(
+            measuredIntegratedLUFS: measuredI,
+            measuredLoudnessRangeLU: 3,
+            measuredTruePeakDBTP: measuredTP,
+            measuredThresholdLUFS: min(measuredI - 10, -10),
+            targetIntegratedLUFS: -14,
+            targetTruePeakDBTP: -1
+        )
+    }
+
+    private func floatFormat(
+        sampleRate: Double,
+        channels: UInt32,
+        interleaved: Bool
+    ) -> AudioStreamBasicDescription {
+        AudioStreamBasicDescription(
+            mSampleRate: sampleRate,
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags:
+                kAudioFormatFlagIsFloat
+                | kAudioFormatFlagIsPacked
+                | (interleaved ? 0 : kAudioFormatFlagIsNonInterleaved),
+            mBytesPerPacket: 4 * (interleaved ? channels : 1),
+            mFramesPerPacket: 1,
+            mBytesPerFrame: 4 * (interleaved ? channels : 1),
+            mChannelsPerFrame: channels,
+            mBitsPerChannel: 32,
+            mReserved: 0
+        )
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # BiliKit macOS 路线图
 
-> 更新时间：2026-08-09。本文只描述本分支合并后 `main` 的产品基线、产品大方向和唯一已选择的
+> 更新时间：2026-08-22。本文只描述本分支合并后 `main` 的产品基线、产品大方向和唯一已选择的
 > 后续阶段。
 > 完成状态以当前代码、自动测试和必要的真实行为证据共同判断；旧计划、分支、worktree、
 > checkpoint、测试数量和 CI run ID 不构成现行契约。
@@ -33,8 +33,10 @@ BiliKit 是 macOS-first 的原生第三方 B 站浏览与播放客户端。v1 �
 - 播放链路包含 DASH 到本机 loopback HLS bridge、单一 AVPlayer host、统一播放时间线、
   语义音轨、系统原生字幕与弹幕；HLS master 会保守发布已解析的音视频格式、语言、角色、
   closed-captions、independent-segments 与按需 I-frame metadata。
+- macOS 26 可在设置中为之后新播放显式开启实验性静态响度均一化；默认关闭，macOS 15 保持无 tap
+  的 unity 路径。该能力依赖未文档化 HLS Processing Tap 行为，边界见 ADR 0012。
 
-模块与依赖的持久约束见 ADR 0001–0009。当前 target、product 和 entitlement 必须以
+模块与依赖的持久约束见 ADR 0001–0012。当前 target、product 和 entitlement 必须以
 `Packages/BiliKitCore/Package.swift` 与 Xcode 工程为准。
 
 ## 3. 工程能力状态

--- a/docs/adr/0012-experimental-macos26-loudness-normalization.md
+++ b/docs/adr/0012-experimental-macos26-loudness-normalization.md
@@ -1,0 +1,34 @@
+# ADR 0012：仅 macOS 26 提供实验性静态响度均一化
+
+- 状态：Conditional GO
+- 日期：2026-08-22
+- 关联：ADR 0002、ADR 0011、`security/playback-loudness-normalization.md`
+
+## 背景
+
+UGC playurl 在请求 `voice_balance=1` 后可能为当前 CID 与语义音轨响应返回完整的 integrated loudness、
+LRA、true peak、threshold 与服务端 target。macOS 26 arm64 的真实运行验证表明，现有
+`DASHToHLSBridge → loopback HLS → AVPlayerItem` 可通过无显式 track 的 post-effects
+`MTAudioProcessingTap` 修改 Float32 PCM；macOS 15.7.7 x86_64 上同一入口不会进入 prepare/process。
+Apple 也没有文档承诺 HLS 支持 Processing Tap。
+
+## 决策
+
+- 功能仅在 macOS 26 显示和运行，标记为实验性且默认关闭。设置只在下一次新播放开始时读取一次；
+  macOS 15 即使存储中存在开启值，也不创建或安装 tap。
+- BiliAPI 仅为 UGC original 与每个 AI/语言 playurl 请求加入 `voice_balance=1`。每个响应的完整有效
+  metadata 只绑定自己的语义音轨；同轨码率 representation 可共享，不跨语义音轨复用。
+- 策略使用服务端 target，按 `min(targetI-measuredI, targetTP-measuredTP, +6 dB)` 计算，再以
+  `-12 dB` 保护衰减下限并转换为 `10^(dB/20)`。不使用 `target_offset`，不加入 limiter、compressor、
+  实时测量或 target slider。
+- 唯一 `AVPlayerEngine` 在替换新 item 前安装一个 tap，首帧直接使用默认语义音轨 gain；语义音轨切换
+  只更新该 tap 的原子 target，并在实时线程内做约 150 ms 线性 ramp。用户 volume/mute 仍由现有
+  `AVPlayer` 与 `PlaybackPreferencesController` 管理，不写回 normalization gain。
+- 缺少/异常 metadata、true-peak 无法验证、音轨无法唯一映射、tap 创建失败或系统从未调用
+  prepare/process 时均保持 unity，播放本身不得失败、静音或重建 item。
+
+## 约束与证据边界
+
+Processing Tap 的 HLS 接入是 macOS 26 当前实现行为，不是 Apple 的公开保证。未进入 callback 只能表现为
+静默 unity，产品无法可靠宣称检测到了所有系统失效。未来系统更新必须重新验证；macOS 15 永远走无 tap
+路径。PGC、Dolby、FLAC、第二音频管线、私有 API、下载/预扫和输出设备级 DSP 不在本决策范围。

--- a/docs/security/playback-loudness-normalization.md
+++ b/docs/security/playback-loudness-normalization.md
@@ -1,0 +1,25 @@
+# 播放响度均一化安全边界
+
+## 数据与验证
+
+- playurl `volume` 只作可选解码；六个必要数值必须完整、有限且在保守范围内，否则整组丢弃。
+- `PlaybackLoudnessMetadata` 只保存策略所需的 measured integrated/LRA/true peak/threshold 与 target
+  integrated/true peak。不得保存 `target_offset`、`multi_scene_args`、原始响应、Cookie、完整 URL/query、
+  BVID/CID、标题或样本身份。
+- metadata 属于当前 CID 的当前语义音轨响应。original、AI 与语言轨不能互相借用；无法唯一映射即 unity。
+
+## 播放与实时线程
+
+- macOS 26 且新 load 的设置快照开启时才可能安装 tap；macOS 15 不安装。tap 工厂失败、格式不匹配或
+  callback 未触发都不能阻止播放。
+- process callback 只读取固定内存/原子值并原位乘 Float32 PCM；不得分配、阻塞、记录日志、发起 Task、
+  actor hop、加锁、访问网络或查找业务模型。AudioBufferList 必须按每个 buffer 的真实 byte size 限界。
+- prepare 与 start-of-stream discontinuity 重置 ramp；item/generation 替换、retry、stop、failure 与返回
+  页面必须移除 observer、取消选择任务并释放旧 tap，旧状态不得更新新 item。
+- gain 不进入 `AVPlayer.volume`、用户偏好、系统音量、日志或设置。mute 与用户音量保持既有语义。
+
+## 平台声明
+
+无显式 HLS track 的 Processing Tap 不是 Apple 文档保证。macOS 26 的成功只能证明当前已验证环境可运行；
+未 prepare/process 不能被当作“已检测全部失效”。设置文案必须持续声明实验性、仅 macOS 26、可能随系统
+更新失效，以及下一次新播放生效。


### PR DESCRIPTION
## 变化

- 为 UGC original 与每条 AI/语言 playurl 请求加入 voice_balance=1，并将严格校验后的静态响度 metadata 绑定到各自语义音轨。
- 在 BiliPlayback 增加纯响度策略与单一 Float32 Processing Tap：使用服务端 target、true-peak 约束、+6 dB boost 上限与 -12 dB attenuation 下限；语义音轨切换以约 150 ms ramp 更新同一个 tap。
- 复用现有 AVPlayerEngine 生命周期和 AppSettingsModel；macOS 26 设置页提供默认关闭的实验性开关，设置只影响下一次新播放。macOS 15 不显示开关且不安装 tap。
- 加入 operation/generation/item/tap identity 隔离，防止快速连续切轨时旧异步结果覆盖当前 gain。
- 新增 API、策略、PCM buffer、设置与 stale-operation 测试，并记录 ADR、安全边界与 ROADMAP 状态。

## 原因

不同视频、分 P 与语义音轨的 integrated loudness 可能显著不同。服务端可选 volume metadata 与 macOS 26 当前可运行的 HLS Processing Tap 行为允许在不改变用户音量、不引入第二播放器和不做动态压缩的前提下提供静态均一化。由于 Apple 未文档承诺 HLS tap，该能力保持 Conditional GO、实验性且默认关闭。

## 用户影响

macOS 26 用户可在设置的音频 section 开启响度均一化；开关仅影响之后新开始的播放。缺少或异常 metadata、音轨无法唯一映射、tap 创建/格式/callback 不可用时保持原始响度，播放不失败或重建。用户 volume、mute、方向键反馈、Now Playing、远程命令、seek/rate、PiP、字幕、弹幕和 CDN 线路语义保持不变。macOS 15 行为不变。

## 验证

- [x] 唯一最高适用 Gate（app；实际命令：DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer sh Scripts/run-quality-gates.sh app）
  - static/architecture/security/format 与 git diff 检查通过
  - Package：596 tests / 60 suites 通过
  - App build-for-testing 与 BiliKitMacTests 通过
- [x] 必要的真实 UI、签名、网络或性能检查
  - Apple Development 签名链、Bundle ID 与 Team 校验通过；最终签名 App 可启动到主窗口
  - macOS 26 设置开关可见且默认关闭，CDN 设置共存
  - 开启后真实远端新播放进入 LoudnessProcessingTap callback；覆盖 Space、±5 秒 seek、用户音量、PiP、A→B、返回/stop，返回后旧 tap 不再执行
  - 用户完成最终 App 检查后未发现问题

## 未覆盖边界

- HLS Processing Tap 是 macOS 26 当前未文档化实现行为；callback 未进入只能静默 unity，无法宣称检测所有系统失效。
- 本轮最终 production 签名构建未单独重跑真实多语义音轨快速切换与物理长按 0.5×/2×；自动测试固定 stale-operation，既有 owner 测试覆盖长短按互斥。
- 未覆盖扬声器实际输出电平与真人听感 A/B、macOS 26 Intel、更多 PGC/Dolby/FLAC/AI/账号/地区组合和未来系统更新。