### PR TITLE
fix(settings): 修正测速生命周期并降低定向测试成本

### DIFF
--- a/BiliKitMac/App/BiliKitMacApp.swift
+++ b/BiliKitMac/App/BiliKitMacApp.swift
@@ -9,9 +9,19 @@ import SwiftUI
 
 @main
 struct BiliKitMacApp: App {
-    @State private var accountSessionCoordinator = AccountSessionCoordinator()
+    @State private var accountSessionCoordinator: AccountSessionCoordinator
     @State private var systemNowPlayingController = SystemNowPlayingController()
-    @State private var appSettingsModel = AppSettingsModel.live()
+    @State private var appSettingsModel: AppSettingsModel
+
+    init() {
+        let accountSessionCoordinator = AccountSessionCoordinator()
+        _accountSessionCoordinator = State(initialValue: accountSessionCoordinator)
+        _appSettingsModel = State(
+            initialValue: AppEnvironment.liveAppSettingsModel(
+                accountSessionCoordinator: accountSessionCoordinator
+            )
+        )
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -349,6 +349,44 @@ struct AppEnvironment {
         )
     }
 
+    static func liveAppSettingsModel(
+        accountSessionCoordinator: AccountSessionCoordinator
+    ) -> AppSettingsModel {
+        let api = makeLiveAPIClient()
+        _ = accountSessionCoordinator.registerSessionInvalidator(api)
+        let discoverer = CDNBenchmarkSampleDiscoverer(client: api)
+        let benchmark = BilivideoRouteBenchmark()
+        return AppSettingsModel(
+            store: UserDefaultsPlaybackSourcePreferenceStore(),
+            benchmarkAccess: .resolving,
+            discover: { targetCount in
+                do {
+                    return try await discoverer.discover(targetCount: targetCount).map {
+                        PlaybackRouteBenchmarkSample(
+                            template: $0.videoRepresentation,
+                            headers: $0.mediaHeaders
+                        )
+                    }
+                } catch let error as BiliAPIError {
+                    switch error {
+                    case .authorizationRequired, .authenticationInvalid,
+                        .authorizationUnavailable:
+                        throw PlaybackRouteBenchmarkOperationError.authenticationFailure
+                    default:
+                        throw error
+                    }
+                }
+            },
+            resetDiscovery: { await discoverer.resetSeenSamples() },
+            run: { samples, progress in
+                try await benchmark.benchmarkUnifiedPool(
+                    samples: samples,
+                    progress: progress
+                )
+            }
+        )
+    }
+
     /// 创建生产对象图，并保持游客、媒体与字幕正文请求不自动继承登录 Cookie。
     ///
     /// 只有 BiliAPI 私有标记的账户读取才经过 authorizer；公开 Browse、Search、评论、
@@ -358,25 +396,7 @@ struct AppEnvironment {
         accountSessionCoordinator: AccountSessionCoordinator? = nil,
         appSettingsModel: AppSettingsModel? = nil
     ) -> AppEnvironment {
-        let requestAuthorizer = BiliCredentialRequestAuthorizer()
-        let transportFactory: @Sendable () -> any HTTPTransport = {
-            let configuration = URLSessionConfiguration.ephemeral
-            configuration.httpShouldSetCookies = false
-            configuration.httpCookieStorage = nil
-            configuration.urlCache = nil
-            configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
-            configuration.timeoutIntervalForRequest = 15
-            configuration.timeoutIntervalForResource = 30
-            return URLSessionTransport(
-                configuration: configuration,
-                redirectPolicy: .reject
-            )
-        }
-        let api = BiliAPIClient(
-            requestAuthorizer: requestAuthorizer,
-            transportFactory: transportFactory
-        )
-        appSettingsModel?.configureBenchmark(client: api)
+        let api = makeLiveAPIClient()
         let sessionRegistration = accountSessionCoordinator.map {
             AppEnvironmentSessionRegistration(
                 coordinator: $0,
@@ -442,6 +462,27 @@ struct AppEnvironment {
         surfaceWidth: 0,
         surfaceHeight: 0
     )
+
+    private static func makeLiveAPIClient() -> BiliAPIClient {
+        let requestAuthorizer = BiliCredentialRequestAuthorizer()
+        let transportFactory: @Sendable () -> any HTTPTransport = {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.httpShouldSetCookies = false
+            configuration.httpCookieStorage = nil
+            configuration.urlCache = nil
+            configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+            configuration.timeoutIntervalForRequest = 15
+            configuration.timeoutIntervalForResource = 30
+            return URLSessionTransport(
+                configuration: configuration,
+                redirectPolicy: .reject
+            )
+        }
+        return BiliAPIClient(
+            requestAuthorizer: requestAuthorizer,
+            transportFactory: transportFactory
+        )
+    }
 }
 
 @MainActor

--- a/BiliKitMac/Settings/AppSettingsModel.swift
+++ b/BiliKitMac/Settings/AppSettingsModel.swift
@@ -1,4 +1,3 @@
-import BiliAPI
 import BiliPlayback
 import Foundation
 import Observation
@@ -26,16 +25,19 @@ enum PlaybackRouteBenchmarkAccess: Sendable, Equatable {
     var allowsBenchmark: Bool { self == .signedIn }
 }
 
+enum PlaybackRouteBenchmarkOperationError: Error {
+    case authenticationFailure
+}
+
 @MainActor
 @Observable
 final class AppSettingsModel {
-    static let supportedBenchmarkSampleCounts =
-        CDNBenchmarkSampleDiscoverer.supportedSampleCounts
-    typealias Discover = @Sendable (Int) async throws -> [CDNBenchmarkDiscoveredSample]
+    static let supportedBenchmarkSampleCounts = 1...3
+    typealias Discover = @Sendable (Int) async throws -> [PlaybackRouteBenchmarkSample]
     typealias ResetDiscovery = @Sendable () async -> Void
     typealias Run =
         @Sendable (
-            [CDNBenchmarkDiscoveredSample],
+            [PlaybackRouteBenchmarkSample],
             @escaping @Sendable (Int, Int) async -> Void
         ) async throws -> [PlaybackRouteMeasurement]
 
@@ -51,7 +53,6 @@ final class AppSettingsModel {
     @ObservationIgnored private var task: Task<Void, Never>?
     @ObservationIgnored private var discoveryResetTask: Task<Void, Never>?
     @ObservationIgnored private var generation = UUID()
-    @ObservationIgnored private var isConfigured = false
     @ObservationIgnored private var authenticationAccessByOwner:
         [UUID: PlaybackRouteBenchmarkAccess] = [:]
 
@@ -70,38 +71,9 @@ final class AppSettingsModel {
         record = store.load()
     }
 
-    static func live() -> AppSettingsModel {
-        AppSettingsModel(
-            store: UserDefaultsPlaybackSourcePreferenceStore(),
-            benchmarkAccess: .resolving,
-            discover: { _ in throw BiliAPIError.authorizationRequired },
-            run: { _, _ in throw BiliAPIError.authorizationRequired }
-        )
-    }
-
     deinit {
         task?.cancel()
         discoveryResetTask?.cancel()
-    }
-
-    func configureBenchmark(client: BiliAPIClient) {
-        guard !isConfigured else { return }
-        isConfigured = true
-        let discoverer = CDNBenchmarkSampleDiscoverer(client: client)
-        let benchmark = BilivideoRouteBenchmark()
-        discover = { try await discoverer.discover(targetCount: $0) }
-        resetDiscovery = { await discoverer.resetSeenSamples() }
-        run = { samples, progress in
-            try await benchmark.benchmarkUnifiedPool(
-                samples: samples.map {
-                    PlaybackRouteBenchmarkSample(
-                        template: $0.videoRepresentation,
-                        headers: $0.mediaHeaders
-                    )
-                },
-                progress: progress
-            )
-        }
     }
 
     func synchronizeAuthentication(_ access: PlaybackRouteBenchmarkAccess) {
@@ -227,16 +199,11 @@ final class AppSettingsModel {
                 self?.applyResult(result, generation: currentGeneration)
             } catch is CancellationError {
                 self?.applyCancellation(generation: currentGeneration)
-            } catch let error as BiliAPIError {
-                let failure: PlaybackRouteBenchmarkState =
-                    switch error {
-                    case .authorizationRequired, .authenticationInvalid,
-                        .authorizationUnavailable:
-                        .authenticationFailure
-                    default:
-                        .networkOrProtocolFailure
-                    }
-                self?.applyFailure(failure, generation: currentGeneration)
+            } catch PlaybackRouteBenchmarkOperationError.authenticationFailure {
+                self?.applyFailure(
+                    .authenticationFailure,
+                    generation: currentGeneration
+                )
             } catch {
                 self?.applyFailure(
                     .networkOrProtocolFailure,

--- a/BiliKitMacTests/PlaybackSourceSettingsTests.swift
+++ b/BiliKitMacTests/PlaybackSourceSettingsTests.swift
@@ -1,4 +1,3 @@
-import BiliAPI
 import BiliAuthFeature
 import BiliModels
 import BiliPlayback
@@ -281,10 +280,26 @@ struct PlaybackSourceSettingsTests {
         let model = AppSettingsModel(
             store: MemoryPlaybackSourcePreferenceStore(),
             discover: { _ in [try Self.sample()] },
-            run: { _, _ in throw BiliAPIError.transportFailure }
+            run: { _, _ in throw BenchmarkTestError.transportFailure }
         )
         model.startBenchmark()
         try await waitUntil { model.state == .networkOrProtocolFailure }
+
+        #expect(model.measurements.isEmpty)
+        #expect(model.selection == .serverDefault)
+    }
+
+    @Test @MainActor
+    func authenticationFailureKeepsItsDedicatedPresentationState() async throws {
+        let model = AppSettingsModel(
+            store: MemoryPlaybackSourcePreferenceStore(),
+            discover: { _ in
+                throw PlaybackRouteBenchmarkOperationError.authenticationFailure
+            },
+            run: { _, _ in [] }
+        )
+        model.startBenchmark()
+        try await waitUntil { model.state == .authenticationFailure }
 
         #expect(model.measurements.isEmpty)
         #expect(model.selection == .serverDefault)
@@ -387,15 +402,15 @@ struct PlaybackSourceSettingsTests {
         AppSettingsModel(store: store, discover: { _ in [] }, run: { _, _ in [] })
     }
 
-    private static func sample() throws -> CDNBenchmarkDiscoveredSample {
+    private static func sample() throws -> PlaybackRouteBenchmarkSample {
         let primaryURL = try #require(
             URL(string: "https://a.bilivideo.com/v.m4s?t=1")
         )
         let backupURL = try #require(
             URL(string: "https://a.akamaized.net/v.m4s?h=1")
         )
-        return CDNBenchmarkDiscoveredSample(
-            videoRepresentation: MediaRepresentation(
+        return PlaybackRouteBenchmarkSample(
+            template: MediaRepresentation(
                 id: 80,
                 kind: .video,
                 codecs: "avc1.640028",
@@ -409,7 +424,7 @@ struct PlaybackSourceSettingsTests {
                     index: try MediaByteRange(start: 10, endInclusive: 19)
                 )
             ),
-            mediaHeaders: [:]
+            headers: [:]
         )
     }
 
@@ -428,6 +443,10 @@ struct PlaybackSourceSettingsTests {
             try await Task.sleep(for: .milliseconds(1))
         }
     }
+}
+
+private enum BenchmarkTestError: Error {
+    case transportFailure
 }
 
 private final class MemoryPlaybackSourcePreferenceStore: PlaybackSourcePreferenceStoring,

--- a/Scripts/check-project-contract.sh
+++ b/Scripts/check-project-contract.sh
@@ -71,5 +71,6 @@ expect_count 0 '#if compiler(>=6.2)' "$app_source_roots" "搜索栏不得为旧 
 expect_count 0 '#if compiler(>=6.2)' "$player_host" "播放器提示不得为旧 SDK 保留编译期回退"
 
 sh -n Scripts/run-quality-gates.sh || fail "质量 Gate 脚本语法无效"
+sh -n Scripts/run-targeted-tests.sh || fail "定向测试脚本语法无效"
 
 echo "工程、安全能力与最低系统版本静态契约检查通过"

--- a/Scripts/run-quality-gates.sh
+++ b/Scripts/run-quality-gates.sh
@@ -24,6 +24,9 @@ fi
 export DEVELOPER_DIR="$developer_dir"
 
 artifact_root=$(mktemp -d "${TMPDIR:-/tmp}/BiliKit-quality-gate.XXXXXX")
+task_tmp="$artifact_root/tmp"
+module_cache="$artifact_root/ModuleCache.noindex"
+mkdir -p "$task_tmp" "$module_cache"
 cleanup() {
     status=$?
     if ! rm -rf -- "$artifact_root" 2>/dev/null; then
@@ -54,6 +57,9 @@ echo "[Gate] package"
 HOME="$swiftpm_home" \
 CFFIXED_USER_HOME="$swiftpm_home" \
 XDG_CACHE_HOME="$swiftpm_home/.cache" \
+TMPDIR="$task_tmp" \
+CLANG_MODULE_CACHE_PATH="$module_cache" \
+SWIFTPM_MODULECACHE_OVERRIDE="$module_cache" \
 xcrun swift test \
     --quiet \
     --package-path Packages/BiliKitCore \
@@ -76,6 +82,9 @@ echo "[Gate] app build-for-testing"
 HOME="$xcode_home" \
 CFFIXED_USER_HOME="$xcode_home" \
 XDG_CACHE_HOME="$xcode_home/.cache" \
+TMPDIR="$task_tmp" \
+CLANG_MODULE_CACHE_PATH="$module_cache" \
+SWIFTPM_MODULECACHE_OVERRIDE="$module_cache" \
 xcodebuild \
     -quiet \
     -project BiliKitMac.xcodeproj \
@@ -92,6 +101,9 @@ echo "[Gate] app tests"
 HOME="$xcode_home" \
 CFFIXED_USER_HOME="$xcode_home" \
 XDG_CACHE_HOME="$xcode_home/.cache" \
+TMPDIR="$task_tmp" \
+CLANG_MODULE_CACHE_PATH="$module_cache" \
+SWIFTPM_MODULECACHE_OVERRIDE="$module_cache" \
 xcodebuild \
     -quiet \
     -project BiliKitMac.xcodeproj \

--- a/Scripts/run-targeted-tests.sh
+++ b/Scripts/run-targeted-tests.sh
@@ -1,0 +1,116 @@
+#!/bin/sh
+
+set -eu
+
+umask 077
+
+if [ "$#" -ne 3 ]; then
+    echo "用法：$0 <任务临时根> <package|app> <测试筛选器>" >&2
+    exit 2
+fi
+
+requested_root=$1
+mode=$2
+test_filter=$3
+
+case "$requested_root" in
+    /*) ;;
+    *)
+        echo "任务临时根必须是绝对路径" >&2
+        exit 2
+        ;;
+esac
+case "$mode" in
+    package|app) ;;
+    *)
+        echo "测试模式必须是 package 或 app" >&2
+        exit 2
+        ;;
+esac
+[ -n "$test_filter" ] || {
+    echo "测试筛选器不能为空" >&2
+    exit 2
+}
+
+repository_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd -P)
+[ -d "$requested_root" ] || {
+    echo "任务临时根必须由当前任务预先创建" >&2
+    exit 2
+}
+artifact_root=$(CDPATH= cd -- "$requested_root" && pwd -P)
+case "$artifact_root" in
+    /|/tmp|/private/tmp|"$repository_root")
+        echo "拒绝使用过宽的任务临时根：$artifact_root" >&2
+        exit 2
+        ;;
+esac
+
+owner_marker="$artifact_root/.bilikit-targeted-cache-owner"
+if [ -f "$owner_marker" ]; then
+    recorded_repository_root=$(sed -n '1p' "$owner_marker")
+    [ "$recorded_repository_root" = "$repository_root" ] || {
+        echo "任务临时根属于其他 worktree：$recorded_repository_root" >&2
+        exit 2
+    }
+elif [ -e "$owner_marker" ]; then
+    echo "任务临时根 owner marker 不是普通文件" >&2
+    exit 2
+elif find "$artifact_root" -mindepth 1 -print -quit | grep -q .; then
+    echo "拒绝使用没有 owner marker 的非空任务临时根" >&2
+    exit 2
+else
+    printf '%s\n' "$repository_root" > "$owner_marker"
+fi
+
+cd "$repository_root"
+developer_dir="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}"
+if [ ! -x "$developer_dir/usr/bin/xcodebuild" ]; then
+    echo "需要完整 Xcode：$developer_dir" >&2
+    exit 1
+fi
+export DEVELOPER_DIR="$developer_dir"
+task_tmp="$artifact_root/tmp"
+module_cache="$artifact_root/ModuleCache.noindex"
+mkdir -p "$task_tmp" "$module_cache"
+
+if [ "$mode" = "package" ]; then
+    swiftpm_home="$artifact_root/swiftpm-home"
+    mkdir -p "$swiftpm_home"
+    HOME="$swiftpm_home" \
+    CFFIXED_USER_HOME="$swiftpm_home" \
+    XDG_CACHE_HOME="$swiftpm_home/.cache" \
+    TMPDIR="$task_tmp" \
+    CLANG_MODULE_CACHE_PATH="$module_cache" \
+    SWIFTPM_MODULECACHE_OVERRIDE="$module_cache" \
+    xcrun swift test \
+        --package-path Packages/BiliKitCore \
+        --scratch-path "$artifact_root/swiftpm" \
+        --cache-path "$artifact_root/swiftpm-cache" \
+        --config-path "$artifact_root/swiftpm-config" \
+        --security-path "$artifact_root/swiftpm-security" \
+        --filter "$test_filter"
+    exit 0
+fi
+
+xcode_home="$artifact_root/xcode-home"
+derived_data="$artifact_root/DerivedData"
+packages="$artifact_root/SourcePackages"
+mkdir -p "$xcode_home"
+HOME="$xcode_home" \
+CFFIXED_USER_HOME="$xcode_home" \
+XDG_CACHE_HOME="$xcode_home/.cache" \
+TMPDIR="$task_tmp" \
+CLANG_MODULE_CACHE_PATH="$module_cache" \
+SWIFTPM_MODULECACHE_OVERRIDE="$module_cache" \
+xcodebuild \
+    -quiet \
+    -project BiliKitMac.xcodeproj \
+    -scheme BiliKitMac \
+    -configuration Debug \
+    -destination 'platform=macOS' \
+    -derivedDataPath "$derived_data" \
+    -clonedSourcePackagesDirPath "$packages" \
+    CODE_SIGNING_ALLOWED=NO \
+    SWIFT_ENABLE_EXPLICIT_MODULES=NO \
+    test \
+    -only-testing:"$test_filter"

--- a/docs/development/QUALITY-GATES.md
+++ b/docs/development/QUALITY-GATES.md
@@ -18,6 +18,25 @@ Gate 每次使用私有临时目录保存 SwiftPM 与 Xcode 产物，退出时�
 临时运行时诊断时需注明证据边界。CI 使用同一入口，并在 macOS 15/26
 宿主上显式选择同一套新 Xcode/SDK；这个矩阵不承诺旧 SDK 编译兼容。
 
+Gate 是交付闭包，不是迭代命令。定向测试可在同一任务内复用一份私有缓存；临时根必须由
+当前任务唯一创建，不能跨 worktree 或任务复用，并在任务结束时整体删除：
+
+```sh
+task_artifact_root=$(mktemp -d "${TMPDIR:-/tmp}/BiliKit-targeted.XXXXXX")
+cleanup() { rm -rf -- "$task_artifact_root"; }
+trap cleanup EXIT
+
+sh Scripts/run-targeted-tests.sh \
+    "$task_artifact_root" package 'GuestVideoViewModelTests'
+sh Scripts/run-targeted-tests.sh \
+    "$task_artifact_root" app 'BiliKitMacTests/PlaybackSourceSettingsTests'
+```
+
+重复调用同一模式会复用该任务根内的 SwiftPM scratch 或 Xcode DerivedData；`--filter` 和
+`-only-testing` 只缩小测试执行集合，首次调用仍可能编译对应 test product 的完整依赖图。
+脚本会在空任务根写入当前 canonical worktree 的 owner marker；非空但无 marker 或 owner 不匹配
+时拒绝复用。最终验证仍使用上面的 Gate，由 Gate 创建并清理新的 fresh closure。
+
 仅在明确的性能裁决中运行 Instruments/`xctrace`；事前限定问题、时长、次数和产物目录。
 摘要完成后默认删除 raw trace，并退出 Instruments、确认没有开放 trace、清理临时产物。
 


### PR DESCRIPTION
## 变化
- 在进程级 Composition 中一次构造 CDN 测速 API、discoverer 与 benchmark，并注册到现有账户 session invalidation。
- AppSettingsModel 不再接受首次窗口的具体 API client，也不再依赖 BiliAPI DTO 或错误类型。
- 新增任务专用的 Package/App 定向测试入口；同一任务可复用缓存，跨 worktree owner 不匹配时拒绝。
- 将 TMPDIR 与 module cache 纳入唯一任务根，保持最终质量 Gate 的 fresh closure 与自动清理。

## 原因
V1 收尾审查确认主要架构健康，但进程级 Settings 曾隐式绑定首次窗口 transport；同时日常单测的主要成本来自重复冷编译，而非测试函数执行。此次只修复这两个窄边界，不改变播放、认证、导航或网络 owner。

## 用户影响
- 多窗口与登出后的测速 transport 生命周期更清晰，不再由首个窗口决定。
- 迭代时可以安全复用当前任务缓存，减少重复冷编译与机器负载。
- 不改变播放路线选择、响度设置、认证交互或测速结果语义。

## 验证
- 独立 agent 两轮只读审查；最终无 P0/P1/P2。
- Settings 定向 App tests 通过；同根 warm repeat 为 3.86 秒。
- sh Scripts/run-quality-gates.sh app 通过：631 个 Package tests、App build-for-testing 与全部 App tests 通过。
- owner marker 收紧后再次通过 static Gate、shell syntax、diff whitespace，并验证空根绑定和非空无 marker 拒绝。

## 未覆盖边界
- 未运行真实网络、登录、CDN 测速或真实播放。
- Signed Keychain smoke 按既有条件跳过。
- owner marker 是完整 App Gate 后的脚本边界收紧；该部分由定向行为检查和 PR CI 覆盖。