### PR TITLE
fix(playback): 防止视频播放时显示器休眠

### DIFF
--- a/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
+++ b/Packages/BiliKitCore/Sources/BiliPlayback/Player/AVPlayerEngine.swift
@@ -191,6 +191,7 @@ public final class AVPlayerEngine:
             }
     ) {
         self.player = player
+        player.preventsDisplaySleepDuringVideoPlayback = true
         self.bridge = bridge
         self.subtitleUseCase = subtitleUseCase
         self.sourcePreferenceProvider = sourcePreferenceProvider


### PR DESCRIPTION
## 变化

- 在现有唯一 `AVPlayer` 初始化时显式设置 `preventsDisplaySleepDuringVideoPlayback = true`。
- 不增加 `NSProcessInfo` activity、IOPMAssertion 或第二套播放 owner。

## 原因

macOS 上该属性默认是 `false`。显式启用后，AVPlayer 可在实际视频播放期间阻止因用户空闲导致的显示器睡眠。

## 用户影响

视频实际播放时，长时间没有鼠标或键盘输入不再因 User Idle Display Sleep 关闭显示器。用户主动锁屏、合盖、系统安全策略及其他 forced sleep 不受影响。

## 验证

- `sh Scripts/run-quality-gates.sh package`
- 586 个 Swift Testing 测试通过
- 静态架构、秘密模式、平台契约与 Swift 格式检查通过

## 未覆盖边界

- 未等待真实屏保、显示器关闭或密码锁超时
- 未实测 macOS 15、Intel、仅电池供电及多显示器组合