### PR TITLE
fix(auth): 收紧账户读取请求边界

### DIFF
--- a/BiliKitMac/Composition/AppEnvironment.swift
+++ b/BiliKitMac/Composition/AppEnvironment.swift
@@ -441,7 +441,9 @@ struct AppEnvironment {
     static func liveAppSettingsModel(
         accountSessionCoordinator: AccountSessionCoordinator
     ) -> AppSettingsModel {
-        let api = makeLiveAPIClient()
+        let api = makeLiveAPIClient(
+            accountReadAllowedPaths: cdnBenchmarkAccountReadAllowedPaths
+        )
         _ = accountSessionCoordinator.registerSessionInvalidator(api)
         let discoverer = CDNBenchmarkSampleDiscoverer(client: api)
         let benchmark = BilivideoRouteBenchmark()
@@ -481,7 +483,10 @@ struct AppEnvironment {
         accountSessionCoordinator: AccountSessionCoordinator
     ) {
         _ = accountSessionCoordinator.resolveWatchProgressRepository {
-            let writeAPI = makeLiveAPIClient(historyWriteEnabled: true)
+            let writeAPI = makeLiveAPIClient(
+                accountReadAllowedPaths: watchProgressAccountReadAllowedPaths,
+                historyWriteEnabled: true
+            )
             return (
                 BiliWatchProgressRepository(client: writeAPI),
                 writeAPI
@@ -498,7 +503,9 @@ struct AppEnvironment {
         accountSessionCoordinator: AccountSessionCoordinator? = nil,
         appSettingsModel: AppSettingsModel? = nil
     ) -> AppEnvironment {
-        let api = makeLiveAPIClient()
+        let api = makeLiveAPIClient(
+            accountReadAllowedPaths: mainAccountReadAllowedPaths
+        )
         let sessionRegistration = accountSessionCoordinator.map {
             AppEnvironmentSessionRegistration(
                 coordinator: $0,
@@ -516,7 +523,10 @@ struct AppEnvironment {
         if let accountSessionCoordinator {
             watchProgressRepository = accountSessionCoordinator.watchProgressRepository
         } else {
-            let writeAPI = makeLiveAPIClient(historyWriteEnabled: true)
+            let writeAPI = makeLiveAPIClient(
+                accountReadAllowedPaths: watchProgressAccountReadAllowedPaths,
+                historyWriteEnabled: true
+            )
             let writer = SerializedWatchProgressRepository(
                 base: BiliWatchProgressRepository(client: writeAPI)
             )
@@ -524,6 +534,7 @@ struct AppEnvironment {
             standaloneWriteInvalidators = [writer, writeAPI]
         }
         let authenticationService = BiliAuthenticationService(
+            accountReadAllowedPaths: accountSessionValidationAllowedPaths,
             additionalSessionInvalidators: [sessionInvalidator] + standaloneWriteInvalidators
         )
         let player = AVPlayer()
@@ -578,10 +589,39 @@ struct AppEnvironment {
         surfaceHeight: 0
     )
 
+    static let accountSessionValidationAllowedPaths: Set<String> = [
+        "/x/web-interface/nav"
+    ]
+
+    static let mainAccountReadAllowedPaths: Set<String> = [
+        "/x/player/pagelist",
+        "/x/player/playurl",
+        "/x/player/wbi/v2",
+        "/x/v2/dm/wbi/web/seg.so",
+        "/x/v2/reply/reply",
+        "/x/v2/reply/wbi/main",
+        "/x/web-interface/archive/related",
+        "/x/web-interface/card",
+        "/x/web-interface/history/cursor",
+        "/x/web-interface/popular",
+        "/x/web-interface/view",
+        "/x/web-interface/wbi/index/top/feed/rcmd",
+        "/x/web-interface/wbi/search/type",
+    ]
+
+    static let cdnBenchmarkAccountReadAllowedPaths: Set<String> = [
+        "/x/player/playurl"
+    ]
+
+    static let watchProgressAccountReadAllowedPaths: Set<String>? = nil
+
     private static func makeLiveAPIClient(
+        accountReadAllowedPaths: Set<String>?,
         historyWriteEnabled: Bool = false
     ) -> BiliAPIClient {
-        let requestAuthorizer = BiliCredentialRequestAuthorizer()
+        let requestAuthorizer = accountReadAllowedPaths.map {
+            BiliCredentialRequestAuthorizer(allowedPaths: $0)
+        }
         let historyWriteAuthorizer: (any HTTPRequestAuthorizing)? =
             historyWriteEnabled ? BiliPlaybackHeartbeatRequestAuthorizer() : nil
         let transportFactory: @Sendable () -> any HTTPTransport = {

--- a/BiliKitMacTests/AccountReadAuthorizationCompositionTests.swift
+++ b/BiliKitMacTests/AccountReadAuthorizationCompositionTests.swift
@@ -1,0 +1,96 @@
+import BiliNetworking
+import Foundation
+import Testing
+
+@testable import BiliAuth
+@testable import BiliKit
+
+struct AccountReadAuthorizationCompositionTests {
+    @Test
+    @MainActor
+    func productionCapabilitiesStayExactAndMinimal() {
+        #expect(
+            AppEnvironment.accountSessionValidationAllowedPaths == [
+                "/x/web-interface/nav"
+            ]
+        )
+        #expect(
+            AppEnvironment.mainAccountReadAllowedPaths == [
+                "/x/player/pagelist",
+                "/x/player/playurl",
+                "/x/player/wbi/v2",
+                "/x/v2/dm/wbi/web/seg.so",
+                "/x/v2/reply/reply",
+                "/x/v2/reply/wbi/main",
+                "/x/web-interface/archive/related",
+                "/x/web-interface/card",
+                "/x/web-interface/history/cursor",
+                "/x/web-interface/popular",
+                "/x/web-interface/view",
+                "/x/web-interface/wbi/index/top/feed/rcmd",
+                "/x/web-interface/wbi/search/type",
+            ]
+        )
+        #expect(
+            AppEnvironment.cdnBenchmarkAccountReadAllowedPaths == [
+                "/x/player/playurl"
+            ]
+        )
+        #expect(AppEnvironment.watchProgressAccountReadAllowedPaths == nil)
+    }
+
+    @Test
+    @MainActor
+    func everyProductionReadPathCanAuthorizeAnExactGet() async throws {
+        let credential = try makeCompositionFixtureCredential()
+        let configuredCapabilities = [
+            AppEnvironment.accountSessionValidationAllowedPaths,
+            AppEnvironment.mainAccountReadAllowedPaths,
+            AppEnvironment.cdnBenchmarkAccountReadAllowedPaths,
+        ]
+
+        for allowedPaths in configuredCapabilities {
+            let authorizer = BiliCredentialRequestAuthorizer(
+                store: CompositionFixtureCredentialStore(credential: credential),
+                allowedPaths: allowedPaths
+            )
+            for path in allowedPaths {
+                let request = HTTPRequest(
+                    url: try #require(
+                        URL(string: "https://api.bilibili.com\(path)?fixture=1")
+                    )
+                )
+
+                let authorized = try await authorizer.authorize(request)
+
+                #expect(authorized.url.path == path)
+                #expect(authorized.method == .get)
+                #expect(authorized.headers == ["Cookie": credential.cookieHeader])
+            }
+        }
+    }
+}
+
+private struct CompositionFixtureCredentialStore: WebCredentialStoring {
+    let credential: WebCredential
+
+    func load() -> WebCredential? { credential }
+    func save(_ credential: WebCredential) {}
+    func delete() {}
+}
+
+private func makeCompositionFixtureCredential() throws -> WebCredential {
+    try WebCredential(
+        cookies: WebCredentialCookieName.allCases.map { name in
+            WebCredentialCookie(
+                name: name,
+                value: "FIXTURE_\(name.rawValue)_VALUE",
+                domain: ".bilibili.com",
+                path: "/",
+                isSecure: true,
+                isHTTPOnly: name == .session,
+                expiresAt: Date(timeIntervalSince1970: 4_102_444_800)
+            )
+        }
+    )
+}

--- a/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
+++ b/Packages/BiliKitCore/Sources/BiliAPI/Client/BiliAPIClient.swift
@@ -768,7 +768,7 @@ public actor BiliAPIClient: AuthenticatedSessionInvalidating {
         after continuation: WatchHistoryContinuation? = nil,
         pageSize: Int = 20
     ) async throws -> WatchHistoryPage {
-        guard (1...50).contains(pageSize) else {
+        guard (1...30).contains(pageSize) else {
             throw BiliAPIError.invalidRequest
         }
         let cursor: WatchHistoryCursorPayload

--- a/Packages/BiliKitCore/Sources/BiliApplication/History/WatchHistoryUseCase.swift
+++ b/Packages/BiliKitCore/Sources/BiliApplication/History/WatchHistoryUseCase.swift
@@ -19,7 +19,7 @@ public struct WatchHistoryUseCase: Sendable {
         after continuation: WatchHistoryContinuation? = nil,
         pageSize: Int = 20
     ) async throws -> WatchHistoryPage {
-        guard (1...50).contains(pageSize) else {
+        guard (1...30).contains(pageSize) else {
             throw WatchHistoryError.invalidResponse
         }
         var requestContinuation = continuation

--- a/Packages/BiliKitCore/Sources/BiliAuth/Application/BiliAuthenticationService.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/Application/BiliAuthenticationService.swift
@@ -19,12 +19,19 @@ public actor BiliAuthenticationService: AuthenticationServicing {
     private var requiresLogout = false
 
     public init(
+        accountReadAllowedPaths: Set<String>,
         additionalSessionInvalidators: [any AuthenticatedSessionInvalidating] = []
     ) {
         loginSession = WebQRLoginSession()
-        authorizer = BiliCredentialRequestAuthorizer()
+        authorizer = BiliCredentialRequestAuthorizer(
+            allowedPaths: accountReadAllowedPaths
+        )
         loginSessionFactory = { WebQRLoginSession() }
-        authorizerFactory = { BiliCredentialRequestAuthorizer() }
+        authorizerFactory = {
+            BiliCredentialRequestAuthorizer(
+                allowedPaths: accountReadAllowedPaths
+            )
+        }
         self.additionalSessionInvalidators = additionalSessionInvalidators
     }
 

--- a/Packages/BiliKitCore/Sources/BiliAuth/Credential/BiliCredentialRequestAuthorizer.swift
+++ b/Packages/BiliKitCore/Sources/BiliAuth/Credential/BiliCredentialRequestAuthorizer.swift
@@ -28,8 +28,8 @@ public enum BiliRequestAuthorizationError:
 
 /// 从 Keychain 按需读取 Cookie，并只授权 Bilibili API 的只读账户请求。
 ///
-/// 调用方声明账户读取能力后，scheme、host、port、method、userinfo、fragment 与现有 Cookie
-/// header 仍会再次验证。损坏或过期凭据会清除，媒体/CDN/loopback 请求无法通过此边界。
+/// 调用方声明账户读取能力后，scheme、host、port、method、exact path、userinfo、fragment 与
+/// 现有凭据 header 仍会再次验证。损坏或过期凭据会清除，媒体/CDN/loopback 请求无法通过此边界。
 public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable {
     private static let maximumResponseSize = 256 * 1_024
     private static let navigationValidationURL: URL = {
@@ -46,16 +46,19 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
     private let store: any WebCredentialStoring
     private let httpClient: HTTPClient
     private let transportInvalidator: (@Sendable () -> Void)?
+    private let allowedPaths: Set<String>
 
-    public init() {
+    public init(allowedPaths: Set<String>) {
         let transport = Self.makeProductionTransport()
         store = KeychainWebCredentialStore()
         httpClient = HTTPClient(transport: transport)
         transportInvalidator = { transport.invalidateAndCancel() }
+        self.allowedPaths = allowedPaths
     }
 
     init(
         store: any WebCredentialStoring,
+        allowedPaths: Set<String>,
         transport: any HTTPTransport = Self.makeProductionTransport()
     ) {
         self.store = store
@@ -65,18 +68,15 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
         } else {
             transportInvalidator = nil
         }
+        self.allowedPaths = allowedPaths
     }
 
     /// 返回附带短生命周期 Cookie header 的新请求；原请求不会被原地共享或缓存。
     public func authorize(_ request: HTTPRequest) async throws -> HTTPRequest {
-        guard Self.isAllowed(request) else {
+        guard isAllowed(request) else {
             throw BiliRequestAuthorizationError.requestNotAllowed
         }
-        guard
-            !request.headers.keys.contains(where: {
-                $0.caseInsensitiveCompare("Cookie") == .orderedSame
-            })
-        else {
+        guard !Self.containsCredentialHeader(request.headers) else {
             throw BiliRequestAuthorizationError.credentialHeaderAlreadyPresent
         }
 
@@ -169,7 +169,7 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
         return .signedIn(identity)
     }
 
-    private static func isAllowed(_ request: HTTPRequest) -> Bool {
+    private func isAllowed(_ request: HTTPRequest) -> Bool {
         guard
             let components = URLComponents(
                 url: request.url,
@@ -183,8 +183,18 @@ public struct BiliCredentialRequestAuthorizer: HTTPRequestAuthorizing, Sendable 
             && (components.port == nil || components.port == 443)
             && components.user == nil
             && components.password == nil
+            && allowedPaths.contains(components.path)
+            && components.percentEncodedPath == components.path
             && components.fragment == nil
             && request.method == .get
+    }
+
+    private static func containsCredentialHeader(_ headers: [String: String]) -> Bool {
+        headers.keys.contains {
+            $0.caseInsensitiveCompare("Cookie") == .orderedSame
+                || $0.caseInsensitiveCompare("Authorization") == .orderedSame
+                || $0.caseInsensitiveCompare("X-CSRF-Token") == .orderedSame
+        }
     }
 
     private func purgeStoredCredential() throws {

--- a/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAPITests/BiliAPIClientTests.swift
@@ -1921,6 +1921,45 @@ struct BiliAPIClientTests {
     }
 
     @Test
+    func historyAcceptsDefaultAndMaximumPageSizeAndRejectsOutOfRangeBeforeTransport()
+        async throws
+    {
+        let transport = RecordingTransport(
+            responses: [
+                try fixtureResponse("history"),
+                try fixtureResponse("history"),
+            ]
+        )
+        let client = BiliAPIClient(
+            transport: transport,
+            requestAuthorizer: RecordingRequestAuthorizer()
+        )
+
+        _ = try await client.watchHistory()
+        _ = try await client.watchHistory(pageSize: 30)
+
+        let validRequests = await transport.capturedRequests()
+        #expect(validRequests.count == 2)
+        let defaultQuery = URLComponents(
+            url: validRequests[0].url,
+            resolvingAgainstBaseURL: false
+        )?.queryItems
+        let maximumQuery = URLComponents(
+            url: validRequests[1].url,
+            resolvingAgainstBaseURL: false
+        )?.queryItems
+        #expect(defaultQuery?.contains(URLQueryItem(name: "ps", value: "20")) == true)
+        #expect(maximumQuery?.contains(URLQueryItem(name: "ps", value: "30")) == true)
+
+        for pageSize in [31, 0, -1] {
+            await #expect(throws: BiliAPIError.invalidRequest) {
+                try await client.watchHistory(pageSize: pageSize)
+            }
+        }
+        #expect(await transport.capturedRequests().count == 2)
+    }
+
+    @Test
     func popularVideoDetailAndPageListUseAccountRead()
         async throws
     {

--- a/Packages/BiliKitCore/Tests/BiliApplicationTests/WatchHistoryUseCaseTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliApplicationTests/WatchHistoryUseCaseTests.swift
@@ -22,12 +22,28 @@ struct WatchHistoryUseCaseTests {
     }
 
     @Test
-    func rejectsInvalidPageSizeBeforeCallingRepository() async {
+    func defaultsToTwentyItems() async throws {
+        let repository = WatchHistoryRepositoryStub(
+            pages: [WatchHistoryPage(items: [], continuation: nil)]
+        )
+        let useCase = WatchHistoryUseCase(repository: repository)
+
+        _ = try await useCase.load()
+
+        #expect(
+            await repository.requests() == [
+                Request(continuation: nil, pageSize: 20)
+            ]
+        )
+    }
+
+    @Test(arguments: [31, 0, -1])
+    func rejectsInvalidPageSizeBeforeCallingRepository(pageSize: Int) async {
         let repository = WatchHistoryRepositoryStub(pages: [])
         let useCase = WatchHistoryUseCase(repository: repository)
 
         await #expect(throws: WatchHistoryError.invalidResponse) {
-            try await useCase.load(pageSize: 0)
+            try await useCase.load(pageSize: pageSize)
         }
         #expect(await repository.requests().isEmpty)
     }

--- a/Packages/BiliKitCore/Tests/BiliAuthTests/BiliAuthenticationServiceTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthTests/BiliAuthenticationServiceTests.swift
@@ -6,6 +6,10 @@ import Testing
 
 @testable import BiliAuth
 
+private let accountSessionValidationAllowedPaths: Set<String> = [
+    "/x/web-interface/nav"
+]
+
 struct BiliAuthenticationServiceTests {
     @Test
     func mapsQRCodeFlowAndCommitsOnlyAfterFinalValidation() async throws {
@@ -35,6 +39,7 @@ struct BiliAuthenticationServiceTests {
             session: session,
             authorizer: BiliCredentialRequestAuthorizer(
                 store: store,
+                allowedPaths: accountSessionValidationAllowedPaths,
                 transport: RecordingAuthTransport()
             ),
             store: store
@@ -64,6 +69,7 @@ struct BiliAuthenticationServiceTests {
             ),
             authorizer: BiliCredentialRequestAuthorizer(
                 store: store,
+                allowedPaths: accountSessionValidationAllowedPaths,
                 transport: RecordingAuthTransport(
                     responses: [
                         navigationResponse(
@@ -92,6 +98,7 @@ struct BiliAuthenticationServiceTests {
             ),
             authorizer: BiliCredentialRequestAuthorizer(
                 store: store,
+                allowedPaths: accountSessionValidationAllowedPaths,
                 transport: RecordingAuthTransport(
                     responses: [
                         navigationResponse(isLogin: true),
@@ -108,6 +115,7 @@ struct BiliAuthenticationServiceTests {
             authorizerFactory: {
                 BiliCredentialRequestAuthorizer(
                     store: store,
+                    allowedPaths: accountSessionValidationAllowedPaths,
                     transport: RecordingAuthTransport()
                 )
             },
@@ -135,6 +143,7 @@ struct BiliAuthenticationServiceTests {
             ),
             authorizer: BiliCredentialRequestAuthorizer(
                 store: store,
+                allowedPaths: accountSessionValidationAllowedPaths,
                 transport: RecordingAuthTransport()
             ),
             loginSessionFactory: {
@@ -146,6 +155,7 @@ struct BiliAuthenticationServiceTests {
             authorizerFactory: {
                 BiliCredentialRequestAuthorizer(
                     store: store,
+                    allowedPaths: accountSessionValidationAllowedPaths,
                     transport: RecordingAuthTransport()
                 )
             },
@@ -171,6 +181,7 @@ struct BiliAuthenticationServiceTests {
             ),
             authorizer: BiliCredentialRequestAuthorizer(
                 store: store,
+                allowedPaths: accountSessionValidationAllowedPaths,
                 transport: RecordingAuthTransport(
                     responses: [navigationResponse(isLogin: false)]
                 )
@@ -184,6 +195,7 @@ struct BiliAuthenticationServiceTests {
             authorizerFactory: {
                 BiliCredentialRequestAuthorizer(
                     store: store,
+                    allowedPaths: accountSessionValidationAllowedPaths,
                     transport: RecordingAuthTransport()
                 )
             },
@@ -210,6 +222,7 @@ struct BiliAuthenticationServiceTests {
             ),
             authorizer: BiliCredentialRequestAuthorizer(
                 store: store,
+                allowedPaths: accountSessionValidationAllowedPaths,
                 transport: RecordingAuthTransport(
                     responses: [navigationResponse(isLogin: false)]
                 )
@@ -223,6 +236,7 @@ struct BiliAuthenticationServiceTests {
             authorizerFactory: {
                 BiliCredentialRequestAuthorizer(
                     store: store,
+                    allowedPaths: accountSessionValidationAllowedPaths,
                     transport: RecordingAuthTransport()
                 )
             },
@@ -257,6 +271,7 @@ struct BiliAuthenticationServiceTests {
             ),
             authorizer: BiliCredentialRequestAuthorizer(
                 store: store,
+                allowedPaths: accountSessionValidationAllowedPaths,
                 transport: RecordingAuthTransport()
             ),
             store: store
@@ -288,6 +303,7 @@ struct BiliAuthenticationServiceTests {
             ),
             authorizer: BiliCredentialRequestAuthorizer(
                 store: store,
+                allowedPaths: accountSessionValidationAllowedPaths,
                 transport: RecordingAuthTransport(
                     responses: [navigationResponse(isLogin: true)]
                 )
@@ -301,6 +317,7 @@ struct BiliAuthenticationServiceTests {
             authorizerFactory: {
                 BiliCredentialRequestAuthorizer(
                     store: store,
+                    allowedPaths: accountSessionValidationAllowedPaths,
                     transport: RecordingAuthTransport()
                 )
             },
@@ -340,6 +357,7 @@ struct BiliAuthenticationServiceTests {
             ),
             authorizer: BiliCredentialRequestAuthorizer(
                 store: store,
+                allowedPaths: accountSessionValidationAllowedPaths,
                 transport: validationTransport
             ),
             loginSessionFactory: {
@@ -351,6 +369,7 @@ struct BiliAuthenticationServiceTests {
             authorizerFactory: {
                 BiliCredentialRequestAuthorizer(
                     store: store,
+                    allowedPaths: accountSessionValidationAllowedPaths,
                     transport: RecordingAuthTransport()
                 )
             },
@@ -397,6 +416,7 @@ struct BiliAuthenticationServiceTests {
             ),
             authorizer: BiliCredentialRequestAuthorizer(
                 store: store,
+                allowedPaths: accountSessionValidationAllowedPaths,
                 transport: validationTransport
             ),
             loginSessionFactory: {
@@ -408,6 +428,7 @@ struct BiliAuthenticationServiceTests {
             authorizerFactory: {
                 BiliCredentialRequestAuthorizer(
                     store: store,
+                    allowedPaths: accountSessionValidationAllowedPaths,
                     transport: RecordingAuthTransport()
                 )
             },
@@ -448,6 +469,7 @@ struct BiliAuthenticationServiceTests {
             authorizerFactory: {
                 BiliCredentialRequestAuthorizer(
                     store: store,
+                    allowedPaths: accountSessionValidationAllowedPaths,
                     transport: RecordingAuthTransport()
                 )
             }

--- a/Packages/BiliKitCore/Tests/BiliAuthTests/Credential/BiliCredentialRequestAuthorizerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliAuthTests/Credential/BiliCredentialRequestAuthorizerTests.swift
@@ -4,45 +4,103 @@ import Testing
 
 @testable import BiliAuth
 
+private let fixtureNavigationAllowedPaths: Set<String> = [
+    "/x/web-interface/nav"
+]
+
+private let fixturePlaybackAllowedPaths: Set<String> = [
+    "/x/player/playurl"
+]
+
 struct BiliCredentialRequestAuthorizerTests {
     @Test
-    func addsCredentialToExactAPIReadCapability() async throws {
+    func authorizesConfiguredPathsAndInjectsOnlyStoredCredential() async throws {
         let credential = try makeFixtureCredential()
-        let authorizer = BiliCredentialRequestAuthorizer(
-            store: MemoryWebCredentialStore(credential: credential)
-        )
-        let request = HTTPRequest(
-            url: try #require(
-                URL(
-                    string:
-                        "https://api.bilibili.com:443/x/web-interface/wbi/search/type?keyword=macOS&page=1"
+        for allowedPaths in [
+            fixtureNavigationAllowedPaths,
+            fixturePlaybackAllowedPaths,
+        ] {
+            let authorizer = BiliCredentialRequestAuthorizer(
+                store: MemoryWebCredentialStore(credential: credential),
+                allowedPaths: allowedPaths
+            )
+            for path in allowedPaths {
+                let request = HTTPRequest(
+                    url: try #require(
+                        URL(
+                            string: "https://api.bilibili.com:443\(path)?fixture=1"
+                        )
+                    ),
+                    headers: ["Accept": "application/json"]
                 )
-            ),
-            headers: ["Accept": "application/json"]
+
+                let authorized = try await authorizer.authorize(request)
+
+                #expect(authorized.headers["Accept"] == "application/json")
+                #expect(authorized.headers["Cookie"] == credential.cookieHeader)
+                #expect(authorized.headers["Authorization"] == nil)
+                #expect(authorized.headers["X-CSRF-Token"] == nil)
+                #expect(authorized.headers.count == 2)
+            }
+        }
+    }
+
+    @Test
+    func keepsConfiguredReadCapabilitiesDisjoint() async throws {
+        let store = MemoryWebCredentialStore(credential: try makeFixtureCredential())
+        let validationAuthorizer = BiliCredentialRequestAuthorizer(
+            store: store,
+            allowedPaths: fixtureNavigationAllowedPaths
+        )
+        let apiAuthorizer = BiliCredentialRequestAuthorizer(
+            store: store,
+            allowedPaths: fixturePlaybackAllowedPaths
+        )
+        let navigationRequest = HTTPRequest(
+            url: try #require(
+                URL(string: "https://api.bilibili.com/x/web-interface/nav")
+            )
+        )
+        let playbackRequest = HTTPRequest(
+            url: try #require(
+                URL(string: "https://api.bilibili.com/x/player/playurl")
+            )
         )
 
-        let authorized = try await authorizer.authorize(request)
-
-        #expect(authorized.headers["Accept"] == "application/json")
-        #expect(authorized.headers["Cookie"] == credential.cookieHeader)
+        await #expect(throws: BiliRequestAuthorizationError.requestNotAllowed) {
+            try await validationAuthorizer.authorize(playbackRequest)
+        }
+        await #expect(throws: BiliRequestAuthorizationError.requestNotAllowed) {
+            try await apiAuthorizer.authorize(navigationRequest)
+        }
     }
 
     @Test
     func rejectsNonAPIReadCapabilities() async throws {
         let store = MemoryWebCredentialStore(credential: try makeFixtureCredential())
-        let authorizer = BiliCredentialRequestAuthorizer(store: store)
+        let authorizer = BiliCredentialRequestAuthorizer(
+            store: store,
+            allowedPaths: fixturePlaybackAllowedPaths
+        )
         let cases: [(String, HTTPMethod)] = [
-            ("http://api.bilibili.com/x/web-interface/nav", .get),
-            ("https://api.bilibili.com.evil.invalid/x/web-interface/nav", .get),
-            ("https://i0.hdslb.com/x/web-interface/nav", .get),
-            ("http://127.0.0.1:8080/x/web-interface/nav", .get),
+            ("http://api.bilibili.com/x/player/playurl", .get),
+            ("https://api.bilibili.com.evil.invalid/x/player/playurl", .get),
+            ("https://i0.hdslb.com/x/player/playurl", .get),
+            ("http://127.0.0.1:8080/x/player/playurl", .get),
             (
-                "https://api.bilibili.com:444/x/web-interface/wbi/search/type",
+                "https://api.bilibili.com:444/x/player/playurl",
                 .get
             ),
-            ("https://api.bilibili.com/x/web-interface/nav", .post),
-            ("https://user@api.bilibili.com/x/web-interface/nav", .get),
-            ("https://api.bilibili.com/x/web-interface/nav#fragment", .get),
+            ("https://api.bilibili.com/x/player/playurl", .post),
+            ("https://user@api.bilibili.com/x/player/playurl", .get),
+            ("https://api.bilibili.com/x/player/playurl#fragment", .get),
+            ("https://api.bilibili.com/x/player/playurl/", .get),
+            ("https://api.bilibili.com/x/player/playurl/extra", .get),
+            ("https://api.bilibili.com/x/player/playurl-similar", .get),
+            ("https://api.bilibili.com/%78/player/playurl", .get),
+            ("https://api.bilibili.com/x/player/wbi/playurl", .get),
+            ("https://api.bilibili.com/x/v2/history/report", .get),
+            ("https://api.bilibili.com/x/web-interface/future", .get),
         ]
 
         for (urlString, method) in cases {
@@ -57,28 +115,32 @@ struct BiliCredentialRequestAuthorizerTests {
     }
 
     @Test
-    func rejectsPreexistingCredentialHeader() async throws {
+    func rejectsPreexistingCredentialHeadersCaseInsensitively() async throws {
         let authorizer = BiliCredentialRequestAuthorizer(
-            store: MemoryWebCredentialStore(credential: try makeFixtureCredential())
+            store: MemoryWebCredentialStore(credential: try makeFixtureCredential()),
+            allowedPaths: fixtureNavigationAllowedPaths
         )
-        let request = HTTPRequest(
-            url: try #require(
-                URL(string: "https://api.bilibili.com/x/web-interface/nav")
-            ),
-            headers: ["cookie": "FIXTURE_PREEXISTING_VALUE"]
-        )
+        for header in ["cOoKiE", "aUtHoRiZaTiOn", "x-CsRf-ToKeN"] {
+            let request = HTTPRequest(
+                url: try #require(
+                    URL(string: "https://api.bilibili.com/x/web-interface/nav")
+                ),
+                headers: [header: "FIXTURE_PREEXISTING_VALUE"]
+            )
 
-        await #expect(
-            throws: BiliRequestAuthorizationError.credentialHeaderAlreadyPresent
-        ) {
-            try await authorizer.authorize(request)
+            await #expect(
+                throws: BiliRequestAuthorizationError.credentialHeaderAlreadyPresent
+            ) {
+                try await authorizer.authorize(request)
+            }
         }
     }
 
     @Test
     func missingCredentialFailsWithoutChangingRequest() async throws {
         let authorizer = BiliCredentialRequestAuthorizer(
-            store: MemoryWebCredentialStore()
+            store: MemoryWebCredentialStore(),
+            allowedPaths: fixtureNavigationAllowedPaths
         )
         let request = HTTPRequest(
             url: try #require(
@@ -115,7 +177,10 @@ struct BiliCredentialRequestAuthorizerTests {
         let expiredStore = MemoryWebCredentialStore(
             credential: try makeFixtureCredential(expiresAt: .distantPast)
         )
-        let expiredAuthorizer = BiliCredentialRequestAuthorizer(store: expiredStore)
+        let expiredAuthorizer = BiliCredentialRequestAuthorizer(
+            store: expiredStore,
+            allowedPaths: fixtureNavigationAllowedPaths
+        )
 
         await #expect(throws: BiliRequestAuthorizationError.expiredCredential) {
             try await expiredAuthorizer.authorize(HTTPRequest(url: endpoint))
@@ -125,7 +190,10 @@ struct BiliCredentialRequestAuthorizerTests {
         let corruptStore = MemoryWebCredentialStore(
             loadError: WebCredentialStoreError.corruptCredential
         )
-        let corruptAuthorizer = BiliCredentialRequestAuthorizer(store: corruptStore)
+        let corruptAuthorizer = BiliCredentialRequestAuthorizer(
+            store: corruptStore,
+            allowedPaths: fixtureNavigationAllowedPaths
+        )
         await #expect(throws: BiliRequestAuthorizationError.invalidCredential) {
             try await corruptAuthorizer.authorize(HTTPRequest(url: endpoint))
         }
@@ -136,7 +204,8 @@ struct BiliCredentialRequestAuthorizerTests {
             deleteError: FixtureValidationError.offline
         )
         let deletionFailureAuthorizer = BiliCredentialRequestAuthorizer(
-            store: deletionFailure
+            store: deletionFailure,
+            allowedPaths: fixtureNavigationAllowedPaths
         )
         await #expect(
             throws: BiliRequestAuthorizationError.credentialStoreUnavailable
@@ -154,6 +223,7 @@ struct BiliCredentialRequestAuthorizerTests {
         )
         let authorizer = BiliCredentialRequestAuthorizer(
             store: MemoryWebCredentialStore(credential: try makeFixtureCredential()),
+            allowedPaths: fixtureNavigationAllowedPaths,
             transport: transport
         )
 
@@ -172,6 +242,7 @@ struct BiliCredentialRequestAuthorizerTests {
         )
         let missing = BiliCredentialRequestAuthorizer(
             store: MemoryWebCredentialStore(),
+            allowedPaths: fixtureNavigationAllowedPaths,
             transport: missingTransport
         )
         #expect(
@@ -185,6 +256,7 @@ struct BiliCredentialRequestAuthorizerTests {
         )
         let invalid = BiliCredentialRequestAuthorizer(
             store: invalidStore,
+            allowedPaths: fixtureNavigationAllowedPaths,
             transport: CredentialValidationTransport(
                 response: navigationResponse(isLogin: false)
             )
@@ -200,6 +272,7 @@ struct BiliCredentialRequestAuthorizerTests {
                 credential: try makeFixtureCredential(),
                 deleteError: FixtureValidationError.offline
             ),
+            allowedPaths: fixtureNavigationAllowedPaths,
             transport: CredentialValidationTransport(
                 response: navigationResponse(isLogin: false)
             )
@@ -216,6 +289,7 @@ struct BiliCredentialRequestAuthorizerTests {
         let store = MemoryWebCredentialStore(credential: try makeFixtureCredential())
         let authorizer = BiliCredentialRequestAuthorizer(
             store: store,
+            allowedPaths: fixtureNavigationAllowedPaths,
             transport: CredentialValidationTransport(error: FixtureValidationError.offline)
         )
 


### PR DESCRIPTION
## 变化

- 为账户读取 authorizer 增加不可变的 exact-path allowlist，并在 Composition 按真实能力显式装配：主读取客户端保留当前 main 的 13 个可达路径，CDN 样本发现仅允许 `/x/player/playurl`，会话校验仅允许 `/x/web-interface/nav`，heartbeat 写客户端不获得读取能力。
- 继续严格限制 HTTPS、`api.bilibili.com`、默认或显式 443、GET、无 userinfo/fragment、精确解码路径；拒绝调用方预置的 Cookie、Authorization 与 X-CSRF-Token，再注入项目受控 Cookie。
- 将 `/x/web-interface/history/cursor` 的公开 `ps` 范围从 `1...50` 收紧为 `1...30`，默认值保持 20。

## 原因

此前账户读取 authorizer 只校验 origin 与方法，具体 API 客户端可能把登录 Cookie 带到不属于其能力的 GET 路径。本次把 endpoint 能力清单留在 Composition，并按每个具体 adapter 最小化授权；同时让 history 参数与服务端上限一致。

## 用户影响

- 正常浏览、播放、搜索、评论与历史记录继续支持现有匿名回退和登录增强行为。
- history `ps=30` 可用，`31`、`0` 和负数会在发送网络请求前失败。
- 无 UI 变化。

## 验证

- 三位代理分别完成安全边界、实际调用图、测试与范围审查；修正发现项后复审均无剩余问题。
- `sh Scripts/run-quality-gates.sh app`
  - Package：662 tests / 69 suites 通过
  - App build-for-testing 与 BiliKitMacTests 通过
  - SignedKeychainSmokeTests 因 unsigned test host 按既有条件跳过
- `git diff --check`

## 安全与未覆盖边界

- 未发送真实 B 站请求，未使用真实账号、浏览器登录态或任何真实凭据。
- 当前 main 的播放地址仍是 `/x/player/playurl`；没有为尚未合入的 `/x/player/wbi/playurl` 预授权。
- legacy `/x/v2/history/report` 继续拒绝；heartbeat 专用 authorizer 实现未改动。
- 未改变 Keychain、Cookie 存储、匿名回退、transport、redirect policy、DTO、分页 continuation 或 UI。
- 未涉及暂停中的 PR1、DASH、QR、图片、search 或 danmaku 行为改动。
