### PR TITLE
feat(search): 实现视频搜索排序与筛选

### DIFF
--- a/BiliKitMac/App/AppRootView.swift
+++ b/BiliKitMac/App/AppRootView.swift
@@ -25,7 +25,9 @@ struct AppRootView: View {
     private let accountSessionCoordinator: AccountSessionCoordinator
     private let appSettingsModel: AppSettingsModel?
     @State private var isAuthenticationPresented = false
-    @State private var submittedSearchQuery: String?
+    @State private var searchFilterSelection = SearchFilterSelection()
+    @State private var appliedSearchFilters = AppliedVideoSearchFilters()
+    @State private var submittedSearchCriteria: VideoSearchCriteria?
     init(
         environment: AppEnvironment? = nil,
         accountSessionCoordinator: AccountSessionCoordinator = AccountSessionCoordinator(),
@@ -96,8 +98,12 @@ struct AppRootView: View {
             commentLinkURLResolver: windowOwner.commentLinkURLResolver,
             commentImagePipeline: windowOwner.commentImagePipeline,
             isAuthenticationPresented: $isAuthenticationPresented,
-            submittedSearchQuery: submittedSearchQuery,
-            onSubmitSearch: performSearch
+            searchFilterSelection: $searchFilterSelection,
+            submittedSearchCriteria: submittedSearchCriteria,
+            onSubmitSearch: performSearch,
+            onSelectSearchOrder: selectSearchOrder,
+            onApplySearchFilters: applySearchFilters,
+            onClearSearchFilters: clearSearchFilters
         )
         .task(id: browseActivation) {
             await applyBrowseActivation(for: browseActivation)
@@ -188,7 +194,7 @@ struct AppRootView: View {
             else {
                 return
             }
-            submittedSearchQuery = nil
+            submittedSearchCriteria = nil
         }
         .onDisappear {
             appSettingsModel?.removeAuthenticationOwner(
@@ -282,8 +288,37 @@ struct AppRootView: View {
     private func performSearch() {
         guard !normalizedSearchDraft.isEmpty else { return }
         navigationCoordinator.searchDraft = normalizedSearchDraft
-        submittedSearchQuery = normalizedSearchDraft
-        browseModel.search(normalizedSearchDraft)
+        let criteria = appliedSearchFilters.criteria(query: normalizedSearchDraft)
+        if submittedSearchCriteria == criteria {
+            browseModel.search(criteria)
+        } else {
+            submittedSearchCriteria = criteria
+        }
+    }
+
+    private func selectSearchOrder(_ order: VideoSearchOrder) {
+        appliedSearchFilters.order = order
+        updateSubmittedSearchCriteriaIfNeeded()
+    }
+
+    private func applySearchFilters(_ selection: SearchFilterSelection) {
+        guard let filters = try? selection.resolvedFilters() else { return }
+        appliedSearchFilters = filters
+        updateSubmittedSearchCriteriaIfNeeded()
+    }
+
+    private func clearSearchFilters() {
+        searchFilterSelection.resetFilters()
+        appliedSearchFilters.duration = .all
+        appliedSearchFilters.publicationRange = nil
+        updateSubmittedSearchCriteriaIfNeeded()
+    }
+
+    private func updateSubmittedSearchCriteriaIfNeeded() {
+        guard let submittedSearchCriteria else { return }
+        self.submittedSearchCriteria = appliedSearchFilters.criteria(
+            query: submittedSearchCriteria.query
+        )
     }
 
     private var browseActivation: BrowseActivation {
@@ -293,7 +328,7 @@ struct AppRootView: View {
         case .popular:
             return .popular
         case .search:
-            return .search(query: submittedSearchQuery)
+            return .search(criteria: submittedSearchCriteria)
         case .history:
             return .inactive
         }
@@ -312,8 +347,8 @@ struct AppRootView: View {
             await browseModel.waitForCurrentTask()
         case .search(nil), .inactive:
             browseModel.deactivateRoute()
-        case .search(.some(let query)):
-            browseModel.activateSearch(query)
+        case .search(.some(let criteria)):
+            browseModel.activateSearch(criteria)
             await browseModel.waitForCurrentTask()
         }
     }
@@ -418,7 +453,7 @@ private final class AppWindowActivationObserverOwner: @unchecked Sendable {
 private enum BrowseActivation: Hashable {
     case recommendation
     case popular
-    case search(query: String?)
+    case search(criteria: VideoSearchCriteria?)
     case inactive
 }
 

--- a/BiliKitMac/App/AppShellView.swift
+++ b/BiliKitMac/App/AppShellView.swift
@@ -22,8 +22,12 @@ struct AppShellView: View {
     let commentLinkURLResolver: CommentLinkURLResolver
     let commentImagePipeline: NativeVideoImagePipeline
     @Binding var isAuthenticationPresented: Bool
-    let submittedSearchQuery: String?
+    @Binding var searchFilterSelection: SearchFilterSelection
+    let submittedSearchCriteria: VideoSearchCriteria?
     let onSubmitSearch: () -> Void
+    let onSelectSearchOrder: (VideoSearchOrder) -> Void
+    let onApplySearchFilters: (SearchFilterSelection) -> Void
+    let onClearSearchFilters: () -> Void
     @State private var columnVisibility = NavigationSplitViewVisibility.all
     @State private var homeScrollOffsetY: CGFloat = 0
     @State private var popularScrollOffsetY: CGFloat = 0
@@ -99,8 +103,8 @@ struct AppShellView: View {
         .sheet(isPresented: $isAuthenticationPresented) {
             AuthenticationView(model: authenticationModel)
         }
-        .onChange(of: submittedSearchQuery) { previousQuery, query in
-            guard previousQuery != query else { return }
+        .onChange(of: submittedSearchCriteria) { previousCriteria, criteria in
+            guard previousCriteria != criteria else { return }
             searchScrollOffsetY = 0
             searchScrollReset.request()
         }
@@ -139,6 +143,8 @@ struct AppShellView: View {
             }
             homeScrollOffsetY = 0
             homeScrollReset.request()
+            searchScrollOffsetY = 0
+            searchScrollReset.request()
             historyScrollOffsetY = 0
             historyScrollReset.request()
         }
@@ -261,16 +267,20 @@ struct AppShellView: View {
             )
         case .search:
             SearchTabRoot(
+                filterSelection: $searchFilterSelection,
                 model: browseModel,
                 searchDraft: Binding(
                     get: { navigationCoordinator.searchDraft },
                     set: { navigationCoordinator.searchDraft = $0 }
                 ),
-                submittedSearchQuery: submittedSearchQuery,
+                submittedSearchCriteria: submittedSearchCriteria,
                 scrollOffsetY: $searchScrollOffsetY,
                 scrollReset: $searchScrollReset,
                 onSelect: navigationCoordinator.openPlayback,
-                onSubmit: onSubmitSearch
+                onSubmit: onSubmitSearch,
+                onSelectOrder: onSelectSearchOrder,
+                onApplyFilters: onApplySearchFilters,
+                onClearFilters: onClearSearchFilters
             )
         case .popular:
             PopularTabRoot(

--- a/BiliKitMac/App/AppSourceRootViews.swift
+++ b/BiliKitMac/App/AppSourceRootViews.swift
@@ -76,18 +76,23 @@ struct PopularTabRoot: View {
 }
 
 struct SearchTabRoot: View {
+    @Binding var filterSelection: SearchFilterSelection
     let model: GuestBrowseViewModel
     @Binding var searchDraft: String
-    let submittedSearchQuery: String?
+    let submittedSearchCriteria: VideoSearchCriteria?
     @Binding var scrollOffsetY: CGFloat
     @Binding var scrollReset: NativeVideoGridScrollResetState
     let onSelect: (String) -> Void
     let onSubmit: () -> Void
+    let onSelectOrder: (VideoSearchOrder) -> Void
+    let onApplyFilters: (SearchFilterSelection) -> Void
+    let onClearFilters: () -> Void
 
     var body: some View {
         VideoSearchView(
             model: model,
-            submittedSearchQuery: submittedSearchQuery,
+            submittedSearchCriteria: submittedSearchCriteria,
+            hasActiveFilters: filterSelection.activeFilterCount > 0,
             scrollOffsetY: $scrollOffsetY,
             makeLoadedContent: {
                 presentations,
@@ -109,11 +114,11 @@ struct SearchTabRoot: View {
                 )
                 .ignoresSafeArea(.container, edges: .top)
             },
-            onSelect: onSelect
+            onSelect: onSelect,
+            onClearFilters: onClearFilters
         )
         .navigationTitle("搜索")
         .toolbar(removing: .title)
-        .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
         .searchable(
             text: $searchDraft,
             placement: searchFieldPlacement,
@@ -121,6 +126,15 @@ struct SearchTabRoot: View {
         )
         .onSubmit(of: .search) {
             onSubmit()
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .primaryAction) {
+                SearchToolbarControls(
+                    selection: $filterSelection,
+                    onSelectOrder: onSelectOrder,
+                    onApplyFilters: onApplyFilters
+                )
+            }
         }
     }
 

--- a/BiliKitMac/App/SearchToolbarControls.swift
+++ b/BiliKitMac/App/SearchToolbarControls.swift
@@ -1,0 +1,297 @@
+import BiliBrowseFeature
+import SwiftUI
+
+struct AppliedVideoSearchFilters: Hashable {
+    var order: VideoSearchOrder = .relevance
+    var duration: VideoDurationFilter = .all
+    var publicationRange: VideoPublicationTimeRange?
+
+    func criteria(query: String) -> VideoSearchCriteria {
+        VideoSearchCriteria(
+            query: query,
+            order: order,
+            duration: duration,
+            publicationRange: publicationRange
+        )
+    }
+}
+
+struct SearchFilterSelection: Hashable {
+    var order: VideoSearchOrder = .relevance
+    var publication = VideoPublicationFilter.all
+    var duration = VideoDurationFilter.all
+    var customStart = Calendar.current.date(byAdding: .month, value: -1, to: Date()) ?? Date()
+    var customEnd = Date()
+
+    var activeFilterCount: Int {
+        (publication == .all ? 0 : 1) + (duration == .all ? 0 : 1)
+    }
+
+    mutating func resetFilters() {
+        publication = .all
+        duration = .all
+    }
+
+    func resolvedFilters(
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) throws -> AppliedVideoSearchFilters {
+        AppliedVideoSearchFilters(
+            order: order,
+            duration: duration,
+            publicationRange: try VideoPublicationRangeResolver.resolve(
+                filter: publication,
+                customStart: customStart,
+                customEnd: customEnd,
+                now: now,
+                calendar: calendar
+            )
+        )
+    }
+
+    var summary: String {
+        [
+            publication == .all ? nil : publication.localizedTitle,
+            duration == .all ? nil : duration.localizedTitle,
+        ].compactMap { $0 }.joined(separator: "，")
+    }
+}
+
+struct SearchToolbarControls: View {
+    @Binding var selection: SearchFilterSelection
+    @State private var draft = SearchFilterSelection()
+    @State private var isFilterPopoverPresented = false
+
+    let onSelectOrder: (VideoSearchOrder) -> Void
+    let onApplyFilters: (SearchFilterSelection) -> Void
+
+    var body: some View {
+        Group {
+            Menu {
+                ForEach(VideoSearchOrder.allCases) { order in
+                    Toggle(
+                        isOn: Binding(
+                            get: { selection.order == order },
+                            set: { isSelected in
+                                guard isSelected else { return }
+                                selection.order = order
+                                onSelectOrder(order)
+                            }
+                        )
+                    ) {
+                        Text(order.title)
+                    }
+                }
+            } label: {
+                Label {
+                    Text(selection.order.title)
+                } icon: {
+                    Image(systemName: "arrow.up.arrow.down")
+                }
+                .labelStyle(.titleAndIcon)
+            }
+            .help(
+                String(
+                    localized: "搜索结果排序：\(selection.order.localizedTitle)"
+                )
+            )
+
+            Button {
+                draft = selection
+                isFilterPopoverPresented = true
+            } label: {
+                Label {
+                    Text(filterButtonTitle)
+                } icon: {
+                    Image(systemName: filterButtonImage)
+                }
+                .labelStyle(.titleAndIcon)
+            }
+            .accessibilityValue(
+                Text("已启用 \(selection.activeFilterCount) 项")
+            )
+            .help(filterButtonHelp)
+            .popover(isPresented: $isFilterPopoverPresented, arrowEdge: .bottom) {
+                SearchFilterPopover(
+                    draft: $draft,
+                    onCancel: cancelDraft,
+                    onApply: applyDraft
+                )
+            }
+            .onChange(of: isFilterPopoverPresented) { _, isPresented in
+                if !isPresented {
+                    draft = selection
+                }
+            }
+        }
+    }
+
+    private var filterButtonTitle: LocalizedStringResource {
+        if selection.activeFilterCount == 0 {
+            "筛选"
+        } else {
+            "筛选 \(selection.activeFilterCount)"
+        }
+    }
+
+    private var filterButtonImage: String {
+        selection.activeFilterCount == 0
+            ? "line.3.horizontal.decrease.circle"
+            : "line.3.horizontal.decrease.circle.fill"
+    }
+
+    private var filterButtonHelp: String {
+        selection.summary.isEmpty
+            ? String(localized: "筛选搜索结果")
+            : String(localized: "筛选搜索结果：\(selection.summary)")
+    }
+
+    private func cancelDraft() {
+        draft = selection
+        isFilterPopoverPresented = false
+    }
+
+    private func applyDraft() {
+        selection = draft
+        isFilterPopoverPresented = false
+        onApplyFilters(draft)
+    }
+}
+
+private struct SearchFilterPopover: View {
+    @Binding var draft: SearchFilterSelection
+    let onCancel: () -> Void
+    let onApply: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("筛选搜索结果")
+                .font(.headline)
+
+            LabeledContent("发布日期") {
+                Picker("发布日期", selection: $draft.publication) {
+                    ForEach(VideoPublicationFilter.allCases) { filter in
+                        Text(filter.title).tag(filter)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 176)
+            }
+
+            if draft.publication == .custom {
+                VStack(alignment: .leading, spacing: 10) {
+                    DatePicker(
+                        "开始日期",
+                        selection: $draft.customStart,
+                        in: ...Date(),
+                        displayedComponents: .date
+                    )
+                    DatePicker(
+                        "结束日期",
+                        selection: $draft.customEnd,
+                        in: ...Date(),
+                        displayedComponents: .date
+                    )
+                    if let validationMessage {
+                        Label {
+                            Text(validationMessage)
+                        } icon: {
+                            Image(systemName: "exclamationmark.triangle")
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                    }
+                }
+                .padding(.leading, 12)
+            }
+
+            LabeledContent("视频时长") {
+                Picker("视频时长", selection: $draft.duration) {
+                    ForEach(VideoDurationFilter.allCases) { duration in
+                        Text(duration.title).tag(duration)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 176)
+            }
+
+            Divider()
+
+            HStack {
+                Button("恢复默认") {
+                    draft.resetFilters()
+                }
+                .disabled(draft.activeFilterCount == 0)
+                Spacer()
+                Button("取消", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button("应用", action: onApply)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(validationMessage != nil)
+            }
+        }
+        .padding(16)
+        .frame(width: 350)
+    }
+
+    private var validationMessage: LocalizedStringResource? {
+        guard draft.publication == .custom else { return nil }
+        do {
+            _ = try draft.resolvedFilters()
+            return nil
+        } catch let error as VideoPublicationRangeError {
+            switch error {
+            case .startAfterEnd:
+                return "开始日期不能晚于结束日期"
+            case .futureDate:
+                return "结束日期不能超过今天"
+            case .invalidCalendarRange:
+                return "无法使用这个日期范围"
+            }
+        } catch {
+            return "无法使用这个日期范围"
+        }
+    }
+}
+
+extension VideoSearchOrder {
+    var title: LocalizedStringResource {
+        switch self {
+        case .relevance: "综合排序"
+        case .mostPlayed: "最多播放"
+        case .newest: "最新发布"
+        case .mostDanmaku: "最多弹幕"
+        case .mostFavorited: "最多收藏"
+        }
+    }
+
+    var localizedTitle: String { String(localized: title) }
+}
+
+extension VideoDurationFilter {
+    var title: LocalizedStringResource {
+        switch self {
+        case .all: "全部时长"
+        case .underTenMinutes: "10 分钟以下"
+        case .tenToThirtyMinutes: "10–30 分钟"
+        case .thirtyToSixtyMinutes: "30–60 分钟"
+        case .overSixtyMinutes: "60 分钟以上"
+        }
+    }
+
+    var localizedTitle: String { String(localized: title) }
+}
+
+extension VideoPublicationFilter {
+    var title: LocalizedStringResource {
+        switch self {
+        case .all: "全部日期"
+        case .today: "最近一天"
+        case .lastSevenDays: "最近一周"
+        case .last180Days: "最近半年"
+        case .custom: "自定义日期"
+        }
+    }
+
+    var localizedTitle: String { String(localized: title) }
+}

--- a/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliGuestRepository.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Adapter/BiliGuestRepository.swift
@@ -30,6 +30,12 @@ public struct BiliGuestRepository: GuestContentRepository, RelatedVideoRepositor
         }
     }
 
+    public func searchVideos(request: VideoSearchRequest) async throws -> SearchPage {
+        try await mapError {
+            try await client.searchVideos(request: request)
+        }
+    }
+
     public func videoDetail(for bvid: String) async throws -> VideoDetail {
         try await mapError {
             try await client.videoDetail(for: bvid)

--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
@@ -205,19 +205,43 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
         keyword: String,
         page: Int = 1
     ) async throws -> SearchPage {
+        try await searchVideos(
+            request: VideoSearchRequest(
+                criteria: VideoSearchCriteria(query: keyword),
+                page: page
+            )
+        )
+    }
+
+    public func searchVideos(
+        request: VideoSearchRequest
+    ) async throws -> SearchPage {
         let searchSessionEpoch = authenticatedSessionEpoch
-        let normalizedKeyword = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !normalizedKeyword.isEmpty,
-            normalizedKeyword.count <= 100,
-            page > 0
+        let criteria = request.criteria
+        let hasValidPublicationRange =
+            criteria.publicationRange.map {
+                $0.beginTimestamp >= 0 && $0.beginTimestamp <= $0.endTimestamp
+            } ?? true
+        guard !criteria.query.isEmpty,
+            criteria.query.count <= 100,
+            criteria.pageSize == VideoSearchCriteria.pageSize,
+            request.page > 0,
+            hasValidPublicationRange
         else {
             throw BiliAPIError.invalidRequest
         }
-        let parameters = [
-            "keyword": normalizedKeyword,
-            "page": String(page),
+        var parameters = [
+            "keyword": criteria.query,
+            "page": String(request.page),
+            "page_size": String(criteria.pageSize),
             "search_type": "video",
+            "order": criteria.order.apiValue,
+            "duration": criteria.duration.apiValue,
         ]
+        if let range = criteria.publicationRange {
+            parameters["pubtime_begin_s"] = String(range.beginTimestamp)
+            parameters["pubtime_end_s"] = String(range.endTimestamp)
+        }
         do {
             return try await signedSearch(
                 parameters: parameters,

--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/VideoSearchParameterEncoding.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/VideoSearchParameterEncoding.swift
@@ -1,0 +1,17 @@
+import BiliApplication
+
+extension VideoSearchOrder {
+    var apiValue: String {
+        switch self {
+        case .relevance: "totalrank"
+        case .mostPlayed: "click"
+        case .newest: "pubdate"
+        case .mostDanmaku: "dm"
+        case .mostFavorited: "stow"
+        }
+    }
+}
+
+extension VideoDurationFilter {
+    var apiValue: String { String(rawValue) }
+}

--- a/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestContracts.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestContracts.swift
@@ -19,6 +19,7 @@ public protocol GuestContentRepository: Sendable {
     ) async throws -> RecommendationPage
     func popular(page: Int, pageSize: Int) async throws -> PopularPage
     func searchVideos(keyword: String, page: Int) async throws -> SearchPage
+    func searchVideos(request: VideoSearchRequest) async throws -> SearchPage
     func videoDetail(for bvid: String) async throws -> VideoDetail
     func pages(for bvid: String) async throws -> [VideoPage]
     func playback(for bvid: String, cid: Int64) async throws -> VideoPlayback
@@ -29,6 +30,13 @@ extension GuestContentRepository {
         after continuation: RecommendationContinuation?
     ) async throws -> RecommendationPage {
         throw GuestApplicationError.unavailable
+    }
+
+    public func searchVideos(request: VideoSearchRequest) async throws -> SearchPage {
+        try await searchVideos(
+            keyword: request.criteria.query,
+            page: request.page
+        )
     }
 }
 

--- a/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestFeedUseCase.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Guest/GuestFeedUseCase.swift
@@ -4,7 +4,16 @@ import Foundation
 public enum GuestFeedRequest: Sendable, Equatable {
     case recommendation(continuation: RecommendationContinuation?)
     case popular(page: Int, pageSize: Int)
-    case search(query: String, page: Int)
+    case search(VideoSearchRequest)
+
+    public static func search(query: String, page: Int) -> Self {
+        .search(
+            VideoSearchRequest(
+                criteria: VideoSearchCriteria(query: query),
+                page: page
+            )
+        )
+    }
 }
 
 public enum GuestFeedContent: Sendable, Equatable {
@@ -38,21 +47,26 @@ public struct GuestFeedUseCase: Sendable {
             return .popular(
                 try await repository.popular(page: page, pageSize: pageSize)
             )
-        case .search(let query, let page):
-            let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !normalizedQuery.isEmpty,
-                normalizedQuery.count <= 100,
-                page > 0
+        case .search(let request):
+            let criteria = request.criteria
+            guard !criteria.query.isEmpty,
+                criteria.query.count <= 100,
+                criteria.pageSize == VideoSearchCriteria.pageSize,
+                request.page > 0,
+                Self.isValid(criteria.publicationRange)
             else {
                 throw GuestApplicationError.invalidRequest
             }
             return .search(
-                query: normalizedQuery,
-                page: try await repository.searchVideos(
-                    keyword: normalizedQuery,
-                    page: page
-                )
+                query: criteria.query,
+                page: try await repository.searchVideos(request: request)
             )
         }
+    }
+
+    private static func isValid(_ range: VideoPublicationTimeRange?) -> Bool {
+        guard let range else { return true }
+        return range.beginTimestamp >= 0
+            && range.beginTimestamp <= range.endTimestamp
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliApplication/Guest/VideoSearchCriteria.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/Guest/VideoSearchCriteria.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+public enum VideoSearchOrder: String, Sendable, Hashable, CaseIterable, Identifiable {
+    case relevance
+    case mostPlayed
+    case newest
+    case mostDanmaku
+    case mostFavorited
+
+    public var id: Self { self }
+}
+
+public enum VideoDurationFilter: Int, Sendable, Hashable, CaseIterable, Identifiable {
+    case all = 0
+    case underTenMinutes = 1
+    case tenToThirtyMinutes = 2
+    case thirtyToSixtyMinutes = 3
+    case overSixtyMinutes = 4
+
+    public var id: Self { self }
+}
+
+/// 已冻结的闭区间；相对日期在进入搜索 criteria 前解析为该值，避免跨午夜改变请求含义。
+public struct VideoPublicationTimeRange: Sendable, Hashable {
+    public let beginTimestamp: Int64
+    public let endTimestamp: Int64
+
+    public init(beginTimestamp: Int64, endTimestamp: Int64) {
+        self.beginTimestamp = beginTimestamp
+        self.endTimestamp = endTimestamp
+    }
+}
+
+public enum VideoPublicationFilter: Sendable, Hashable, CaseIterable, Identifiable {
+    case all
+    case today
+    case lastSevenDays
+    case last180Days
+    case custom
+
+    public var id: Self { self }
+}
+
+public enum VideoPublicationRangeError: Error, Sendable, Equatable {
+    case startAfterEnd
+    case futureDate
+    case invalidCalendarRange
+}
+
+/// 将日期选择集中转换为 API 使用的整日 Unix 秒闭区间。
+public enum VideoPublicationRangeResolver {
+    public static func resolve(
+        filter: VideoPublicationFilter,
+        customStart: Date,
+        customEnd: Date,
+        now: Date,
+        calendar: Calendar
+    ) throws -> VideoPublicationTimeRange? {
+        guard filter != .all else { return nil }
+
+        let today = calendar.startOfDay(for: now)
+        let endDay = filter == .custom ? calendar.startOfDay(for: customEnd) : today
+        guard endDay <= today else {
+            throw VideoPublicationRangeError.futureDate
+        }
+
+        let beginDay: Date
+        switch filter {
+        case .all:
+            return nil
+        case .today:
+            beginDay = today
+        case .lastSevenDays:
+            guard let value = calendar.date(byAdding: .day, value: -6, to: today) else {
+                throw VideoPublicationRangeError.invalidCalendarRange
+            }
+            beginDay = value
+        case .last180Days:
+            guard let value = calendar.date(byAdding: .day, value: -179, to: today) else {
+                throw VideoPublicationRangeError.invalidCalendarRange
+            }
+            beginDay = value
+        case .custom:
+            beginDay = calendar.startOfDay(for: customStart)
+        }
+
+        guard beginDay <= endDay else {
+            throw VideoPublicationRangeError.startAfterEnd
+        }
+        guard let endExclusive = calendar.date(byAdding: .day, value: 1, to: endDay) else {
+            throw VideoPublicationRangeError.invalidCalendarRange
+        }
+        return VideoPublicationTimeRange(
+            beginTimestamp: Int64(beginDay.timeIntervalSince1970),
+            endTimestamp: Int64(endExclusive.timeIntervalSince1970) - 1
+        )
+    }
+}
+
+/// 一个搜索工作集的完整 identity。
+///
+/// `query` 在初始化时即完成空白规范化。
+public struct VideoSearchCriteria: Sendable, Hashable {
+    public static let pageSize = 20
+
+    public let query: String
+    public let order: VideoSearchOrder
+    public let duration: VideoDurationFilter
+    public let publicationRange: VideoPublicationTimeRange?
+    public let pageSize: Int
+
+    public init(
+        query: String,
+        order: VideoSearchOrder = .relevance,
+        duration: VideoDurationFilter = .all,
+        publicationRange: VideoPublicationTimeRange? = nil
+    ) {
+        self.query = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.order = order
+        self.duration = duration
+        self.publicationRange = publicationRange
+        self.pageSize = Self.pageSize
+    }
+}
+
+/// 单次网络请求 identity；分页只改变 `page`，其余条件完整保留。
+public struct VideoSearchRequest: Sendable, Hashable {
+    public let criteria: VideoSearchCriteria
+    public let page: Int
+
+    public init(criteria: VideoSearchCriteria, page: Int) {
+        self.criteria = criteria
+        self.page = page
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/BrowseScene/GuestBrowseViewModel.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/BrowseScene/GuestBrowseViewModel.swift
@@ -92,9 +92,14 @@ public final class GuestBrowseViewModel {
     }
 
     public func activateSearch(_ query: String) {
-        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        let request = GuestFeedRequest.search(query: normalizedQuery, page: 1)
-        guard isValidSearch(normalizedQuery) else {
+        activateSearch(VideoSearchCriteria(query: query))
+    }
+
+    public func activateSearch(_ criteria: VideoSearchCriteria) {
+        let request = GuestFeedRequest.search(
+            VideoSearchRequest(criteria: criteria, page: 1)
+        )
+        guard isValidSearch(criteria) else {
             fail(request: request, error: .invalidRequest)
             return
         }
@@ -196,9 +201,14 @@ public final class GuestBrowseViewModel {
     }
 
     public func search(_ query: String) {
-        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        let request = GuestFeedRequest.search(query: normalizedQuery, page: 1)
-        guard isValidSearch(normalizedQuery) else {
+        search(VideoSearchCriteria(query: query))
+    }
+
+    public func search(_ criteria: VideoSearchCriteria) {
+        let request = GuestFeedRequest.search(
+            VideoSearchRequest(criteria: criteria, page: 1)
+        )
+        guard isValidSearch(criteria) else {
             fail(request: request, error: .invalidRequest)
             return
         }
@@ -210,9 +220,10 @@ public final class GuestBrowseViewModel {
 
     public func loadMoreSearch() {
         guard
-            case .search(let query, 1) = activeRequestIdentity,
+            case .search(let baseSearchRequest) = activeRequestIdentity,
+            baseSearchRequest.page == 1,
             case .loaded(.search(let loadedQuery, let page)) = state,
-            loadedQuery == query,
+            loadedQuery == baseSearchRequest.criteria.query,
             page.pageNumber < page.totalPages,
             !isRefreshing,
             !searchWorkset.isLoadingMore,
@@ -221,10 +232,12 @@ public final class GuestBrowseViewModel {
             return
         }
 
-        let baseRequest = GuestFeedRequest.search(query: query, page: 1)
+        let baseRequest = GuestFeedRequest.search(baseSearchRequest)
         let nextRequest = GuestFeedRequest.search(
-            query: query,
-            page: page.pageNumber + 1
+            VideoSearchRequest(
+                criteria: baseSearchRequest.criteria,
+                page: page.pageNumber + 1
+            )
         )
         generation += 1
         let currentGeneration = generation
@@ -266,8 +279,8 @@ public final class GuestBrowseViewModel {
             activateRecommendation()
         case .popular(let page, let pageSize):
             activatePopular(page: page, pageSize: pageSize)
-        case .search(let query, _):
-            activateSearch(query)
+        case .search(let request):
+            activateSearch(request.criteria)
         case nil:
             break
         }
@@ -385,12 +398,19 @@ public final class GuestBrowseViewModel {
     func searchPagination(
         for query: String
     ) -> SearchPaginationPresentation {
-        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        let request = GuestFeedRequest.search(query: normalizedQuery, page: 1)
+        searchPagination(for: VideoSearchCriteria(query: query))
+    }
+
+    func searchPagination(
+        for criteria: VideoSearchCriteria
+    ) -> SearchPaginationPresentation {
+        let request = GuestFeedRequest.search(
+            VideoSearchRequest(criteria: criteria, page: 1)
+        )
         guard
             searchWorkset.request == request,
             case .loaded(.search(let loadedQuery, let page)) = searchWorkset.state,
-            loadedQuery == normalizedQuery
+            loadedQuery == criteria.query
         else {
             return SearchPaginationPresentation(
                 canLoadMore: false,
@@ -403,7 +423,7 @@ public final class GuestBrowseViewModel {
             searchWorkset.loadMoreError == nil
             && page.pageNumber < page.totalPages
         let tailIdentity = page.videos.last.map {
-            "\(normalizedQuery)|\(page.pageNumber)|\($0.bvid)"
+            "\(criteria.identityComponent)|\(page.pageNumber)|\($0.bvid)"
         }
         return SearchPaginationPresentation(
             canLoadMore: canLoadMore,
@@ -546,13 +566,14 @@ public final class GuestBrowseViewModel {
             guard
                 generation == currentGeneration,
                 activeRequestIdentity == baseRequest,
-                case .search(let requestedQuery, let requestedPage) = request,
+                case .search(let requestedRequest) = request,
                 case .search(let responseQuery, let responsePage) = content,
-                requestedQuery == responseQuery,
-                requestedPage == responsePage.pageNumber,
+                requestedRequest.criteria.query == responseQuery,
+                requestedRequest.page == responsePage.pageNumber,
+                requestedRequest.criteria.pageSize == responsePage.pageSize,
                 responsePage.pageNumber <= responsePage.totalPages,
                 case .loaded(.search(let loadedQuery, let loadedPage)) = state,
-                loadedQuery == requestedQuery,
+                loadedQuery == requestedRequest.criteria.query,
                 loadedPage.pageNumber + 1 == responsePage.pageNumber
             else {
                 throw GuestApplicationError.invalidResponse
@@ -562,15 +583,19 @@ public final class GuestBrowseViewModel {
             let appended = responsePage.videos.filter {
                 seen.insert($0.bvid).inserted
             }
+            let totalPages =
+                appended.isEmpty
+                ? responsePage.pageNumber
+                : responsePage.totalPages
             state = .loaded(
                 .search(
-                    query: requestedQuery,
+                    query: requestedRequest.criteria.query,
                     page: SearchPage(
                         videos: loadedPage.videos + appended,
                         pageNumber: responsePage.pageNumber,
                         pageSize: responsePage.pageSize,
                         totalResults: responsePage.totalResults,
-                        totalPages: responsePage.totalPages
+                        totalPages: totalPages
                     )
                 )
             )
@@ -765,12 +790,12 @@ public final class GuestBrowseViewModel {
         case (.popular(let requestedPage, let requestedSize), .popular(let page)):
             page.pageNumber == requestedPage && page.pageSize == requestedSize
         case (
-            .search(let requestedQuery, let requestedPage),
+            .search(let requestedRequest),
             .search(let responseQuery, let page)
         ):
-            responseQuery == requestedQuery
-                && page.pageNumber == requestedPage
-                && page.pageSize > 0
+            responseQuery == requestedRequest.criteria.query
+                && page.pageNumber == requestedRequest.page
+                && page.pageSize == requestedRequest.criteria.pageSize
                 && page.totalResults >= 0
                 && (page.totalPages >= page.pageNumber
                     || (page.totalPages == 0 && page.videos.isEmpty))
@@ -913,8 +938,24 @@ public final class GuestBrowseViewModel {
         }
     }
 
-    private func isValidSearch(_ query: String) -> Bool {
-        !query.isEmpty && query.count <= 100
+    private func isValidSearch(_ criteria: VideoSearchCriteria) -> Bool {
+        guard !criteria.query.isEmpty,
+            criteria.query.count <= 100,
+            criteria.pageSize == VideoSearchCriteria.pageSize
+        else { return false }
+        guard let range = criteria.publicationRange else { return true }
+        return range.beginTimestamp >= 0
+            && range.beginTimestamp <= range.endTimestamp
+    }
+}
+
+extension VideoSearchCriteria {
+    fileprivate var identityComponent: String {
+        let range =
+            publicationRange.map {
+                "\($0.beginTimestamp)-\($0.endTimestamp)"
+            } ?? "all"
+        return "\(query)|\(order.rawValue)|\(duration.rawValue)|\(range)|\(pageSize)"
     }
 }
 

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/Search/VideoSearchSemanticTypes.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/Search/VideoSearchSemanticTypes.swift
@@ -1,0 +1,11 @@
+@_exported import BiliApplication
+
+public typealias VideoSearchCriteria = BiliApplication.VideoSearchCriteria
+public typealias VideoSearchOrder = BiliApplication.VideoSearchOrder
+public typealias VideoDurationFilter = BiliApplication.VideoDurationFilter
+public typealias VideoPublicationFilter = BiliApplication.VideoPublicationFilter
+public typealias VideoPublicationTimeRange = BiliApplication.VideoPublicationTimeRange
+public typealias VideoPublicationRangeResolver =
+    BiliApplication.VideoPublicationRangeResolver
+public typealias VideoPublicationRangeError =
+    BiliApplication.VideoPublicationRangeError

--- a/Packages/BiliKitCore/Sources/BiliBrowseFeature/Search/VideoSearchView.swift
+++ b/Packages/BiliKitCore/Sources/BiliBrowseFeature/Search/VideoSearchView.swift
@@ -6,7 +6,8 @@ import SwiftUI
 public struct VideoSearchView<LoadedContent: View>: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let model: GuestBrowseViewModel
-    private let submittedSearchQuery: String?
+    private let submittedSearchCriteria: VideoSearchCriteria?
+    private let hasActiveFilters: Bool
     @Binding private var scrollOffsetY: CGFloat
     private let makeLoadedContent:
         (
@@ -19,10 +20,12 @@ public struct VideoSearchView<LoadedContent: View>: View {
             @escaping (String) -> Void
         ) -> LoadedContent
     private let onSelect: (String) -> Void
+    private let onClearFilters: () -> Void
 
     public init(
         model: GuestBrowseViewModel,
-        submittedSearchQuery: String?,
+        submittedSearchCriteria: VideoSearchCriteria?,
+        hasActiveFilters: Bool,
         scrollOffsetY: Binding<CGFloat>,
         makeLoadedContent:
             @escaping (
@@ -34,13 +37,16 @@ public struct VideoSearchView<LoadedContent: View>: View {
                 @escaping () -> Void,
                 @escaping (String) -> Void
             ) -> LoadedContent,
-        onSelect: @escaping (String) -> Void
+        onSelect: @escaping (String) -> Void,
+        onClearFilters: @escaping () -> Void
     ) {
         self.model = model
-        self.submittedSearchQuery = submittedSearchQuery
+        self.submittedSearchCriteria = submittedSearchCriteria
+        self.hasActiveFilters = hasActiveFilters
         _scrollOffsetY = scrollOffsetY
         self.makeLoadedContent = makeLoadedContent
         self.onSelect = onSelect
+        self.onClearFilters = onClearFilters
     }
 
     public var body: some View {
@@ -55,10 +61,9 @@ public struct VideoSearchView<LoadedContent: View>: View {
     }
 
     private var visualPhase: LoadingVisualPhase {
-        guard let submittedSearchQuery else { return .idle }
+        guard let submittedSearchCriteria else { return .idle }
         let request = GuestFeedRequest.search(
-            query: submittedSearchQuery,
-            page: 1
+            VideoSearchRequest(criteria: submittedSearchCriteria, page: 1)
         )
         switch model.presentation(for: request).state {
         case .idle, .loading:
@@ -67,7 +72,7 @@ public struct VideoSearchView<LoadedContent: View>: View {
             return .empty
         case .loaded(.search(_, _)):
             return .content
-        case .failed(request: .search(_, _), error: _):
+        case .failed(request: .search, error: _):
             return .failure
         default:
             return .transitioning
@@ -76,10 +81,9 @@ public struct VideoSearchView<LoadedContent: View>: View {
 
     @ViewBuilder
     private var results: some View {
-        if let submittedSearchQuery {
+        if let submittedSearchCriteria {
             let request = GuestFeedRequest.search(
-                query: submittedSearchQuery,
-                page: 1
+                VideoSearchRequest(criteria: submittedSearchCriteria, page: 1)
             )
             searchResults(for: request)
         } else {
@@ -95,44 +99,29 @@ public struct VideoSearchView<LoadedContent: View>: View {
             let query = request.searchQuery ?? ""
             SearchResultsSkeleton(query: query)
         case .loaded(.search(let query, let page)) where page.videos.isEmpty:
-            ContentUnavailableView.search(text: query)
-        case .loaded(.search(let query, let page)):
-            VStack(spacing: 0) {
-                HStack {
-                    Text("“\(query)”")
-                    Spacer()
-                    Text("约 \(page.totalResults.formatted()) 条结果")
-                        .foregroundStyle(.secondary)
+            VStack(spacing: 12) {
+                ContentUnavailableView.search(text: query)
+                if hasActiveFilters {
+                    Button("清除筛选", action: onClearFilters)
+                }
+            }
+        case .loaded(.search(_, let page)):
+            loadedResults(criteria: request.searchCriteria, page: page)
+                .overlay(alignment: .top) {
                     if presentation.isRefreshing {
                         ProgressView()
                             .controlSize(.small)
+                            .padding(8)
+                            .background(.regularMaterial, in: Capsule())
                             .accessibilityLabel("正在刷新搜索结果")
-                    } else {
-                        Button {
-                            model.search(query)
-                        } label: {
-                            Label("刷新搜索结果", systemImage: "arrow.clockwise")
-                                .labelStyle(.iconOnly)
-                        }
-                        .buttonStyle(.borderless)
-                        .accessibilityHint("从第 1 页重新加载当前搜索")
+                    } else if let error = presentation.refreshError {
+                        Text(error.guestMessage)
+                            .font(.caption)
+                            .padding(8)
+                            .background(.regularMaterial, in: Capsule())
                     }
                 }
-                .font(.caption)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-
-                loadedResults(query: query, page: page)
-            }
-            .overlay(alignment: .top) {
-                if let error = presentation.refreshError {
-                    Text(error.guestMessage)
-                        .font(.caption)
-                        .padding(8)
-                        .background(.regularMaterial, in: Capsule())
-                }
-            }
-        case .failed(request: .search(_, _), let error):
+        case .failed(request: .search, let error):
             BrowseFailureView(
                 title: error.guestTitle,
                 message: error.guestMessage,
@@ -144,10 +133,17 @@ public struct VideoSearchView<LoadedContent: View>: View {
     }
 
     private func loadedResults(
-        query: String,
+        criteria: VideoSearchCriteria?,
         page: SearchPage
     ) -> some View {
-        let pagination = model.searchPagination(for: query)
+        let pagination =
+            criteria.map(model.searchPagination(for:))
+            ?? SearchPaginationPresentation(
+                canLoadMore: false,
+                tailIdentity: nil,
+                isLoadingMore: false,
+                loadMoreError: nil
+            )
         return makeLoadedContent(
             page.videos.map(SearchVideoCardPresentation.init),
             $scrollOffsetY,
@@ -192,27 +188,17 @@ private struct SearchResultsSkeleton: View {
     let query: String
 
     var body: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Text("“\(query)”")
-                Spacer()
-                RoundedRectangle(cornerRadius: 3)
-                    .fill(.quinary)
-                    .frame(width: 96, height: 12)
-                    .accessibilityHidden(true)
-            }
-            .font(.caption)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-
-            VideoCardGridSkeleton(loadingLabel: "正在搜索“\(query)”")
-        }
+        VideoCardGridSkeleton(loadingLabel: "正在搜索“\(query)”")
     }
 }
 
 extension GuestFeedRequest {
     fileprivate var searchQuery: String? {
-        guard case .search(let query, _) = self else { return nil }
-        return query
+        searchCriteria?.query
+    }
+
+    fileprivate var searchCriteria: VideoSearchCriteria? {
+        guard case .search(let request) = self else { return nil }
+        return request.criteria
     }
 }

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
@@ -533,6 +533,78 @@ struct BiliAPIClientTests {
     }
 
     @Test
+    func searchEncodesAllTypedCriteriaAndFixedPagination() async throws {
+        let searchResponse = try fixtureResponse("search")
+        let transport = RecordingTransport(
+            responses: [try fixtureResponse("nav")]
+                + Array(repeating: searchResponse, count: 11)
+        )
+        let client = BiliAPIClient(
+            transport: transport,
+            timestampProvider: { 1_700_000_000 }
+        )
+
+        for order in VideoSearchOrder.allCases {
+            _ = try await client.searchVideos(
+                request: VideoSearchRequest(
+                    criteria: VideoSearchCriteria(query: "macOS", order: order),
+                    page: 1
+                )
+            )
+        }
+        for duration in VideoDurationFilter.allCases {
+            _ = try await client.searchVideos(
+                request: VideoSearchRequest(
+                    criteria: VideoSearchCriteria(query: "macOS", duration: duration),
+                    page: 1
+                )
+            )
+        }
+        _ = try await client.searchVideos(
+            request: VideoSearchRequest(
+                criteria: VideoSearchCriteria(
+                    query: "macOS",
+                    publicationRange: VideoPublicationTimeRange(
+                        beginTimestamp: 1_700_000_000,
+                        endTimestamp: 1_700_086_399
+                    )
+                ),
+                page: 2
+            )
+        )
+
+        let searchRequests = await transport.capturedRequests().dropFirst()
+        #expect(searchRequests.count == 11)
+        let queries = searchRequests.map { request in
+            Dictionary(
+                uniqueKeysWithValues: (URLComponents(
+                    url: request.url,
+                    resolvingAgainstBaseURL: false
+                )?.queryItems ?? []).compactMap { item in
+                    item.value.map { (item.name, $0) }
+                }
+            )
+        }
+        #expect(
+            queries.prefix(5).map { $0["order"] } == [
+                "totalrank", "click", "pubdate", "dm", "stow",
+            ]
+        )
+        #expect(
+            queries.dropFirst(5).prefix(5).map { $0["duration"] } == [
+                "0", "1", "2", "3", "4",
+            ]
+        )
+        #expect(queries.allSatisfy { $0["search_type"] == "video" })
+        #expect(queries.allSatisfy { $0["page_size"] == "20" })
+        #expect(queries.last?["page"] == "2")
+        #expect(queries.last?["pubtime_begin_s"] == "1700000000")
+        #expect(queries.last?["pubtime_end_s"] == "1700086399")
+        #expect(queries.allSatisfy { $0["wts"] == "1700000000" })
+        #expect(queries.allSatisfy { $0["w_rid"]?.count == 32 })
+    }
+
+    @Test
     func searchUsesAccountReadWhileWBIKeyStaysAnonymous() async throws {
         let authorizer = RecordingRequestAuthorizer()
         let transport = RecordingTransport(

--- a/Packages/BiliKitCore/Tests/BiliApplicationTests/GuestFeedUseCaseTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliApplicationTests/GuestFeedUseCaseTests.swift
@@ -39,10 +39,48 @@ struct GuestFeedUseCaseTests {
         }
         #expect(await repository.searchQueries().isEmpty)
     }
+
+    @Test
+    func forwardsCompleteSearchCriteriaAndRejectsInvalidRange() async throws {
+        let repository = FeedRepositoryStub()
+        let useCase = GuestFeedUseCase(repository: repository)
+        let criteria = VideoSearchCriteria(
+            query: "  macOS  ",
+            order: .mostDanmaku,
+            duration: .tenToThirtyMinutes,
+            publicationRange: VideoPublicationTimeRange(
+                beginTimestamp: 100,
+                endTimestamp: 200
+            )
+        )
+
+        _ = try await useCase.execute(
+            .search(VideoSearchRequest(criteria: criteria, page: 2))
+        )
+        #expect(
+            await repository.searchRequests()
+                == [VideoSearchRequest(criteria: criteria, page: 2)]
+        )
+
+        let invalid = VideoSearchCriteria(
+            query: "macOS",
+            publicationRange: VideoPublicationTimeRange(
+                beginTimestamp: 201,
+                endTimestamp: 200
+            )
+        )
+        await #expect(throws: GuestApplicationError.invalidRequest) {
+            try await useCase.execute(
+                .search(VideoSearchRequest(criteria: invalid, page: 1))
+            )
+        }
+        #expect(await repository.searchRequests().count == 1)
+    }
 }
 
 private actor FeedRepositoryStub: GuestContentRepository {
     private var observedSearchQueries: [String] = []
+    private var observedSearchRequests: [VideoSearchRequest] = []
 
     func popular(page: Int, pageSize: Int) async throws -> PopularPage {
         PopularPage(videos: [], pageNumber: page, pageSize: pageSize)
@@ -54,6 +92,18 @@ private actor FeedRepositoryStub: GuestContentRepository {
             videos: [],
             pageNumber: page,
             pageSize: 20,
+            totalResults: 0,
+            totalPages: 0
+        )
+    }
+
+    func searchVideos(request: VideoSearchRequest) async throws -> SearchPage {
+        observedSearchRequests.append(request)
+        observedSearchQueries.append(request.criteria.query)
+        return SearchPage(
+            videos: [],
+            pageNumber: request.page,
+            pageSize: request.criteria.pageSize,
             totalResults: 0,
             totalPages: 0
         )
@@ -76,5 +126,9 @@ private actor FeedRepositoryStub: GuestContentRepository {
 
     func searchQueries() -> [String] {
         observedSearchQueries
+    }
+
+    func searchRequests() -> [VideoSearchRequest] {
+        observedSearchRequests
     }
 }

--- a/Packages/BiliKitCore/Tests/BiliApplicationTests/VideoSearchCriteriaTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliApplicationTests/VideoSearchCriteriaTests.swift
@@ -1,0 +1,185 @@
+import BiliApplication
+import Foundation
+import Testing
+
+struct VideoSearchCriteriaTests {
+    private var tokyoCalendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo") ?? .gmt
+        return calendar
+    }
+
+    @Test
+    func criteriaNormalizesQueryAndDefaults() {
+        let criteria = VideoSearchCriteria(query: "  macOS\n")
+
+        #expect(criteria.query == "macOS")
+        #expect(criteria.order == .relevance)
+        #expect(criteria.duration == .all)
+        #expect(criteria.publicationRange == nil)
+        #expect(criteria.pageSize == 20)
+    }
+
+    @Test(arguments: [
+        (VideoPublicationFilter.today, 0),
+        (.lastSevenDays, -6),
+        (.last180Days, -179),
+    ])
+    func relativeRangesFreezeToLocalNaturalDays(
+        filter: VideoPublicationFilter,
+        beginDayOffset: Int
+    ) throws {
+        let calendar = tokyoCalendar
+        let now = try #require(
+            calendar.date(
+                from: DateComponents(
+                    year: 2026,
+                    month: 8,
+                    day: 23,
+                    hour: 14
+                )
+            )
+        )
+        let today = calendar.startOfDay(for: now)
+        let expectedBegin = try #require(
+            calendar.date(byAdding: .day, value: beginDayOffset, to: today)
+        )
+        let range = try #require(
+            try VideoPublicationRangeResolver.resolve(
+                filter: filter,
+                customStart: now,
+                customEnd: now,
+                now: now,
+                calendar: calendar
+            )
+        )
+
+        #expect(range.beginTimestamp == Int64(expectedBegin.timeIntervalSince1970))
+        let expectedEndExclusive = try #require(
+            calendar.date(byAdding: .day, value: 1, to: today)
+        )
+        #expect(
+            range.endTimestamp
+                == Int64(expectedEndExclusive.timeIntervalSince1970) - 1
+        )
+    }
+
+    @Test
+    func customRangeIncludesSingleAndMultipleCompleteDays() throws {
+        let calendar = tokyoCalendar
+        let now = try #require(
+            calendar.date(from: DateComponents(year: 2026, month: 8, day: 23))
+        )
+        let start = try #require(
+            calendar.date(from: DateComponents(year: 2026, month: 8, day: 20))
+        )
+        let single = try #require(
+            try VideoPublicationRangeResolver.resolve(
+                filter: .custom,
+                customStart: start,
+                customEnd: start,
+                now: now,
+                calendar: calendar
+            )
+        )
+        let multiple = try #require(
+            try VideoPublicationRangeResolver.resolve(
+                filter: .custom,
+                customStart: start,
+                customEnd: now,
+                now: now,
+                calendar: calendar
+            )
+        )
+
+        let singleEndExclusive = try #require(
+            calendar.date(byAdding: .day, value: 1, to: start)
+        )
+        let multipleEndExclusive = try #require(
+            calendar.date(byAdding: .day, value: 1, to: now)
+        )
+        #expect(
+            single.endTimestamp
+                == Int64(singleEndExclusive.timeIntervalSince1970) - 1
+        )
+        #expect(
+            multiple.endTimestamp
+                == Int64(multipleEndExclusive.timeIntervalSince1970) - 1
+        )
+    }
+
+    @Test
+    func naturalDayRangeFollowsCalendarAcrossDaylightSavingChanges() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "America/Los_Angeles"))
+
+        for (month, day, expectedHours) in [(3, 8, 23), (11, 1, 25)] {
+            let now = try #require(
+                calendar.date(
+                    from: DateComponents(
+                        year: 2026,
+                        month: month,
+                        day: day,
+                        hour: 12
+                    )
+                )
+            )
+            let begin = calendar.startOfDay(for: now)
+            let endExclusive = try #require(
+                calendar.date(byAdding: .day, value: 1, to: begin)
+            )
+            let range = try #require(
+                try VideoPublicationRangeResolver.resolve(
+                    filter: .today,
+                    customStart: now,
+                    customEnd: now,
+                    now: now,
+                    calendar: calendar
+                )
+            )
+
+            #expect(range.beginTimestamp == Int64(begin.timeIntervalSince1970))
+            #expect(
+                range.endTimestamp
+                    == Int64(endExclusive.timeIntervalSince1970) - 1
+            )
+            #expect(
+                range.endTimestamp - range.beginTimestamp
+                    == Int64(expectedHours * 60 * 60 - 1)
+            )
+        }
+    }
+
+    @Test
+    func customRangeRejectsReverseAndFutureDates() throws {
+        let calendar = tokyoCalendar
+        let today = try #require(
+            calendar.date(from: DateComponents(year: 2026, month: 8, day: 23))
+        )
+        let yesterday = try #require(
+            calendar.date(byAdding: .day, value: -1, to: today)
+        )
+        let tomorrow = try #require(
+            calendar.date(byAdding: .day, value: 1, to: today)
+        )
+
+        #expect(throws: VideoPublicationRangeError.startAfterEnd) {
+            try VideoPublicationRangeResolver.resolve(
+                filter: .custom,
+                customStart: today,
+                customEnd: yesterday,
+                now: today,
+                calendar: calendar
+            )
+        }
+        #expect(throws: VideoPublicationRangeError.futureDate) {
+            try VideoPublicationRangeResolver.resolve(
+                filter: .custom,
+                customStart: today,
+                customEnd: tomorrow,
+                now: today,
+                calendar: calendar
+            )
+        }
+    }
+}

--- a/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliBrowseFeatureTests/GuestBrowseAndVideoViewModelTests.swift
@@ -409,8 +409,17 @@ struct GuestBrowseAndVideoViewModelTests {
         let model = GuestBrowseViewModel(
             useCase: GuestFeedUseCase(repository: repository)
         )
+        let criteria = VideoSearchCriteria(
+            query: "Swift",
+            order: .mostFavorited,
+            duration: .thirtyToSixtyMinutes,
+            publicationRange: VideoPublicationTimeRange(
+                beginTimestamp: 100,
+                endTimestamp: 200
+            )
+        )
 
-        model.search("Swift")
+        model.search(criteria)
         await model.waitForCurrentTask()
         let loadedState = model.state
 
@@ -418,11 +427,11 @@ struct GuestBrowseAndVideoViewModelTests {
         await model.waitForCurrentTask()
         #expect(model.state == loadedState)
         #expect(
-            model.searchPagination(for: "Swift").loadMoreError
+            model.searchPagination(for: criteria).loadMoreError
                 == .transportFailure
         )
-        #expect(!model.searchPagination(for: "Swift").canLoadMore)
-        #expect(model.searchPagination(for: "Swift").tailIdentity == nil)
+        #expect(!model.searchPagination(for: criteria).canLoadMore)
+        #expect(model.searchPagination(for: criteria).tailIdentity == nil)
 
         model.retrySearchLoadMore()
         await model.waitForCurrentTask()
@@ -432,6 +441,14 @@ struct GuestBrowseAndVideoViewModelTests {
         }
         #expect(page.videos.map(\.bvid) == [first.bvid, second.bvid])
         #expect(await repository.searchCallCount == 3)
+        #expect(
+            await repository.searchRequests
+                == [
+                    VideoSearchRequest(criteria: criteria, page: 1),
+                    VideoSearchRequest(criteria: criteria, page: 2),
+                    VideoSearchRequest(criteria: criteria, page: 2),
+                ]
+        )
     }
 
     @Test(.timeLimit(.minutes(1)))
@@ -462,6 +479,49 @@ struct GuestBrowseAndVideoViewModelTests {
         #expect(query == "新查询")
         #expect(page.videos.map(\.bvid) == [fresh.bvid])
         #expect(page.pageNumber == 1)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func criteriaChangeCancelsAppendAndStartsANewPageOneWorkset() async throws {
+        let old = GuestFixtures(bvid: "BV1SearchCriteriaOld", title: "旧条件")
+        let fresh = GuestFixtures(bvid: "BV1SearchCriteriaNew", title: "新条件")
+        let repository = BlockingSearchAppendRepositoryStub(old: old, fresh: fresh)
+        let model = GuestBrowseViewModel(
+            useCase: GuestFeedUseCase(repository: repository)
+        )
+        let oldCriteria = VideoSearchCriteria(query: "macOS")
+        let newCriteria = VideoSearchCriteria(
+            query: "macOS",
+            order: .mostPlayed,
+            duration: .underTenMinutes
+        )
+
+        model.search(oldCriteria)
+        await model.waitForCurrentTask()
+        model.loadMoreSearch()
+        try await repository.waitForOldAppendStart()
+        let oldAppendTask = try #require(model.taskSnapshotForTesting())
+
+        model.search(newCriteria)
+        await model.waitForCurrentTask()
+        await repository.releaseOldAppend()
+        await oldAppendTask.value
+
+        guard case .loaded(.search(let query, let page)) = model.state else {
+            Issue.record("新条件应保持 loaded")
+            return
+        }
+        #expect(query == "macOS")
+        #expect(page.pageNumber == 1)
+        #expect(page.videos.map(\.bvid) == [fresh.bvid])
+        #expect(
+            model.activeRequestIdentity
+                == .search(
+                    VideoSearchRequest(criteria: newCriteria, page: 1)
+                )
+        )
+        #expect(model.searchPagination(for: newCriteria).loadMoreError == nil)
     }
 
     @Test(.timeLimit(.minutes(1)))
@@ -2725,6 +2785,7 @@ private actor SearchPaginationRepositoryStub: GuestContentRepository {
     let second: GuestFixtures
     let failFirstSecondPage: Bool
     private(set) var searchCallCount = 0
+    private(set) var searchRequests: [VideoSearchRequest] = []
     private var secondPageAttempts = 0
 
     init(
@@ -2742,8 +2803,18 @@ private actor SearchPaginationRepositoryStub: GuestContentRepository {
     }
 
     func searchVideos(keyword: String, page: Int) async throws -> SearchPage {
+        try await searchVideos(
+            request: VideoSearchRequest(
+                criteria: VideoSearchCriteria(query: keyword),
+                page: page
+            )
+        )
+    }
+
+    func searchVideos(request: VideoSearchRequest) async throws -> SearchPage {
+        searchRequests.append(request)
         searchCallCount += 1
-        switch page {
+        switch request.page {
         case 1:
             return SearchPage(
                 videos: [first.searchVideo, first.searchVideo],
@@ -2960,7 +3031,21 @@ private actor BlockingSearchAppendRepositoryStub: GuestContentRepository {
     }
 
     func searchVideos(keyword: String, page: Int) async throws -> SearchPage {
-        if keyword == "旧查询", page == 2 {
+        try await searchVideos(
+            request: VideoSearchRequest(
+                criteria: VideoSearchCriteria(query: keyword),
+                page: page
+            )
+        )
+    }
+
+    func searchVideos(request: VideoSearchRequest) async throws -> SearchPage {
+        let keyword = request.criteria.query
+        let page = request.page
+        let isOldCriteria = request.criteria.order == .relevance
+        if keyword == "旧查询" || keyword == "macOS", page == 2,
+            isOldCriteria
+        {
             await oldAppendEvents.signal()
             await withCheckedContinuation { continuation in
                 if oldAppendReleased {
@@ -2977,13 +3062,14 @@ private actor BlockingSearchAppendRepositoryStub: GuestContentRepository {
                 totalPages: 2
             )
         }
-        let fixture = keyword == "旧查询" ? old : fresh
+        let usesOldResult = keyword == "旧查询" || (keyword == "macOS" && isOldCriteria)
+        let fixture = usesOldResult ? old : fresh
         return SearchPage(
             videos: [fixture.searchVideo],
             pageNumber: 1,
             pageSize: 20,
-            totalResults: keyword == "旧查询" ? 2 : 1,
-            totalPages: keyword == "旧查询" ? 2 : 1
+            totalResults: usesOldResult ? 2 : 1,
+            totalPages: usesOldResult ? 2 : 1
         )
     }
 


### PR DESCRIPTION
## 变化

- 在原生搜索 toolbar 增加单层排序 Menu，支持综合排序、最多播放、最新发布、最多弹幕和最多收藏，并以系统菜单选中状态显示当前项。
- 增加日期与时长筛选 Popover；筛选使用独立 draft，只有“应用”提交，“取消”、外部关闭和“恢复默认”均不会立即改变已生效条件。
- V1 固定视频搜索，完整编码 order、duration、pubtime_begin_s、pubtime_end_s、page 与固定 page_size=20。
- 建立语义化 criteria/request，并沿用现有 AppRootView → GuestBrowseViewModel → GuestFeedUseCase → BiliGuestRepository → BiliAPIClient 唯一链路。
- 条件变化会取消旧请求、重置 page/去重/滚动；generation 与完整 request identity 隔离迟到结果，分页继续复用完整 criteria。
- 删除搜索框下方冗余摘要行；空结果保留 toolbar 条件并提供“清除筛选”。

## 原因

现有搜索只能提交关键词，无法表达 B 站视频搜索已有的排序、时长和发布日期参数。本实现把条件纳入搜索工作集 identity，在不新增服务、平行 ViewModel 或认证路径的前提下扩展现有原生链路。

官方搜索页面的实际请求确认：order=dm、order=stow；最近一天为当前时区当天自然日，最近一周为含当天 7 个自然日，最近半年为含当天 180 个自然日。实现采用用户当前 Calendar/时区，并在应用相对日期时冻结具体秒数。

认证边界保持不变：WBI key 继续通过匿名 nav 获取；搜索沿用 account-read authorizer；仅明确缺失凭据允许匿名；授权拒绝与凭据故障 fail closed；403 最多刷新 WBI 后重试一次；412/-352 不匿名旁路。

## 用户影响

用户可以直接从搜索 toolbar 选择排序，并在原生 Popover 中组合发布日期和视频时长筛选。筛选按钮以图标、文字、数量、VoiceOver value 和 help 共同表达状态；760pt 窄窗口沿用系统 toolbar overflow。

## 验证

- [x] 唯一最高适用 Gate（app；实际命令：env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer sh Scripts/run-quality-gates.sh app）
  - 静态架构、秘密模式、工程契约和严格格式检查通过。
  - 61 个 Package suites、604 项测试通过。
  - fresh App build-for-testing 与 App tests 通过；现有 SignedKeychainSmokeTests 按 gate 的无签名合同跳过。
- [x] 必要的真实 UI、签名、网络或性能检查
  - 使用本 worktree fresh Apple Development 签名 Debug App。
  - 检查单层五项排序、筛选 Popover、约 900pt/760pt toolbar 与系统 overflow。
  - 当前登录会话真实 order=stow 搜索返回结果。
  - 日期 helper 覆盖东京自然日、自定义单日/跨日、非法/未来日期，以及洛杉矶 DST 23/25 小时自然日。

## 未覆盖边界

- 当前环境为 macOS 26.6.2，未在 macOS 15 运行。
- 未完成人工 VoiceOver/FKA、浅色/深色完整矩阵、匿名真实网络和全部错误注入矩阵。
- 独立 codesign 严格信任链检查在本机返回 CSSMERR_TP_NOT_TRUSTED；签名 App 本身已成功构建并启动。
- 本 PR 不修改 Localizable.xcstrings。新增文案已使用真实本地化资源入口；按协调约定，本 PR 合并后由并行多语言 worktree 重放最新 main 并补齐 zh-Hans/zh-Hant/ja/en catalog。