### PR TITLE
refactor(comments): 降低评论区滚动绘制开销

### DIFF
--- a/BiliKitMac/Platform/PlaybackSidebar/Comments/NativePlaybackCommentsItems.swift
+++ b/BiliKitMac/Platform/PlaybackSidebar/Comments/NativePlaybackCommentsItems.swift
@@ -1,6 +1,7 @@
 import AppKit
 import BiliBrowseFeature
 import BiliModels
+import CoreText
 
 @MainActor
 enum NativePlaybackCommentsItemMeasurement {
@@ -709,7 +710,7 @@ final class NativePlaybackCommentThreadItem: NSCollectionViewItem {
 
 @MainActor
 private final class NativePlaybackCommentThreadView: NSView {
-    override var isFlipped: Bool { true }
+    nonisolated override var isFlipped: Bool { true }
     private let rootRow = NativePlaybackCommentRowView()
     private let repliesPanel = NativePlaybackCommentRepliesPanelView()
     private let separator = NSBox()
@@ -832,7 +833,7 @@ private final class NativePlaybackCommentThreadView: NSView {
 
 @MainActor
 private final class NativePlaybackCommentRowView: NSView {
-    override var isFlipped: Bool { true }
+    nonisolated override var isFlipped: Bool { true }
     private let avatar = NativePlaybackCommentAvatarView()
     private let authorLabel = NSTextField(labelWithString: "")
     private let authorBadges = NativePlaybackCommentAuthorBadgesView()
@@ -1185,22 +1186,27 @@ final class NativePlaybackCommentAuthorBadgesView: NSView {
         let text: String
         let background: NSColor?
         let stroke: NSColor?
-        let attributedText: NSAttributedString
+        let textLine: CTLine
         let textSize: NSSize
+        let baselineFromTop: CGFloat
         let width: CGFloat
 
         init(_ segment: Segment, font: NSFont) {
             text = segment.text
             background = segment.background
             stroke = segment.stroke
-            attributedText = NSAttributedString(
+            let attributedText = NSAttributedString(
                 string: segment.text,
                 attributes: [
                     .font: font,
                     .foregroundColor: segment.foreground,
                 ]
             )
+            textLine = CTLineCreateWithAttributedString(attributedText)
             textSize = attributedText.size()
+            var ascent: CGFloat = 0
+            CTLineGetTypographicBounds(textLine, &ascent, nil, nil)
+            baselineFromTop = ascent
             width = ceil(textSize.width + segment.horizontalPadding * 2)
         }
     }
@@ -1332,12 +1338,17 @@ final class NativePlaybackCommentAuthorBadgesView: NSView {
                 NSBezierPath(roundedRect: strokeRect, xRadius: 2, yRadius: 2)
                     .stroke()
             }
-            segment.attributedText.draw(
-                at: NSPoint(
+            if let context = NSGraphicsContext.current?.cgContext {
+                context.saveGState()
+                context.textMatrix = CGAffineTransform(scaleX: 1, y: -1)
+                context.textPosition = NSPoint(
                     x: rect.midX - segment.textSize.width / 2,
                     y: rect.midY - segment.textSize.height / 2
+                        + segment.baselineFromTop
                 )
-            )
+                CTLineDraw(segment.textLine, context)
+                context.restoreGState()
+            }
             x += segment.width + 5
         }
     }
@@ -1976,7 +1987,7 @@ struct NativePlaybackCommentPictureGallery {
 
 @MainActor
 private final class NativePlaybackCommentPicturesView: NSView {
-    override var isFlipped: Bool { true }
+    nonisolated override var isFlipped: Bool { true }
     private let tiles = (0..<9).map { _ in NativePlaybackCommentPictureTileView() }
     private var slots: [NativePlaybackCommentPictureSlot] = []
     private var onOpen: ((NativePlaybackCommentPictureGallery) -> Void)?
@@ -2080,7 +2091,7 @@ private final class NativePlaybackCommentPicturesView: NSView {
 
 @MainActor
 private final class NativePlaybackCommentPictureTileView: NSButton {
-    override var isFlipped: Bool { true }
+    nonisolated override var isFlipped: Bool { true }
     private let imageView = NSImageView()
     private let placeholderLabel = NSTextField(labelWithString: AppStrings.localized("图片"))
     private var reference: CommentAssetReference?
@@ -2262,7 +2273,7 @@ private final class NativePlaybackCommentPictureTileView: NSButton {
 
 @MainActor
 private final class NativePlaybackCommentRepliesPanelView: NSView {
-    override var isFlipped: Bool { true }
+    nonisolated override var isFlipped: Bool { true }
     private let headerLabel = NSTextField(labelWithString: "")
     private let statusLabel = NSTextField(labelWithString: "")
     private let expandButton = NSButton(title: "", target: nil, action: nil)


### PR DESCRIPTION
## 变化

- 将评论线程、行、图片容器、图片单元和回复面板的常量 `isFlipped` getter 标记为 `nonisolated`，避免 AppKit 坐标转换期间重复执行主线程 executor 检查。
- 在作者徽章视图配置时缓存 `CTLine`，滚动重绘时直接绘制字形，避免每帧通过 `NSAttributedString.draw` 重新排版。
- 保留现有评论区 owner、复用、分页、快照、高度缓存与无障碍结构。

## 原因与用户影响

Time Profiler 显示，评论区滚动的可操作热点集中在五个常量 `isFlipped` getter，以及作者徽章绘制下的 `NSCoreTypesetter`。本次仅处理这两条已观测调用链，降低滚动期间主线程绘制开销，不改变功能或视觉设计。

三轮相同 20 秒滚动测量中：

- App 总采样权重约从 10.81 秒降至 8.07 秒，下降约 25%。
- 主线程权重约从 10.03 秒降至 7.22 秒，下降约 28%。
- `NSViewBackingLayer display` 约从 4.21 秒降至 2.68 秒，下降约 36%。
- 五个目标 getter 合计约从 868 毫秒降至 49 毫秒。
- 作者徽章 `draw` 从第二轮的 502 毫秒降至 136 毫秒；原徽章路径中的 `NSCoreTypesetter` 不再出现，`CTLine` 创建成本约 78 毫秒。

## 验证

- `xcrun swift-format lint --strict BiliKitMac/Platform/PlaybackSidebar/Comments/NativePlaybackCommentsItems.swift`
- `sh Scripts/run-targeted-tests.sh <task-local-root> app 'BiliKitMacTests/NativePlaybackSidebarTests'`
- `sh Scripts/run-quality-gates.sh app`
  - 静态架构、秘密模式、工程契约和格式检查通过
  - 657 个 Package 测试通过
  - App build-for-testing 与 App tests 通过
- 三轮 Instruments Time Profiler 对比
- 真人肉眼确认 `LV`、闪电、`UP`、性别符号无倒置、偏移、缺字或变色
- 三路只读审查：Swift 6 隔离与生命周期、AppKit/Core Text 绘制、测试与提交范围均无代码 findings

## 未覆盖边界

- Instruments 当前界面无法可靠框选精确的中间 12 秒，因此性能数字采用三轮完整 20 秒的同口径比较，不是跨机器基准。
- 未单独验证运行中浅色/深色外观切换、非 Retina 显示器、辅助字体设置，以及所有徽章组合逐一展示。
- 未进行长期内存曲线或专门线程压力测试；缓存按视图配置整体替换，并在复用 reset 时清空。
