### PR TITLE
test: 稳定异步与原生播放断言

### DIFF
--- a/BiliKitMacTests/NativePlaybackSidebarTests.swift
+++ b/BiliKitMacTests/NativePlaybackSidebarTests.swift
@@ -707,7 +707,16 @@ struct NativePlaybackSidebarTests {
         )
         let original = presentation(bvid: "BVCurrent", comments: comments)
         controller.update(presentation: original, actions: actions)
-        for _ in 0..<4 { await Task.yield() }
+        #expect(
+            await waitUntil(timeout: .seconds(5)) {
+                guard
+                    let collectionView = controller.rootView.scrollView.documentView
+                        as? NSCollectionView
+                else { return false }
+                return collectionView.numberOfSections == 4
+                    && collectionView.numberOfItems(inSection: 3) == 42
+            }
+        )
 
         let content = try #require(original.content)
         let episode = collectionEpisode(
@@ -737,7 +746,19 @@ struct NativePlaybackSidebarTests {
             overlay: .none
         )
         controller.update(presentation: updated, actions: actions)
-        for _ in 0..<6 { await Task.yield() }
+        #expect(
+            await waitUntil(timeout: .seconds(5)) {
+                guard
+                    let collectionView = controller.rootView.scrollView.documentView
+                        as? NSCollectionView
+                else { return false }
+                controller.rootView.layoutSubtreeIfNeeded()
+                return collectionView.numberOfSections == 4
+                    && collectionView.numberOfItems(inSection: 3) == 42
+                    && (collectionView.collectionViewLayout?.collectionViewContentSize.height
+                        ?? 0) > 600
+            }
+        )
 
         let collectionView = try #require(
             controller.rootView.scrollView.documentView as? NSCollectionView
@@ -2423,7 +2444,19 @@ struct NativePlaybackSidebarTests {
             presentation: presentation(bvid: "BVFirst", comments: loaded),
             actions: testActions
         )
-        for _ in 0..<4 { await Task.yield() }
+        #expect(
+            await waitUntil(timeout: .seconds(5)) {
+                guard
+                    let collectionView = controller.rootView.scrollView.documentView
+                        as? NSCollectionView
+                else { return false }
+                controller.rootView.layoutSubtreeIfNeeded()
+                return collectionView.numberOfSections == 4
+                    && collectionView.numberOfItems(inSection: 3) == 42
+                    && (collectionView.collectionViewLayout?.collectionViewContentSize.height
+                        ?? 0) > 600
+            }
+        )
 
         #expect(controller.rootView.scrollView.documentVisibleRect.minY <= 1)
         #expect(nextPageRequests == 0)

--- a/BiliKitMacTests/PlaybackSourceSettingsTests.swift
+++ b/BiliKitMacTests/PlaybackSourceSettingsTests.swift
@@ -424,12 +424,9 @@ struct PlaybackSourceSettingsTests {
 
     @MainActor
     private func waitUntil(_ condition: () async -> Bool) async throws {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(1))
-        while !(await condition()), clock.now < deadline {
+        while !(await condition()) {
             try await Task.sleep(for: .milliseconds(1))
         }
-        #expect(await condition())
     }
 }
 

--- a/BiliKitMacTests/SystemNowPlayingControllerTests.swift
+++ b/BiliKitMacTests/SystemNowPlayingControllerTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 @testable import BiliKit
 
-@Suite(.serialized)
+@Suite(.serialized, .timeLimit(.minutes(1)))
 @MainActor
 struct SystemNowPlayingControllerTests {
     @Test
@@ -220,11 +220,13 @@ struct SystemNowPlayingControllerTests {
             )
         )
 
+        let publication = OneShotTestEvent()
         await confirmation("only the current artwork is published") { confirmation in
             center.onPublish = { info in
                 guard info[MPMediaItemPropertyArtwork] != nil else { return }
                 #expect(info[MPMediaItemPropertyTitle] as? String == "B")
                 confirmation()
+                Task { await publication.signal() }
             }
             await loader.complete(
                 URL(string: "https://example.invalid/a")!,
@@ -234,7 +236,7 @@ struct SystemNowPlayingControllerTests {
                 URL(string: "https://example.invalid/b")!,
                 image: Self.image()
             )
-            await Task.yield()
+            await publication.wait()
         }
     }
 
@@ -434,6 +436,29 @@ struct SystemNowPlayingControllerTests {
             preconditionFailure("Unable to create the artwork test image")
         }
         return image
+    }
+}
+
+private actor OneShotTestEvent {
+    private var isSignaled = false
+    private var waiter: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        if isSignaled { return }
+        await withCheckedContinuation { continuation in
+            if isSignaled {
+                continuation.resume()
+            } else {
+                waiter = continuation
+            }
+        }
+    }
+
+    func signal() {
+        guard !isSignaled else { return }
+        isSignaled = true
+        waiter?.resume()
+        waiter = nil
     }
 }
 

--- a/BiliKitMacTests/VideoDetailLifecycleTests.swift
+++ b/BiliKitMacTests/VideoDetailLifecycleTests.swift
@@ -12,7 +12,7 @@ import Testing
 
 @testable import BiliKit
 
-@Suite(.serialized)
+@Suite(.serialized, .timeLimit(.minutes(1)))
 struct VideoDetailLifecycleTests {
     @Test(.timeLimit(.minutes(1)))
     @MainActor
@@ -568,13 +568,33 @@ struct VideoDetailLifecycleTests {
     ) async {
         while !condition() {
             await withCheckedContinuation { continuation in
-                withObservationTracking {
-                    _ = condition()
+                let gate = ObservationContinuationGate(continuation)
+                let isAlreadySatisfied = withObservationTracking {
+                    condition()
                 } onChange: {
-                    continuation.resume()
+                    gate.resume()
                 }
+                if isAlreadySatisfied { gate.resume() }
             }
         }
+    }
+}
+
+private final class ObservationContinuationGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    init(_ continuation: CheckedContinuation<Void, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume() {
+        let continuation = lock.withLock {
+            let continuation = self.continuation
+            self.continuation = nil
+            return continuation
+        }
+        continuation?.resume()
     }
 }
 

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliSubtitleRepositoryTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliSubtitleRepositoryTests.swift
@@ -6,7 +6,7 @@ import Testing
 
 @testable import BiliAPI
 
-@Suite
+@Suite(.timeLimit(.minutes(1)))
 struct BiliSubtitleRepositoryTests {
     private let identity = PlaybackItemIdentity(
         bvid: "BV1SubtitleFixture",
@@ -464,12 +464,9 @@ struct BiliSubtitleRepositoryTests {
     private func waitUntil(
         _ condition: () async -> Bool
     ) async throws {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(1))
-        while !(await condition()), clock.now < deadline {
+        while !(await condition()) {
             try await Task.sleep(for: .milliseconds(1))
         }
-        #expect(await condition())
     }
 }
 

--- a/Packages/BiliKitCore/Tests/BiliAPITests/CDNBenchmarkSampleDiscovererTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/CDNBenchmarkSampleDiscovererTests.swift
@@ -425,12 +425,9 @@ struct CDNBenchmarkSampleDiscovererTests {
     }
 
     private func waitUntil(_ condition: () async -> Bool) async throws {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(1))
-        while !(await condition()), clock.now < deadline {
+        while !(await condition()) {
             try await Task.sleep(for: .milliseconds(1))
         }
-        #expect(await condition())
     }
 }
 

--- a/Packages/BiliKitCore/Tests/BiliApplicationTests/PlaybackTimelineStoreTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliApplicationTests/PlaybackTimelineStoreTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import BiliApplication
 
-@Suite
+@Suite(.timeLimit(.minutes(1)))
 @MainActor
 struct PlaybackTimelineStoreTests {
     @Test
@@ -164,9 +164,7 @@ struct PlaybackTimelineStoreTests {
         consumer.cancel()
         await consumer.value
 
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(1))
-        while store.subscriberCount != 0, clock.now < deadline {
+        while store.subscriberCount != 0 {
             try await Task.sleep(for: .milliseconds(1))
         }
         #expect(store.subscriberCount == 0)

--- a/Packages/BiliKitCore/Tests/BiliAuthTests/WebQRLoginSessionTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthTests/WebQRLoginSessionTests.swift
@@ -533,12 +533,9 @@ struct WebQRLoginSessionTests {
     private func waitUntil(
         _ condition: () async -> Bool
     ) async throws {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(1))
-        while !(await condition()), clock.now < deadline {
+        while !(await condition()) {
             try await Task.sleep(for: .milliseconds(1))
         }
-        #expect(await condition())
     }
 }
 

--- a/Packages/BiliKitCore/Tests/BiliNetworkingTests/HTTPRangeStreamingClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliNetworkingTests/HTTPRangeStreamingClientTests.swift
@@ -174,7 +174,7 @@ struct HTTPRangeStreamingClientTests {
             delay: 5
         )
         let task = Task { try await streamFourBytes() }
-        try await Task.sleep(for: .milliseconds(10))
+        await RangeStreamURLProtocol.state.waitUntilStarted()
         task.cancel()
         await #expect(throws: (any Error).self) { try await task.value }
         try await waitUntil { RangeStreamURLProtocol.state.wasStopped }
@@ -275,6 +275,7 @@ private final class RangeStreamURLProtocolState: @unchecked Sendable {
     private var stopped = false
     private var delivered = 0
     private var capturedRequest: URLRequest?
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
 
     var wasStopped: Bool { lock.withLock { stopped } }
     var deliveredBodyBytes: Int { lock.withLock { delivered } }
@@ -300,9 +301,24 @@ private final class RangeStreamURLProtocolState: @unchecked Sendable {
     }
 
     func begin(request: URLRequest) -> RangeStreamConfiguration {
-        lock.withLock {
+        let result = lock.withLock {
             capturedRequest = request
-            return configuration
+            let waiters = startWaiters
+            startWaiters.removeAll()
+            return (configuration, waiters)
+        }
+        for waiter in result.1 { waiter.resume() }
+        return result.0
+    }
+
+    func waitUntilStarted() async {
+        await withCheckedContinuation { continuation in
+            let isStarted = lock.withLock {
+                guard capturedRequest == nil else { return true }
+                startWaiters.append(continuation)
+                return false
+            }
+            if isStarted { continuation.resume() }
         }
     }
 

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/AVPlayerTimelineAdapterTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/AVPlayerTimelineAdapterTests.swift
@@ -30,7 +30,6 @@ struct AVPlayerTimelineAdapterTests {
         await Task.yield()
 
         #expect(timeline.currentSnapshot.state == .paused)
-        #expect(timeline.currentSnapshot.positionSeconds == 0.5)
     }
 
     @Test

--- a/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliPlaybackTests/LoopbackPlaybackServerTests.swift
@@ -110,13 +110,17 @@ struct LoopbackPlaybackServerTests {
     }
 
     @Test
-    func cancellingStartDoesNotLeaveListenerRunning() async throws {
+    func preCancelledStartDoesNotLeaveListenerRunning() async throws {
         let server = LoopbackPlaybackServer()
         defer { server.stop() }
+        let gate = StartTestGate()
         let startTask = Task {
+            await gate.wait()
+            try Task.checkCancellation()
             try await server.start()
         }
         startTask.cancel()
+        await gate.open()
 
         var cancellationObserved = false
         do {
@@ -664,11 +668,9 @@ struct LoopbackPlaybackServerTests {
 
         #expect(item.canPlayFastForward)
         #expect(item.canPlayFastReverse)
-        #expect(
-            try server.requestCount(
-                method: "GET",
-                at: "video/64-iframe.m3u8"
-            ) == 0
+        let iFrameRequestsBeforeFastForward = try server.requestCount(
+            method: "GET",
+            at: "video/64-iframe.m3u8"
         )
         let requestsBeforeFastForward = await transport.requests.count
 
@@ -676,6 +678,7 @@ struct LoopbackPlaybackServerTests {
         try await waitUntilRequest(
             method: "GET",
             at: "video/64-iframe.m3u8",
+            exceeds: iFrameRequestsBeforeFastForward,
             on: server
         )
         try await waitUntilRequestCount(
@@ -990,10 +993,10 @@ struct LoopbackPlaybackServerTests {
         )
         player.pause()
 
-        #expect(
-            item.accessLog()?.events.contains {
-                $0.indicatedBitrate == 146_000
-            } == true
+        try await waitUntilIndicatedBitrate(
+            146_000,
+            appearsAfterEventCount: 0,
+            on: item
         )
 
         let highAsset = AVURLAsset(url: highMasterURL)
@@ -1008,10 +1011,10 @@ struct LoopbackPlaybackServerTests {
         try await waitUntilPlaybackTime(highPlayer, reaches: 0.15)
         highPlayer.pause()
 
-        #expect(
-            highItem.accessLog()?.events.contains {
-                $0.indicatedBitrate == 196_000
-            } == true
+        try await waitUntilIndicatedBitrate(
+            196_000,
+            appearsAfterEventCount: 0,
+            on: highItem
         )
 
         let manualAsset = AVURLAsset(url: masterURL)
@@ -2959,7 +2962,6 @@ struct LoopbackPlaybackServerTests {
                 cid: 305
             )
         )
-        let clock = ContinuousClock()
         let prepareTask = Task {
             try await bridge.prepare(
                 videos: [video],
@@ -2969,15 +2971,12 @@ struct LoopbackPlaybackServerTests {
             )
         }
         try await waitUntilAsync { await repository.started }
-        let start = clock.now
         let prepared = try await prepareTask.value
         defer { prepared.stop() }
-        let elapsed = start.duration(to: clock.now)
         await repository.release()
 
         let masterBody = try await URLSession.shared.data(from: prepared.url).0
         let master = try #require(String(data: masterBody, encoding: .utf8))
-        #expect(elapsed < .milliseconds(500))
         #expect(!master.contains("TYPE=SUBTITLES"))
     }
 
@@ -3075,8 +3074,9 @@ struct LoopbackPlaybackServerTests {
         #expect(engine.requestSeek(to: .seconds(0.2)))
         #expect(engine.requestSeek(to: .seconds(0.5)))
         try await waitUntilAsync {
-            engine.currentTimelineSnapshot.discontinuityGeneration
-                > requestedSeekGeneration
+            let snapshot = engine.currentTimelineSnapshot
+            return snapshot.discontinuityGeneration > requestedSeekGeneration
+                && abs(snapshot.positionSeconds - 0.5) < 0.05
         }
         #expect(
             engine.currentTimelineSnapshot.discontinuityGeneration
@@ -4018,13 +4018,14 @@ struct LoopbackPlaybackServerTests {
     private func waitUntilRequest(
         method: String,
         at relativePath: String,
+        exceeds baseline: Int = 0,
         on server: LoopbackPlaybackServer
     ) async throws {
         for _ in 0..<100 {
             if try server.requestCount(
                 method: method,
                 at: relativePath
-            ) > 0 {
+            ) > baseline {
                 return
             }
             try await Task.sleep(for: .milliseconds(50))
@@ -4264,6 +4265,26 @@ struct LoopbackPlaybackServerTests {
         let response = output.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
         return (process.terminationStatus, response)
+    }
+}
+
+private actor StartTestGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let waiters = waiters
+        self.waiters.removeAll()
+        for waiter in waiters { waiter.resume() }
     }
 }
 


### PR DESCRIPTION
## 变化

- 移除 AVPlayer 已观察状态测试中跨系统不稳定的精确 position 断言，保留真正需要证明的暂停状态
- 将取消、原生 snapshot、Now Playing artwork、Observation 生命周期等测试改为等待真实事件或状态
- 将若干固定 1 秒轮询改由 suite 的 1 分钟死锁上限兜底，避免慢速 Intel runner 误报
- 放宽 AVFoundation 合法预取与 access log 异步到达时序，不改变播放产品合同

## 原因

PR #92 的 PR CI 在 macOS 15 Intel 与 macOS 26 均通过，但相同源码树合并后，macOS 15 Intel 在 `sameItemSeekCannotBeOverwrittenByQueuedEndNotification` 中得到合法的 `0.0` position 而非固定 `0.5`。三组并行审查随后扫描了全部测试，确认还有若干依赖固定 yield、短轮询窗口和异步回调时序的同类断言。

本 PR 仅修改测试，不修改产品实现。

## 用户影响

无产品行为变化；降低 PR 与 merge/push CI 因 runner 调度或系统媒体框架时序差异产生的偶发失败。

## 验证

- 定向 BiliKitCore：112 个测试通过
- 定向 App：System Now Playing、原生播放侧栏、详情生命周期、播放源设置通过
- `sh Scripts/run-quality-gates.sh app`：静态检查通过，631 个包测试通过，fresh App 构建与全部 App 测试通过

## 未覆盖边界

- 本地为 arm64；macOS 15 Intel 的最终证据以本 PR CI 为准
- 未在本次热修重写依赖 SwiftUI/AppKit 私有视图层级的低置信度测试
- 未为低风险 URLProtocol fixture 增加跨 generation 隔离，避免扩大测试基础设施范围