### PR TITLE
refactor(danmaku): 优化弹幕调度游标推进

### DIFF
--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Scheduling/DanmakuScheduler.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Scheduling/DanmakuScheduler.swift
@@ -78,6 +78,7 @@ public struct DanmakuScheduler: Sendable {
     private var filter = DanmakuFilter()
     private var isEnabled = true
     private var segments: [Int: [DanmakuEvent]] = [:]
+    private var nextEventIndexBySegment: [Int: Int] = [:]
     private var deliveredIDsBySegment: [Int: Set<String>] = [:]
     private var previousPositionSeconds: Double?
     private var discontinuityGeneration: UInt64?
@@ -95,6 +96,7 @@ public struct DanmakuScheduler: Sendable {
     public mutating func begin(for identity: PlaybackItemIdentity) {
         self.identity = identity
         segments.removeAll(keepingCapacity: false)
+        nextEventIndexBySegment.removeAll(keepingCapacity: false)
         deliveredIDsBySegment.removeAll(keepingCapacity: false)
         previousPositionSeconds = nil
         discontinuityGeneration = nil
@@ -103,6 +105,7 @@ public struct DanmakuScheduler: Sendable {
     public mutating func reset() {
         identity = nil
         segments.removeAll(keepingCapacity: false)
+        nextEventIndexBySegment.removeAll(keepingCapacity: false)
         deliveredIDsBySegment.removeAll(keepingCapacity: false)
         previousPositionSeconds = nil
         discontinuityGeneration = nil
@@ -111,6 +114,7 @@ public struct DanmakuScheduler: Sendable {
     public mutating func setEnabled(_ enabled: Bool) {
         guard isEnabled != enabled else { return }
         isEnabled = enabled
+        nextEventIndexBySegment.removeAll(keepingCapacity: true)
         deliveredIDsBySegment.removeAll(keepingCapacity: true)
         previousPositionSeconds = nil
     }
@@ -128,7 +132,12 @@ public struct DanmakuScheduler: Sendable {
         for identity: PlaybackItemIdentity
     ) {
         guard self.identity == identity, segment.index > 0 else { return }
-        segments[segment.index] = segment.events.sorted(by: Self.eventOrder)
+        let events = segment.events.sorted(by: Self.eventOrder)
+        segments[segment.index] = events
+        nextEventIndexBySegment[segment.index] = Self.firstEventIndex(
+            after: previousPositionSeconds ?? -.infinity,
+            in: events
+        )
         trimCache()
     }
 
@@ -158,6 +167,7 @@ public struct DanmakuScheduler: Sendable {
         if discontinuityGeneration != snapshot.discontinuityGeneration {
             discontinuityGeneration = snapshot.discontinuityGeneration
             previousPositionSeconds = snapshot.positionSeconds
+            nextEventIndexBySegment.removeAll(keepingCapacity: true)
             deliveredIDsBySegment.removeAll(keepingCapacity: true)
             return DanmakuBatch(
                 identity: identity,
@@ -172,6 +182,7 @@ public struct DanmakuScheduler: Sendable {
             snapshot.rate > 0
         else {
             previousPositionSeconds = snapshot.positionSeconds
+            nextEventIndexBySegment.removeAll(keepingCapacity: true)
             return nil
         }
         guard let previousPositionSeconds else {
@@ -180,6 +191,7 @@ public struct DanmakuScheduler: Sendable {
         }
         guard snapshot.positionSeconds >= previousPositionSeconds else {
             self.previousPositionSeconds = snapshot.positionSeconds
+            nextEventIndexBySegment.removeAll(keepingCapacity: true)
             deliveredIDsBySegment.removeAll(keepingCapacity: true)
             return DanmakuBatch(
                 identity: identity,
@@ -195,11 +207,28 @@ public struct DanmakuScheduler: Sendable {
         var emitted: [DanmakuEvent] = []
         if lowerIndex <= upperIndex {
             for index in lowerIndex...upperIndex {
-                for event in segments[index] ?? [] {
-                    guard event.timeSeconds > previousPositionSeconds,
-                        event.timeSeconds <= snapshot.positionSeconds,
-                        filter.allows(event)
-                    else { continue }
+                guard let events = segments[index] else { continue }
+                var nextEventIndex =
+                    nextEventIndexBySegment[index]
+                    ?? Self.firstEventIndex(
+                        after: previousPositionSeconds,
+                        in: events
+                    )
+                if nextEventIndex < events.count,
+                    events[nextEventIndex].timeSeconds <= previousPositionSeconds
+                {
+                    nextEventIndex = Self.firstEventIndex(
+                        after: previousPositionSeconds,
+                        in: events
+                    )
+                }
+                while nextEventIndex < events.count {
+                    let event = events[nextEventIndex]
+                    guard event.timeSeconds <= snapshot.positionSeconds else {
+                        break
+                    }
+                    nextEventIndex += 1
+                    guard filter.allows(event) else { continue }
 
                     let wasDelivered = hasDelivered(event.id)
                     deliveredIDsBySegment[index, default: []].insert(event.id)
@@ -207,6 +236,7 @@ public struct DanmakuScheduler: Sendable {
 
                     emitted.append(event)
                 }
+                nextEventIndexBySegment[index] = nextEventIndex
             }
         }
         trimDeliveredIDs(through: upperIndex)
@@ -233,6 +263,9 @@ public struct DanmakuScheduler: Sendable {
         }
         let keep = Set(ordered.prefix(Self.maximumCachedSegments))
         segments = segments.filter { keep.contains($0.key) }
+        nextEventIndexBySegment = nextEventIndexBySegment.filter {
+            keep.contains($0.key)
+        }
     }
 
     private func hasDelivered(_ id: String) -> Bool {
@@ -255,6 +288,23 @@ public struct DanmakuScheduler: Sendable {
             ? max(positionSeconds, 0)
             : 0
         return Int(normalized / segmentDurationSeconds) + 1
+    }
+
+    private static func firstEventIndex(
+        after positionSeconds: Double,
+        in events: [DanmakuEvent]
+    ) -> Int {
+        var lowerBound = 0
+        var upperBound = events.count
+        while lowerBound < upperBound {
+            let candidate = lowerBound + (upperBound - lowerBound) / 2
+            if events[candidate].timeSeconds <= positionSeconds {
+                lowerBound = candidate + 1
+            } else {
+                upperBound = candidate
+            }
+        }
+        return lowerBound
     }
 
     private static func eventOrder(

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSchedulerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuSchedulerTests.swift
@@ -21,6 +21,7 @@ struct DanmakuSchedulerTests {
                 index: 1,
                 events: [
                     event(id: "a", time: 1.0),
+                    event(id: "during-pause", time: 1.3),
                     event(id: "b", time: 2.0),
                     event(id: "boundary", time: 360.1),
                 ]
@@ -276,6 +277,77 @@ struct DanmakuSchedulerTests {
         )
         let resumed = try #require(resumedValue)
         #expect(resumed.events.map(\.id) == ["after-enabled"])
+    }
+
+    @Test
+    func replacingCurrentSegmentReanchorsCursorWithoutBackfill() throws {
+        var scheduler = DanmakuScheduler()
+        scheduler.begin(for: identity)
+        scheduler.store(
+            DanmakuSegment(
+                index: 1,
+                events: [
+                    event(id: "initial", time: 1),
+                    event(id: "old-future", time: 4),
+                ]
+            ),
+            for: identity
+        )
+
+        _ = scheduler.consume(snapshot(position: 0, rate: 1, generation: 1))
+        let initialValue = scheduler.consume(
+            snapshot(position: 2, rate: 1, generation: 1)
+        )
+        let initial = try #require(initialValue)
+        #expect(initial.events.map(\.id) == ["initial"])
+
+        scheduler.store(
+            DanmakuSegment(
+                index: 1,
+                events: [
+                    event(id: "late-past", time: 1.5),
+                    event(id: "new-window", time: 2.5),
+                    event(id: "old-future", time: 4),
+                ]
+            ),
+            for: identity
+        )
+
+        let replacementValue = scheduler.consume(
+            snapshot(position: 3, rate: 1, generation: 1)
+        )
+        let replacement = try #require(replacementValue)
+        #expect(replacement.events.map(\.id) == ["new-window"])
+
+        let futureValue = scheduler.consume(
+            snapshot(position: 5, rate: 1, generation: 1)
+        )
+        let future = try #require(futureValue)
+        #expect(future.events.map(\.id) == ["old-future"])
+    }
+
+    @Test
+    func prefetchedSegmentDoesNotBackfillEventsOlderThanPlaybackWindow() throws {
+        var scheduler = DanmakuScheduler()
+        scheduler.begin(for: identity)
+        _ = scheduler.consume(snapshot(position: 0, rate: 1, generation: 1))
+        scheduler.store(
+            DanmakuSegment(
+                index: 2,
+                events: [
+                    event(id: "stale-prefetch", time: 2),
+                    event(id: "current", time: 361),
+                ]
+            ),
+            for: identity
+        )
+
+        _ = scheduler.consume(snapshot(position: 300, rate: 1, generation: 1))
+        let crossingValue = scheduler.consume(
+            snapshot(position: 362, rate: 1, generation: 1)
+        )
+        let crossing = try #require(crossingValue)
+        #expect(crossing.events.map(\.id) == ["current"])
     }
 
     @Test


### PR DESCRIPTION
## 变化

- 为 `DanmakuScheduler` 的分段事件消费增加有界游标，连续播放时只遍历新进入时间窗口的事件，不再每个时间线快照都从分段开头扫描。
- 在 begin/reset、启停、generation discontinuity、向后 seek、非播放状态和分段替换时清空或重新锚定游标，保留原有不补喷语义。
- 消费预取分段时仅在游标落后于当前播放窗口时执行二分追平，避免重叠或异常旧时间戳迟到投递。
- 增加暂停恢复、当前分段替换和预取跨段的回归覆盖。

## 原因与用户影响

高密度弹幕播放期间，调度器原先会反复扫描已缓存分段中的全部事件。该改动把正常连续播放路径改为增量推进，在不改变过滤、去重、分段缓存上限、播放时间线和清屏语义的前提下，降低调度器与主线程 CPU 开销。

## 性能验证

真实 App、固定视频 `BV1yt4y1Q7SS`，Time Profiler 每次录制 20 秒，采用 10–20 秒计算窗口；正常与重叠模式各 3 次有效样本：

| 模式 | 指标 | 基线中位数 | 优化后中位数 | 变化 |
|---|---|---:|---:|---:|
| 正常 | Scheduler | 742 ms | 7 ms | -99.1% |
| 正常 | 总 CPU | 32.04% | 26.62% | -16.9% |
| 正常 | 主线程 CPU | 16.22% | 8.00% | -50.7% |
| 重叠 | Scheduler | 748 ms | 9 ms | -98.8% |
| 重叠 | 总 CPU | 36.09% | 29.05% | -19.5% |
| 重叠 | 主线程 CPU | 19.62% | 12.05% | -38.6% |

- 6 份有效 trace 的 Potential Hangs 均为空。
- Danmaku Lab 人工观察中帧数约从 120 提升到 140；该观察不替代正式 Instruments 数据。
- Raw trace、XML 导出、分析脚本和 DerivedData 已在摘要完成后清理。

## 正确性与自动验证

- 三路只读审查覆盖状态机正确性、复杂度/内存风险及测试契约；发现的暂停恢复补喷和预取分段迟到补喷问题均已修复并由原 reviewer 复审，无 blocker。
- `sh Scripts/run-quality-gates.sh package`
  - 架构、秘密模式、工程契约检查通过
  - strict Swift format 与 diff 检查通过
  - 69 个 suite、659 个测试通过
- 真实播放人工检查：弹幕正常显示；暂停、回跳 seek、恢复播放后时间线继续前进。

## 未覆盖边界

- 未做 60/120 Hz 分屏对照、全屏/窗口缩放专项测量。
- 未做长时间播放的 Allocations/Leaks 与内存增长测量。
- 未扩展到新的渲染器、Package、target、helper 或 DSL。
