### PR TITLE
fix(video): 修正卡片指标符号渲染

### DIFF
--- a/BiliKitMac/Platform/NativeVideoCardView.swift
+++ b/BiliKitMac/Platform/NativeVideoCardView.swift
@@ -658,29 +658,121 @@ final class NativeVideoCardView: NSView {
     }
 }
 
+struct NativeVideoCardSymbolRaster {
+    let image: CGImage
+    let size: NSSize
+}
+
 @MainActor
-private final class NativeVideoMergedCoverView: NSView {
-    private struct SymbolRasterKey: Hashable {
+enum NativeVideoCardSymbolRasterizer {
+    private struct Key: Hashable {
         let name: String
         let pointSize: CGFloat
         let weight: CGFloat
         let scale: CGFloat
         let appearanceName: String
-        let tintName: String
     }
 
+    private static let maximumRasterCount = 32
+    private static var rasters: [Key: NativeVideoCardSymbolRaster] = [:]
+
+    static func raster(
+        named name: String,
+        pointSize: CGFloat,
+        weight: NSFont.Weight,
+        scale requestedScale: CGFloat,
+        appearance: NSAppearance
+    ) -> NativeVideoCardSymbolRaster? {
+        let scale = max(1, requestedScale)
+        let key = Key(
+            name: name,
+            pointSize: pointSize,
+            weight: weight.rawValue,
+            scale: scale,
+            appearanceName: appearance.name.rawValue
+        )
+        if let cached = rasters[key] { return cached }
+
+        var raster: NativeVideoCardSymbolRaster?
+        appearance.performAsCurrentDrawingAppearance {
+            let pointConfiguration = NSImage.SymbolConfiguration(
+                pointSize: pointSize,
+                weight: weight
+            )
+            let paletteColors: [NSColor] =
+                name == "text.bubble.fill" ? [.black, .white] : [.white]
+            let colorConfiguration = NSImage.SymbolConfiguration(
+                paletteColors: paletteColors
+            )
+            guard
+                let image = NSImage(
+                    systemSymbolName: name,
+                    accessibilityDescription: nil
+                )?.withSymbolConfiguration(pointConfiguration.applying(colorConfiguration)),
+                image.size.width > 0,
+                image.size.height > 0
+            else { return }
+
+            let pixelWidth = max(1, Int(ceil(image.size.width * scale)))
+            let pixelHeight = max(1, Int(ceil(image.size.height * scale)))
+            guard
+                let representation = NSBitmapImageRep(
+                    bitmapDataPlanes: nil,
+                    pixelsWide: pixelWidth,
+                    pixelsHigh: pixelHeight,
+                    bitsPerSample: 8,
+                    samplesPerPixel: 4,
+                    hasAlpha: true,
+                    isPlanar: false,
+                    colorSpaceName: .deviceRGB,
+                    bytesPerRow: 0,
+                    bitsPerPixel: 0
+                )
+            else { return }
+            representation.size = image.size
+            guard let graphicsContext = NSGraphicsContext(bitmapImageRep: representation) else {
+                return
+            }
+            NSGraphicsContext.saveGraphicsState()
+            NSGraphicsContext.current = graphicsContext
+            graphicsContext.cgContext.clear(
+                NSRect(origin: .zero, size: image.size)
+            )
+            image.draw(
+                in: NSRect(origin: .zero, size: image.size),
+                from: .zero,
+                operation: .sourceOver,
+                fraction: 1,
+                respectFlipped: false,
+                hints: [.interpolation: NSImageInterpolation.high]
+            )
+            graphicsContext.flushGraphics()
+            NSGraphicsContext.restoreGraphicsState()
+            guard let cgImage = representation.cgImage else { return }
+            raster = NativeVideoCardSymbolRaster(image: cgImage, size: image.size)
+        }
+        guard let raster else { return nil }
+
+        if rasters.count >= maximumRasterCount,
+            let evictedKey = rasters.keys.first
+        {
+            rasters.removeValue(forKey: evictedKey)
+        }
+        rasters[key] = raster
+        return raster
+    }
+}
+
+@MainActor
+private final class NativeVideoMergedCoverView: NSView {
     private static let overlayHeight: CGFloat = 35
     private static let metricBottomOffset: CGFloat = 22
     private static let leadingInset: CGFloat = 9
-    private static let iconSize: CGFloat = 12
     private static let symbolPointSize: CGFloat = 11
     private static let symbolWeight = NSFont.Weight.medium
     private static let iconTextSpacing: CGFloat = 4
     private static let metricSpacing: CGFloat = 10
     private static let trailingInset: CGFloat = 9
-    private static let maximumSymbolRasterCount = 32
-    private static var symbolRasters: [SymbolRasterKey: CGImage] = [:]
-
     private let placeholderLayer = CALayer()
     private let imageLayer = CALayer()
     private let gradientLayer = CAGradientLayer()
@@ -702,6 +794,7 @@ private final class NativeVideoMergedCoverView: NSView {
         ),
     ]
     private var metricIconNames: [String?] = [nil, nil]
+    private var metricIconSizes: [NSSize] = [.zero, .zero]
     private var metricSizes: [NSSize] = [.zero, .zero]
     private var metricCount = 0
     private let trailingCell = NativeVideoMergedCoverView.makeLabelCell(
@@ -765,6 +858,7 @@ private final class NativeVideoMergedCoverView: NSView {
             guard index < metricCount else {
                 metricCells[index].stringValue = ""
                 metricIconNames[index] = nil
+                metricIconSizes[index] = .zero
                 metricSizes[index] = .zero
                 metricIconLayers[index].contents = nil
                 metricIconLayers[index].isHidden = true
@@ -792,6 +886,7 @@ private final class NativeVideoMergedCoverView: NSView {
         for index in metricCells.indices {
             metricCells[index].stringValue = ""
             metricIconNames[index] = nil
+            metricIconSizes[index] = .zero
             metricSizes[index] = .zero
             metricIconLayers[index].contents = nil
             metricIconLayers[index].isHidden = true
@@ -876,14 +971,15 @@ private final class NativeVideoMergedCoverView: NSView {
         let metricY = bounds.height - Self.metricBottomOffset
         var nextX = Self.leadingInset
         for index in 0..<metricCount {
+            let iconSize = metricIconSizes[index]
+            let cellSize = metricSizes[index]
             let iconFrame = NSRect(
                 x: nextX,
-                y: metricY + 2,
-                width: Self.iconSize,
-                height: Self.iconSize
+                y: metricY + floor((cellSize.height - iconSize.height) / 2),
+                width: iconSize.width,
+                height: iconSize.height
             )
             metricIconLayers[index].frame = iconFrame
-            let cellSize = metricSizes[index]
             let cellFrame = NSRect(
                 x: iconFrame.maxX + Self.iconTextSpacing,
                 y: metricY,
@@ -920,14 +1016,17 @@ private final class NativeVideoMergedCoverView: NSView {
                 metricIconLayers[index].isHidden = true
                 continue
             }
-            let icon = Self.symbolRaster(
+            let raster = NativeVideoCardSymbolRasterizer.raster(
                 named: name,
+                pointSize: Self.symbolPointSize,
+                weight: Self.symbolWeight,
                 scale: scale,
                 appearance: appearance
             )
-            metricIconLayers[index].contents = icon
+            metricIconLayers[index].contents = raster?.image
             metricIconLayers[index].contentsScale = scale
-            metricIconLayers[index].isHidden = icon == nil
+            metricIconLayers[index].isHidden = raster == nil
+            metricIconSizes[index] = raster?.size ?? .zero
         }
         needsLayout = true
     }
@@ -996,83 +1095,6 @@ private final class NativeVideoMergedCoverView: NSView {
         "opacity": NSNull(),
         "position": NSNull(),
     ]
-
-    private static func symbolRaster(
-        named name: String,
-        scale: CGFloat,
-        appearance: NSAppearance
-    ) -> CGImage? {
-        let key = SymbolRasterKey(
-            name: name,
-            pointSize: symbolPointSize,
-            weight: symbolWeight.rawValue,
-            scale: scale,
-            appearanceName: appearance.name.rawValue,
-            tintName: "white"
-        )
-        if let cached = symbolRasters[key] { return cached }
-
-        var raster: CGImage?
-        appearance.performAsCurrentDrawingAppearance {
-            let pointConfiguration = NSImage.SymbolConfiguration(
-                pointSize: symbolPointSize,
-                weight: symbolWeight
-            )
-            let colorConfiguration = NSImage.SymbolConfiguration(paletteColors: [.white])
-            guard
-                let image = NSImage(
-                    systemSymbolName: name,
-                    accessibilityDescription: nil
-                )?.withSymbolConfiguration(pointConfiguration.applying(colorConfiguration))
-            else { return }
-
-            let pixelWidth = max(1, Int(ceil(iconSize * scale)))
-            let pixelHeight = max(1, Int(ceil(iconSize * scale)))
-            guard
-                let representation = NSBitmapImageRep(
-                    bitmapDataPlanes: nil,
-                    pixelsWide: pixelWidth,
-                    pixelsHigh: pixelHeight,
-                    bitsPerSample: 8,
-                    samplesPerPixel: 4,
-                    hasAlpha: true,
-                    isPlanar: false,
-                    colorSpaceName: .deviceRGB,
-                    bytesPerRow: 0,
-                    bitsPerPixel: 0
-                )
-            else { return }
-            representation.size = NSSize(width: iconSize, height: iconSize)
-            guard let graphicsContext = NSGraphicsContext(bitmapImageRep: representation) else {
-                return
-            }
-            NSGraphicsContext.saveGraphicsState()
-            NSGraphicsContext.current = graphicsContext
-            graphicsContext.cgContext.clear(
-                NSRect(x: 0, y: 0, width: iconSize, height: iconSize)
-            )
-            image.draw(
-                in: NSRect(x: 0, y: 0, width: iconSize, height: iconSize),
-                from: .zero,
-                operation: .sourceOver,
-                fraction: 1,
-                respectFlipped: false,
-                hints: [.interpolation: NSImageInterpolation.high]
-            )
-            graphicsContext.flushGraphics()
-            NSGraphicsContext.restoreGraphicsState()
-            raster = representation.cgImage
-        }
-        guard let raster else { return nil }
-
-        if symbolRasters.count >= maximumSymbolRasterCount,
-            let oldestKey = symbolRasters.keys.first
-        {
-            symbolRasters.removeValue(forKey: oldestKey)
-        }
-        symbolRasters[key] = raster
-        return raster
-    }
 
     private static var backgroundColor: CGColor {
         NSColor.secondaryLabelColor.withAlphaComponent(0.12).cgColor

--- a/BiliKitMacTests/NativeVideoCardSymbolRasterTests.swift
+++ b/BiliKitMacTests/NativeVideoCardSymbolRasterTests.swift
@@ -1,0 +1,132 @@
+import AppKit
+import Testing
+
+@testable import BiliKit
+
+struct NativeVideoCardSymbolRasterTests {
+    @Test @MainActor
+    func coverSymbolsKeepIntrinsicCanvasAndBackingScale() throws {
+        let appearance = try #require(NSAppearance(named: .aqua))
+        let scale: CGFloat = 2
+        let play = try #require(
+            NativeVideoCardSymbolRasterizer.raster(
+                named: "play.fill",
+                pointSize: 11,
+                weight: .medium,
+                scale: scale,
+                appearance: appearance
+            )
+        )
+        let bubble = try #require(
+            NativeVideoCardSymbolRasterizer.raster(
+                named: "text.bubble.fill",
+                pointSize: 11,
+                weight: .medium,
+                scale: scale,
+                appearance: appearance
+            )
+        )
+
+        #expect(play.size.width < play.size.height)
+        #expect(bubble.size.width > bubble.size.height)
+        #expect(play.size != bubble.size)
+        #expect(play.image.width == Int(ceil(play.size.width * scale)))
+        #expect(play.image.height == Int(ceil(play.size.height * scale)))
+        #expect(bubble.image.width == Int(ceil(bubble.size.width * scale)))
+        #expect(bubble.image.height == Int(ceil(bubble.size.height * scale)))
+
+        let playBounds = try #require(alphaBounds(of: play.image))
+        let bubbleBounds = try #require(alphaBounds(of: bubble.image))
+        #expect(playBounds.width > CGFloat(play.image.width) / 2)
+        #expect(playBounds.height > CGFloat(play.image.height) / 2)
+        #expect(bubbleBounds.width > CGFloat(bubble.image.width) / 2)
+        #expect(bubbleBounds.height > CGFloat(bubble.image.height) / 2)
+
+        let cachedPlay = try #require(
+            NativeVideoCardSymbolRasterizer.raster(
+                named: "play.fill",
+                pointSize: 11,
+                weight: .medium,
+                scale: scale,
+                appearance: appearance
+            )
+        )
+        #expect(cachedPlay.image === play.image)
+    }
+
+    @Test @MainActor
+    func coverSymbolColorsKeepPlayWhiteAndBubbleDetailsDark() throws {
+        let appearance = try #require(NSAppearance(named: .aqua))
+        let play = try #require(
+            NativeVideoCardSymbolRasterizer.raster(
+                named: "play.fill",
+                pointSize: 11,
+                weight: .medium,
+                scale: 4,
+                appearance: appearance
+            )
+        )
+        let bubble = try #require(
+            NativeVideoCardSymbolRasterizer.raster(
+                named: "text.bubble.fill",
+                pointSize: 11,
+                weight: .medium,
+                scale: 4,
+                appearance: appearance
+            )
+        )
+        let playCounts = opaqueWhiteAndDarkPixelCounts(of: play.image)
+        let bubbleCounts = opaqueWhiteAndDarkPixelCounts(of: bubble.image)
+
+        #expect(playCounts.white > 0)
+        #expect(playCounts.dark == 0)
+        #expect(bubbleCounts.dark > 0)
+        #expect(bubbleCounts.white > bubbleCounts.dark)
+    }
+
+    private func opaqueWhiteAndDarkPixelCounts(
+        of image: CGImage
+    ) -> (white: Int, dark: Int) {
+        let representation = NSBitmapImageRep(cgImage: image)
+        var whitePixelCount = 0
+        var darkPixelCount = 0
+
+        for y in 0..<representation.pixelsHigh {
+            for x in 0..<representation.pixelsWide {
+                guard let color = representation.colorAt(x: x, y: y),
+                    color.alphaComponent >= 0.85
+                else { continue }
+                let brightness =
+                    (color.redComponent + color.greenComponent + color.blueComponent) / 3
+                if brightness >= 0.85 { whitePixelCount += 1 }
+                if brightness <= 0.15 { darkPixelCount += 1 }
+            }
+        }
+        return (whitePixelCount, darkPixelCount)
+    }
+
+    private func alphaBounds(of image: CGImage) -> CGRect? {
+        let representation = NSBitmapImageRep(cgImage: image)
+        var minX = representation.pixelsWide
+        var minY = representation.pixelsHigh
+        var maxX = -1
+        var maxY = -1
+
+        for y in 0..<representation.pixelsHigh {
+            for x in 0..<representation.pixelsWide
+            where (representation.colorAt(x: x, y: y)?.alphaComponent ?? 0) >= 0.05 {
+                minX = min(minX, x)
+                minY = min(minY, y)
+                maxX = max(maxX, x)
+                maxY = max(maxY, y)
+            }
+        }
+        guard maxX >= minX, maxY >= minY else { return nil }
+        return CGRect(
+            x: minX,
+            y: minY,
+            width: maxX - minX + 1,
+            height: maxY - minY + 1
+        )
+    }
+}


### PR DESCRIPTION
## 变化

- 按 SF Symbol 固有画布栅格化卡片播放数与弹幕数图标，保留各自纵横比和 backing scale
- 为 `play.fill` 使用白色单层 palette，为 `text.bubble.fill` 使用白色气泡与深色横线
- 保留 CALayer 合成与 32 项有界 CGImage 缓存，不退回滚动中的 AppKit 重绘
- 增加低层像素契约测试，覆盖固有尺寸、Retina 像素、缓存复用与两种符号配色

## 原因

原实现将多层 SF Symbol 用单一白色 palette 合并，并统一重绘到 12×12 方形，导致气泡内部横线消失、符号比例偏离系统外观。

## 用户影响

首页推荐、热门、搜索和相关推荐共用的卡片指标图标会保持系统符号固有比例；播放图标为白色，弹幕气泡为白色填充并保留深色横线。卡片滚动路径仍由 CALayer 和缓存承担。

## 验证

- `NativeVideoCardSymbolRasterTests` 定向测试通过
- `sh Scripts/run-quality-gates.sh app`
  - static 检查通过
  - 631 项 package tests / 65 suites 通过
  - App build-for-testing 与完整 `BiliKitMacTests` 通过
  - 无签名 Keychain smoke test 按 Gate 契约跳过
- fresh Debug App 首页实际检查：播放图标为白色，弹幕气泡保留白色主体与深色细节

## 未覆盖边界

- 自动化像素测试证明颜色层与固有画布契约，但不单独证明深色细节恰为三条横线，也不替代不同封面、缩放和显示器上的人工视觉判断
- 未运行 Instruments；性能结论来自仍使用 CALayer、缓存命中复用同一 CGImage 与有界缓存的代码路径
