### PR TITLE
feat(danmaku): 异步预烘焙纹理并优化间距

### DIFF
--- a/BiliKitMac/Platform/DanmakuOverlayHostView.swift
+++ b/BiliKitMac/Platform/DanmakuOverlayHostView.swift
@@ -11,6 +11,7 @@ final class DanmakuOverlayView: NSView {
     private let controller: DanmakuPresentationController
     private let ownerID = UUID()
     private var previousSize: CGSize?
+    private var previousBackingScale: CGFloat?
     private var isSurfaceAttached = false
 
     init(
@@ -42,6 +43,11 @@ final class DanmakuOverlayView: NSView {
         updateSurfaceIfNeeded()
     }
 
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        updateSurfaceIfNeeded()
+    }
+
     override func hitTest(_ point: NSPoint) -> NSView? {
         nil
     }
@@ -49,13 +55,24 @@ final class DanmakuOverlayView: NSView {
     /// 仅由当前 surface owner 发布布局尺寸；已有弹幕保留运动，新弹幕使用最新尺寸。
     func updateSurfaceIfNeeded() {
         guard bounds.width > 0, bounds.height > 0 else { return }
-        guard bounds.size != previousSize else { return }
+        let backingScale =
+            window?.backingScaleFactor
+            ?? NSScreen.main?.backingScaleFactor
+            ?? 2
+        guard
+            bounds.size != previousSize
+                || backingScale != previousBackingScale
+        else {
+            return
+        }
         previousSize = bounds.size
+        previousBackingScale = backingScale
         let width = max(Double(bounds.width), 0)
         let height = max(Double(bounds.height), 0)
         controller.updateSurface(
             width: width,
             height: height,
+            backingScale: Double(backingScale),
             ownerID: ownerID
         )
     }
@@ -75,6 +92,7 @@ final class DanmakuOverlayView: NSView {
         controller.attachSurface(ownerID: ownerID)
         layer?.addSublayer(renderer.rootLayer)
         previousSize = nil
+        previousBackingScale = nil
         updateSurfaceIfNeeded()
     }
 }

--- a/BiliKitMacTests/PlayerHostViewIdentityTests.swift
+++ b/BiliKitMacTests/PlayerHostViewIdentityTests.swift
@@ -83,7 +83,7 @@ struct PlayerHostViewIdentityTests {
 
     @Test
     @MainActor
-    func danmakuSurfaceSurvivesTemporaryWindowReparenting() throws {
+    func danmakuSurfaceSurvivesTemporaryWindowReparenting() async throws {
         let renderer = CoreAnimationDanmakuRenderer()
         let controller = DanmakuPresentationController(
             backend: renderer,
@@ -120,10 +120,14 @@ struct PlayerHostViewIdentityTests {
                 mode: .scrolling
             )
         )
+        #expect(
+            await waitUntil {
+                renderer.activeLayerCount == 1
+                    && controller.statistics.active == 1
+            }
+        )
         let firstLayer = try #require(renderer.rootLayer.sublayers?.first)
         let epoch = renderer.renderEpoch
-        #expect(renderer.activeLayerCount == 1)
-        #expect(controller.statistics.active == 1)
 
         overlay.removeFromSuperview()
         #expect(overlay.window == nil)
@@ -142,8 +146,12 @@ struct PlayerHostViewIdentityTests {
                 mode: .top
             )
         )
-        #expect(renderer.activeLayerCount == 2)
-        #expect(controller.statistics.active == 2)
+        #expect(
+            await waitUntil {
+                renderer.activeLayerCount == 2
+                    && controller.statistics.active == 2
+            }
+        )
 
         overlay.frame = secondWindow.contentView?.bounds ?? .zero
         secondWindow.contentView?.addSubview(overlay)
@@ -570,6 +578,20 @@ struct PlayerHostViewIdentityTests {
             guard clock.now < deadline else { return false }
             hostingView.layoutSubtreeIfNeeded()
             try? await Task.sleep(for: .milliseconds(5))
+        }
+        return true
+    }
+
+    @MainActor
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        _ condition: @MainActor () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !condition() {
+            guard clock.now < deadline else { return false }
+            await Task.yield()
         }
         return true
     }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuRenderer.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuRenderer.swift
@@ -1,30 +1,27 @@
 import AppKit
 import BiliApplication
 import BiliModels
-import CoreText
 import Foundation
 import QuartzCore
 
 @MainActor
-/// 有硬上限的 Core Animation 弹幕 backend，负责 layer identity、动画时钟与最终回收。
+/// 有硬上限的 Core Animation 弹幕 backend，负责纹理准备、layer identity、动画时钟与回收。
 ///
-/// `renderEpoch + objectIdentity` 使旧动画 completion 无法删除同 ID 的新 layer；显式清屏
-/// 和 stop 会推进 epoch，resize 只更新 geometry 并保留活动对象。
+/// Core Text shaping、整行 union mask、vImage 阴影与 RGBA 合成都由有界 preparation owner
+/// 在后台完成。MainActor 只消费不可变像素并安装一个普通 `CALayer`；用户透明度统一落在
+/// `rootLayer.opacity`，活动 layer 不启用实时 shadow。
 public final class CoreAnimationDanmakuRenderer:
     DanmakuRenderingBackend
 {
-    private static let maximumTextWidthPixels: CGFloat = 8_192
-    private static let maximumTextHeightPixels: CGFloat = 512
-    private static let maximumTextUTF16Length = 512
-    private static let supportedFontSizes: Set<Double> = [18, 25, 36]
-    private static let lightInkRelativeLuminanceThreshold = 0.179
-
     private struct Entry {
-        let layer: CATextLayer
+        let layer: CALayer
         let placement: DanmakuLanePlacement
+        let textureByteCost: Int
         let objectIdentity: UInt64
         let relay: AnimationCompletionRelay
     }
+
+    static let maximumActiveTextureByteCost = 64 * 1_024 * 1_024
 
     public weak var delegate: (any DanmakuRenderingBackendDelegate)?
     public let rootLayer: CALayer
@@ -33,26 +30,39 @@ public final class CoreAnimationDanmakuRenderer:
     public private(set) var renderEpoch: UInt64 = 0
     public var activeLayerCount: Int { entries.count }
 
-    private let contentsScale: CGFloat
-    private let darkInkShadow: NSShadow
-    private let lightInkShadow: NSShadow
+    private var backingScale: Double
     private var entries: [String: Entry] = [:]
     private var nextObjectIdentity: UInt64 = 0
     private var surfaceSize = CGSize.zero
+    private let preparationOwner: DanmakuTexturePreparationOwner
+    private let activeTextureByteLimit: Int
+    private(set) var activeTextureByteCost = 0
 
-    public init(
+    public convenience init(
         style: CoreAnimationDanmakuStyle = .production,
         contentsScale: Double = 2
     ) {
-        self.style = style
-        self.contentsScale = max(CGFloat(contentsScale), 1)
-        darkInkShadow = Self.makeShadow(
-            color: .black,
-            blurRadius: style.shadowBlurRadius
+        self.init(
+            style: style,
+            contentsScale: contentsScale,
+            preparationConfiguration: .production,
+            activeTextureByteLimit: Self.maximumActiveTextureByteCost
         )
-        lightInkShadow = Self.makeShadow(
-            color: .white,
-            blurRadius: style.shadowBlurRadius
+    }
+
+    init(
+        style: CoreAnimationDanmakuStyle,
+        contentsScale: Double,
+        preparationConfiguration: DanmakuTexturePreparationOwner.Configuration,
+        activeTextureByteLimit: Int = CoreAnimationDanmakuRenderer
+            .maximumActiveTextureByteCost
+    ) {
+        precondition(activeTextureByteLimit > 0)
+        self.style = style
+        self.activeTextureByteLimit = activeTextureByteLimit
+        backingScale = Self.normalizedBackingScale(contentsScale)
+        preparationOwner = DanmakuTexturePreparationOwner(
+            configuration: preparationConfiguration
         )
         rootLayer = CALayer()
         rootLayer.anchorPoint = .zero
@@ -60,85 +70,112 @@ public final class CoreAnimationDanmakuRenderer:
         rootLayer.masksToBounds = true
     }
 
+    /// 同步接口只为旧 Lab backend 的协议兼容保留；生产 renderer 必须走 `prepare`。
     public func measure(_ event: DanmakuEvent) -> DanmakuTextMetrics {
-        guard !event.text.isEmpty,
-            event.text.utf16.count <= Self.maximumTextUTF16Length
-        else {
-            return DanmakuTextMetrics(width: 0, height: 0)
+        DanmakuTextMetrics(width: 0, height: 0)
+    }
+
+    /// 同步接口在生产 renderer 中 fail closed，防止恢复 MainActor 栅格化路径。
+    public func render(_ placement: DanmakuLanePlacement) {}
+
+    public func prepare(
+        _ event: DanmakuEvent,
+        preparationID: UInt64,
+        generation: UInt64,
+        backingScale: Double,
+        completion:
+            @escaping @MainActor @Sendable (
+                DanmakuPreparationResult
+            ) -> Void
+    ) {
+        let normalizedScale = Self.normalizedBackingScale(backingScale)
+        guard normalizedScale == self.backingScale else {
+            completion(.rejected(.cancelled))
+            return
         }
-        guard let attributed = attributedString(for: event) else {
-            return DanmakuTextMetrics(width: 0, height: 0)
-        }
-        let framesetter = CTFramesetterCreateWithAttributedString(attributed)
-        let measured = CTFramesetterSuggestFrameSizeWithConstraints(
-            framesetter,
-            CFRange(location: 0, length: attributed.length),
-            nil,
-            CGSize(
-                width: CGFloat.greatestFiniteMagnitude,
-                height: CGFloat.greatestFiniteMagnitude
-            ),
-            nil
-        )
-        let widthPixels = ceil(measured.width * contentsScale) + 8
-        let heightPixels = ceil(measured.height * contentsScale) + 8
-        guard widthPixels.isFinite,
-            heightPixels.isFinite,
-            widthPixels > 0,
-            heightPixels > 0,
-            widthPixels <= Self.maximumTextWidthPixels,
-            heightPixels <= Self.maximumTextHeightPixels
-        else {
-            return DanmakuTextMetrics(width: 0, height: 0)
-        }
-        return DanmakuTextMetrics(
-            width: Double(widthPixels / contentsScale),
-            height: Double(heightPixels / contentsScale)
+        preparationOwner.prepare(
+            event: event,
+            style: style,
+            backingScale: normalizedScale,
+            preparationID: preparationID,
+            generation: generation,
+            completion: completion
         )
     }
 
-    public func render(_ placement: DanmakuLanePlacement) {
+    @discardableResult
+    public func renderPrepared(
+        _ placement: DanmakuLanePlacement,
+        preparationID: UInt64,
+        generation: UInt64
+    ) -> Bool {
         let event = placement.request.event
         guard entries[event.id] == nil,
             entries.count
                 < DanmakuLaneConfiguration.hardMaximumActiveCount,
             surfaceSize.width > 0,
-            surfaceSize.height > 0
+            surfaceSize.height > 0,
+            let key = DanmakuTextureRasterizer.key(
+                event: event,
+                style: style,
+                backingScale: backingScale
+            ),
+            let payload = preparationOwner.consume(
+                preparationID: preparationID,
+                generation: generation,
+                expectedKey: key
+            )
         else {
-            return
+            preparationOwner.discard(preparationID: preparationID)
+            return false
+        }
+        let remainingTextureBytes = max(
+            activeTextureByteLimit - activeTextureByteCost,
+            0
+        )
+        guard payload.byteCost <= remainingTextureBytes,
+            let image = Self.makeImage(payload)
+        else {
+            return false
         }
 
         nextObjectIdentity &+= 1
         let objectIdentity = nextObjectIdentity
-        guard let textLayer = makeTextLayer(for: placement) else {
-            return
-        }
+        let layer = makeLayer(for: placement, image: image, scale: backingScale)
         let relay = AnimationCompletionRelay(
             renderer: self,
             eventID: event.id,
             objectIdentity: objectIdentity,
             renderEpoch: renderEpoch
         )
-        let animation = makeAnimation(
-            for: placement,
-            layer: textLayer
-        )
+        let animation = makeAnimation(for: placement, layer: layer)
         animation.delegate = relay
         entries[event.id] = Entry(
-            layer: textLayer,
+            layer: layer,
             placement: placement,
+            textureByteCost: payload.byteCost,
             objectIdentity: objectIdentity,
             relay: relay
         )
+        activeTextureByteCost += payload.byteCost
 
         CATransaction.begin()
         CATransaction.setDisableActions(true)
-        rootLayer.addSublayer(textLayer)
+        rootLayer.addSublayer(layer)
         if event.mode == .scrolling {
-            textLayer.position.x = -textLayer.bounds.width / 2
+            layer.position.x = -layer.bounds.width / 2
         }
-        textLayer.add(animation, forKey: "danmaku")
+        layer.add(animation, forKey: "danmaku")
         CATransaction.commit()
+        return true
+    }
+
+    public func discardPreparation(preparationID: UInt64) {
+        preparationOwner.discard(preparationID: preparationID)
+    }
+
+    public func cancelPendingPreparations() {
+        preparationOwner.cancelAllPreparations()
     }
 
     public func remove(eventID: String) {
@@ -147,6 +184,7 @@ public final class CoreAnimationDanmakuRenderer:
 
     public func clearAll() {
         advanceEpoch()
+        preparationOwner.cancelAllPreparations()
         removeAllEntries()
     }
 
@@ -173,6 +211,23 @@ public final class CoreAnimationDanmakuRenderer:
     }
 
     public func updateSurfaceSize(width: Double, height: Double) {
+        updateSurfaceSize(
+            width: width,
+            height: height,
+            backingScale: backingScale
+        )
+    }
+
+    public func updateSurfaceSize(
+        width: Double,
+        height: Double,
+        backingScale: Double
+    ) {
+        let normalizedScale = Self.normalizedBackingScale(backingScale)
+        if normalizedScale != self.backingScale {
+            self.backingScale = normalizedScale
+            preparationOwner.cancelAllPreparations()
+        }
         let oldSurfaceSize = surfaceSize
         surfaceSize = CGSize(
             width: max(width.isFinite ? width : 0, 0),
@@ -192,16 +247,35 @@ public final class CoreAnimationDanmakuRenderer:
 
     public func stop() {
         advanceEpoch()
+        preparationOwner.cancelAllPreparations()
         removeAllEntries()
         setPlaybackRate(0)
     }
 
-    func textLayer(forEventID eventID: String) -> CATextLayer? {
+    func textLayer(forEventID eventID: String) -> CALayer? {
         entries[eventID]?.layer
     }
 
     func objectIdentity(forEventID eventID: String) -> UInt64? {
         entries[eventID]?.objectIdentity
+    }
+
+    var outstandingPreparationCount: Int {
+        preparationOwner.outstandingRequestCount
+    }
+
+    var cachedTextureCount: Int { preparationOwner.cachedTextureCount }
+    var cachedTextureByteCost: Int { preparationOwner.cachedByteCost }
+    var cacheHitCount: Int { preparationOwner.cacheHitCount }
+    var cacheMissCount: Int { preparationOwner.cacheMissCount }
+    var cacheEvictionCount: Int { preparationOwner.cacheEvictionCount }
+    var rasterizationCount: Int { preparationOwner.rasterizationCount }
+    var maximumConcurrentPreparationCount: Int {
+        preparationOwner.maximumConcurrentOperationCount
+    }
+
+    func handleMemoryPressureForTesting() {
+        preparationOwner.handleMemoryPressureForTesting()
     }
 
     func completeAnimation(
@@ -219,109 +293,17 @@ public final class CoreAnimationDanmakuRenderer:
         delegate?.rendererDidFinish(eventID: eventID)
     }
 
-    private func attributedString(
-        for event: DanmakuEvent
-    ) -> NSAttributedString? {
-        guard let font = font(for: event) else { return nil }
-        let components = rgbComponents(for: event.colorRGB)
-        var attributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: NSColor(
-                srgbRed: components.red,
-                green: components.green,
-                blue: components.blue,
-                alpha: 1
-            ),
-        ]
-        attributes[.shadow] = adaptiveShadow(for: components)
-        return NSAttributedString(
-            string: event.text,
-            attributes: attributes
-        )
-    }
-
-    private func font(for event: DanmakuEvent) -> NSFont? {
-        guard event.fontSize.isFinite else {
-            return nil
-        }
-        let normalizedFontSize =
-            Self.supportedFontSizes.contains(event.fontSize)
-            ? event.fontSize : 25
-        return NSFont.systemFont(
-            ofSize: CGFloat(normalizedFontSize * style.fontScale),
-            weight: fontWeight
-        )
-    }
-
-    private var fontWeight: NSFont.Weight {
-        switch style.fontWeight {
-        case .regular: .regular
-        case .medium: .medium
-        case .semibold: .semibold
-        case .bold: .bold
-        }
-    }
-
-    private static func makeShadow(
-        color: NSColor,
-        blurRadius: Double
-    ) -> NSShadow {
-        let shadow = NSShadow()
-        shadow.shadowColor = color
-        shadow.shadowOffset = .zero
-        shadow.shadowBlurRadius = CGFloat(blurRadius)
-        return shadow
-    }
-
-    private func rgbComponents(
-        for colorRGB: UInt32
-    ) -> (red: CGFloat, green: CGFloat, blue: CGFloat) {
-        let baseRGB = colorRGB & 0x00FF_FFFF
-        return (
-            red: CGFloat((baseRGB >> 16) & 0xFF) / 255,
-            green: CGFloat((baseRGB >> 8) & 0xFF) / 255,
-            blue: CGFloat(baseRGB & 0xFF) / 255
-        )
-    }
-
-    private func adaptiveShadow(
-        for components: (red: CGFloat, green: CGFloat, blue: CGFloat)
-    ) -> NSShadow {
-        Double(relativeLuminance(for: components))
-            < Self.lightInkRelativeLuminanceThreshold
-            ? lightInkShadow
-            : darkInkShadow
-    }
-
-    private func relativeLuminance(
-        for components: (red: CGFloat, green: CGFloat, blue: CGFloat)
-    ) -> CGFloat {
-        0.2126 * linearized(components.red)
-            + 0.7152 * linearized(components.green)
-            + 0.0722 * linearized(components.blue)
-    }
-
-    private func linearized(_ component: CGFloat) -> CGFloat {
-        component <= 0.04045
-            ? component / 12.92
-            : pow((component + 0.055) / 1.055, 2.4)
-    }
-
-    private func makeTextLayer(
-        for placement: DanmakuLanePlacement
-    ) -> CATextLayer? {
-        let layer = CATextLayer()
-        guard
-            let attributed = attributedString(
-                for: placement.request.event
-            )
-        else {
-            return nil
-        }
-        layer.string = attributed
-        layer.alignmentMode = .left
-        layer.isWrapped = false
-        layer.contentsScale = contentsScale
+    private func makeLayer(
+        for placement: DanmakuLanePlacement,
+        image: CGImage,
+        scale: Double
+    ) -> CALayer {
+        let layer = CALayer()
+        layer.contents = image
+        layer.contentsScale = CGFloat(scale)
+        layer.contentsGravity = .resize
+        layer.magnificationFilter = .linear
+        layer.minificationFilter = .linear
         layer.bounds = CGRect(
             x: 0,
             y: 0,
@@ -341,7 +323,7 @@ public final class CoreAnimationDanmakuRenderer:
 
     private func makeAnimation(
         for placement: DanmakuLanePlacement,
-        layer: CATextLayer
+        layer: CALayer
     ) -> CABasicAnimation {
         let animation: CABasicAnimation
         switch placement.request.event.mode {
@@ -381,6 +363,7 @@ public final class CoreAnimationDanmakuRenderer:
     private func removeAllEntries() {
         let oldEntries = entries
         entries.removeAll(keepingCapacity: false)
+        activeTextureByteCost = 0
         for entry in oldEntries.values {
             entry.layer.removeAllAnimations()
             entry.layer.removeFromSuperlayer()
@@ -391,7 +374,42 @@ public final class CoreAnimationDanmakuRenderer:
         guard let entry = entries.removeValue(forKey: eventID) else {
             return
         }
+        activeTextureByteCost -= entry.textureByteCost
         entry.layer.removeAllAnimations()
         entry.layer.removeFromSuperlayer()
+    }
+
+    private static func normalizedBackingScale(_ scale: Double) -> Double {
+        scale.isFinite
+            ? min(max(scale, 1), DanmakuTextureRasterizer.maximumBackingScale)
+            : 2
+    }
+
+    private static func makeImage(
+        _ payload: DanmakuTexturePayload
+    ) -> CGImage? {
+        guard let provider = CGDataProvider(data: payload.pixels as CFData)
+        else {
+            return nil
+        }
+        let colorSpace =
+            CGColorSpace(name: CGColorSpace.sRGB)
+            ?? CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(
+            rawValue: CGImageAlphaInfo.premultipliedLast.rawValue
+        ).union(.byteOrder32Big)
+        return CGImage(
+            width: payload.widthPixels,
+            height: payload.heightPixels,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: payload.bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo,
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: true,
+            intent: .defaultIntent
+        )
     }
 }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuStyle.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/CoreAnimationDanmakuStyle.swift
@@ -15,8 +15,9 @@ public enum CoreAnimationDanmakuFontWeight:
 
 /// Core Animation renderer 的有界视觉输入。
 ///
-/// 该类型只描述产品需要稳定复用的文本视觉语义，不暴露 `CATextLayer`、Core Text attribute
-/// 或动画实现细节。App 始终使用 `production`；开发工具可以为单轮 renderer 提供不同值。
+/// 该类型只描述产品需要稳定复用的文本视觉语义，不暴露 Core Text 或动画实现细节。
+/// `shadowBlurRadius` 是预烘焙 tent convolution 的 point 半径，不是旧 `NSShadow` 的数学
+/// 等价值。App 始终使用 `production`；开发工具可以为单轮 renderer 提供不同值。
 public struct CoreAnimationDanmakuStyle: Sendable, Equatable {
     public static let fontScaleRange = 0.5...1.5
     public static let shadowBlurRadiusRange = 0.0...4.0
@@ -29,7 +30,7 @@ public struct CoreAnimationDanmakuStyle: Sendable, Equatable {
     public init(
         fontScale: Double = 1,
         fontWeight: CoreAnimationDanmakuFontWeight = .semibold,
-        shadowBlurRadius: Double = 2
+        shadowBlurRadius: Double = 1
     ) {
         self.fontScale = Self.normalized(
             fontScale,
@@ -39,7 +40,7 @@ public struct CoreAnimationDanmakuStyle: Sendable, Equatable {
         self.fontWeight = fontWeight
         self.shadowBlurRadius = Self.normalized(
             shadowBlurRadius,
-            fallback: 2,
+            fallback: 1,
             range: Self.shadowBlurRadiusRange
         )
     }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneModels.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuLaneModels.swift
@@ -12,7 +12,7 @@ public struct DanmakuLaneConfiguration: Sendable, Equatable {
             surfaceWidth: surfaceWidth,
             surfaceHeight: surfaceHeight,
             laneHeight: 36,
-            minimumHorizontalGap: 40,
+            minimumHorizontalGap: 64,
             maximumActiveCount: hardMaximumActiveCount,
             displayAreaFraction: 1
         )

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuPresentationController.swift
@@ -9,10 +9,10 @@ struct DanmakuDensityAdmissionPolicy: Sendable, Equatable {
     init(_ density: DanmakuDensity) {
         switch density {
         case .normal:
-            minimumHorizontalGap = 40
+            minimumHorizontalGap = 64
             maximumOverlapDepth = 1
         case .increased:
-            minimumHorizontalGap = 20
+            minimumHorizontalGap = 32
             maximumOverlapDepth = 1
         case .overlapping:
             minimumHorizontalGap = 0
@@ -40,6 +40,19 @@ public struct DanmakuRendererStatistics: Sendable, Equatable {
         droppedCapacity += max(count, 0)
     }
 
+    mutating func recordPreparationDrop(
+        _ reason: DanmakuPreparationRejectionReason
+    ) {
+        switch reason {
+        case .capacity:
+            droppedCapacity += 1
+        case .invalidInput, .oversized:
+            droppedNoLane += 1
+        case .cancelled:
+            break
+        }
+    }
+
     mutating func updateActive(_ count: Int) {
         active = count
         peakActive = max(peakActive, count)
@@ -55,6 +68,14 @@ public final class DanmakuPresentationController:
     DanmakuPresentationSink,
     DanmakuRenderingBackendDelegate
 {
+    private struct PendingPreparation {
+        let event: DanmakuEvent
+        let speedLevel: DanmakuSpeedLevel
+        let identity: PlaybackItemIdentity
+        let discontinuityGeneration: UInt64
+        let preparationGeneration: UInt64
+    }
+
     public private(set) var statistics = DanmakuRendererStatistics()
 
     private let backend: any DanmakuRenderingBackend
@@ -67,6 +88,13 @@ public final class DanmakuPresentationController:
     private var identity: PlaybackItemIdentity?
     private var discontinuityGeneration: UInt64?
     private var surfaceOwnerID: UUID?
+    private var backingScale = 2.0
+    private var preparationGeneration: UInt64 = 0
+    private var nextPreparationID: UInt64 = 0
+    private var pendingPreparations: [UInt64: PendingPreparation] = [:]
+    private var pendingOrder: [UInt64] = []
+    private var completedPreparations: [UInt64: DanmakuPreparationResult] = [:]
+    private var latestSnapshot: PlaybackTimelineSnapshot?
 
     public init(
         backend: any DanmakuRenderingBackend,
@@ -80,7 +108,8 @@ public final class DanmakuPresentationController:
         backend.delegate = self
         backend.updateSurfaceSize(
             width: configuration.surfaceWidth,
-            height: configuration.surfaceHeight
+            height: configuration.surfaceHeight,
+            backingScale: backingScale
         )
     }
 
@@ -123,6 +152,7 @@ public final class DanmakuPresentationController:
         identity = updateIdentity
         discontinuityGeneration =
             update.snapshot.discontinuityGeneration
+        latestSnapshot = update.snapshot
 
         let effectiveRate =
             update.snapshot.state == .playing
@@ -136,38 +166,23 @@ public final class DanmakuPresentationController:
             return
         }
 
-        let attemptedEvents = batch.events.prefix(
+        let availablePreparationSlots = max(
             DanmakuLaneConfiguration.hardMaximumActiveCount
+                - pendingPreparations.count,
+            0
         )
-        let requests = attemptedEvents.map { event in
-            let metrics = backend.measure(event)
-            return DanmakuLaneRequest(
-                event: event,
-                width: metrics.width,
-                height: metrics.height,
-                durationSeconds: motionPolicy.duration(
-                    for: event.mode,
-                    textWidth: metrics.width,
-                    surfaceWidth: configuration.surfaceWidth,
-                    speedLevel: speedLevel
-                )
-            )
-        }
+        let attemptedEvents = batch.events.prefix(availablePreparationSlots)
         statistics.recordCapacityDrops(
             batch.events.count - attemptedEvents.count
         )
-        let admission = allocator.admit(
-            requests,
-            at: update.snapshot.positionSeconds
-        )
-        for placement in admission.expired {
-            backend.remove(eventID: placement.request.event.id)
+        for event in attemptedEvents {
+            enqueuePreparation(
+                event,
+                identity: updateIdentity,
+                discontinuityGeneration:
+                    update.snapshot.discontinuityGeneration
+            )
         }
-        for placement in admission.admitted {
-            backend.render(placement)
-        }
-        statistics.record(admission)
-        statistics.updateActive(allocator.activeCount)
     }
 
     public func clearPresentation() {
@@ -193,17 +208,25 @@ public final class DanmakuPresentationController:
     }
 
     public func stopPresentation() {
+        cancelPendingPreparations()
         _ = allocator.clear()
         backend.stop()
         identity = nil
         discontinuityGeneration = nil
+        latestSnapshot = nil
         statistics.updateActive(0)
     }
 
     private func updateSurfaceSize(
         width: Double,
-        height: Double
+        height: Double,
+        backingScale: Double
     ) {
+        let normalizedScale = Self.normalizedBackingScale(backingScale)
+        if normalizedScale != self.backingScale {
+            self.backingScale = normalizedScale
+            cancelPendingPreparations()
+        }
         configuration = DanmakuLaneConfiguration(
             surfaceWidth: width,
             surfaceHeight: height,
@@ -216,7 +239,8 @@ public final class DanmakuPresentationController:
         allocator.updateConfiguration(configuration)
         backend.updateSurfaceSize(
             width: width,
-            height: height
+            height: height,
+            backingScale: normalizedScale
         )
     }
 
@@ -240,10 +264,15 @@ public final class DanmakuPresentationController:
     public func updateSurface(
         width: Double,
         height: Double,
+        backingScale: Double = 2,
         ownerID: UUID
     ) -> Bool {
         guard surfaceOwnerID == ownerID else { return false }
-        updateSurfaceSize(width: width, height: height)
+        updateSurfaceSize(
+            width: width,
+            height: height,
+            backingScale: backingScale
+        )
         return true
     }
 
@@ -253,9 +282,163 @@ public final class DanmakuPresentationController:
     }
 
     private func clearBackendAndAllocator() {
+        cancelPendingPreparations()
         _ = allocator.clear()
         backend.clearAll()
         statistics.updateActive(0)
+    }
+
+    private func enqueuePreparation(
+        _ event: DanmakuEvent,
+        identity: PlaybackItemIdentity,
+        discontinuityGeneration: UInt64
+    ) {
+        nextPreparationID &+= 1
+        let preparationID = nextPreparationID
+        let generation = preparationGeneration
+        pendingPreparations[preparationID] = PendingPreparation(
+            event: event,
+            speedLevel: speedLevel,
+            identity: identity,
+            discontinuityGeneration: discontinuityGeneration,
+            preparationGeneration: generation
+        )
+        pendingOrder.append(preparationID)
+        backend.prepare(
+            event,
+            preparationID: preparationID,
+            generation: generation,
+            backingScale: backingScale
+        ) { [weak self] result in
+            self?.completePreparation(
+                preparationID: preparationID,
+                generation: generation,
+                result: result
+            )
+        }
+    }
+
+    private func completePreparation(
+        preparationID: UInt64,
+        generation: UInt64,
+        result: DanmakuPreparationResult
+    ) {
+        guard generation == preparationGeneration,
+            pendingPreparations[preparationID]?.preparationGeneration
+                == generation
+        else {
+            backend.discardPreparation(preparationID: preparationID)
+            return
+        }
+        completedPreparations[preparationID] = result
+        drainCompletedPreparations()
+    }
+
+    private func drainCompletedPreparations() {
+        while let preparationID = pendingOrder.first,
+            let result = completedPreparations.removeValue(
+                forKey: preparationID
+            )
+        {
+            pendingOrder.removeFirst()
+            guard
+                let pending = pendingPreparations.removeValue(
+                    forKey: preparationID
+                )
+            else {
+                backend.discardPreparation(preparationID: preparationID)
+                continue
+            }
+            processPreparation(
+                result,
+                preparationID: preparationID,
+                pending: pending
+            )
+        }
+    }
+
+    private func processPreparation(
+        _ result: DanmakuPreparationResult,
+        preparationID: UInt64,
+        pending: PendingPreparation
+    ) {
+        guard pending.preparationGeneration == preparationGeneration,
+            identity == pending.identity,
+            discontinuityGeneration == pending.discontinuityGeneration,
+            let snapshot = latestSnapshot,
+            snapshot.identity == pending.identity,
+            snapshot.discontinuityGeneration
+                == pending.discontinuityGeneration
+        else {
+            backend.discardPreparation(preparationID: preparationID)
+            return
+        }
+        guard case .ready(let metrics) = result else {
+            if case .rejected(let reason) = result {
+                statistics.recordPreparationDrop(reason)
+            }
+            backend.discardPreparation(preparationID: preparationID)
+            return
+        }
+
+        let request = DanmakuLaneRequest(
+            event: pending.event,
+            width: metrics.width,
+            height: metrics.height,
+            durationSeconds: motionPolicy.duration(
+                for: pending.event.mode,
+                textWidth: metrics.width,
+                surfaceWidth: configuration.surfaceWidth,
+                speedLevel: pending.speedLevel
+            )
+        )
+        let admission = allocator.admit(
+            [request],
+            at: snapshot.positionSeconds
+        )
+        for expired in admission.expired {
+            backend.remove(eventID: expired.request.event.id)
+        }
+        var installed: [DanmakuLanePlacement] = []
+        for placement in admission.admitted {
+            if backend.renderPrepared(
+                placement,
+                preparationID: preparationID,
+                generation: preparationGeneration
+            ) {
+                installed.append(placement)
+            } else {
+                allocator.remove(eventID: placement.request.event.id)
+            }
+        }
+        if installed.isEmpty {
+            backend.discardPreparation(preparationID: preparationID)
+        }
+        statistics.recordCapacityDrops(
+            admission.admitted.count - installed.count
+        )
+        statistics.record(
+            DanmakuLaneAdmission(
+                expired: admission.expired,
+                admitted: installed,
+                dropCounts: admission.dropCounts
+            )
+        )
+        statistics.updateActive(allocator.activeCount)
+    }
+
+    private func cancelPendingPreparations() {
+        preparationGeneration &+= 1
+        pendingPreparations.removeAll(keepingCapacity: false)
+        pendingOrder.removeAll(keepingCapacity: false)
+        completedPreparations.removeAll(keepingCapacity: false)
+        backend.cancelPendingPreparations()
+    }
+
+    private static func normalizedBackingScale(_ scale: Double) -> Double {
+        scale.isFinite
+            ? min(max(scale, 1), DanmakuTextureRasterizer.maximumBackingScale)
+            : 2
     }
 
     private func updateAdmissionPolicy() {

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuRenderingBackend.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuRenderingBackend.swift
@@ -12,6 +12,18 @@ public struct DanmakuTextMetrics: Sendable, Equatable {
     }
 }
 
+public enum DanmakuPreparationRejectionReason: Sendable, Equatable {
+    case capacity
+    case invalidInput
+    case oversized
+    case cancelled
+}
+
+public enum DanmakuPreparationResult: Sendable, Equatable {
+    case ready(DanmakuTextMetrics)
+    case rejected(DanmakuPreparationRejectionReason)
+}
+
 public struct DanmakuRendererDurations: Sendable, Equatable {
     public let scrollingSeconds: Double
     public let fixedSeconds: Double
@@ -153,4 +165,74 @@ public protocol DanmakuRenderingBackend: AnyObject {
     func setOpacity(_ opacity: DanmakuOpacity)
     func updateSurfaceSize(width: Double, height: Double)
     func stop()
+
+    /// 准备完成回调必须返回 MainActor；controller 只会在 `.ready` 后执行 lane 准入。
+    func prepare(
+        _ event: DanmakuEvent,
+        preparationID: UInt64,
+        generation: UInt64,
+        backingScale: Double,
+        completion:
+            @escaping @MainActor @Sendable (
+                DanmakuPreparationResult
+            ) -> Void
+    )
+
+    @discardableResult
+    func renderPrepared(
+        _ placement: DanmakuLanePlacement,
+        preparationID: UInt64,
+        generation: UInt64
+    ) -> Bool
+    func discardPreparation(preparationID: UInt64)
+    func cancelPendingPreparations()
+    func updateSurfaceSize(
+        width: Double,
+        height: Double,
+        backingScale: Double
+    )
+}
+
+extension DanmakuRenderingBackend {
+    /// 旧 Lab/test backend 的同步兼容桥。
+    ///
+    /// 生产 renderer 覆盖此方法并在后台准备纹理。
+    public func prepare(
+        _ event: DanmakuEvent,
+        preparationID: UInt64,
+        generation: UInt64,
+        backingScale: Double,
+        completion:
+            @escaping @MainActor @Sendable (
+                DanmakuPreparationResult
+            ) -> Void
+    ) {
+        let metrics = measure(event)
+        completion(
+            metrics.width > 0 && metrics.height > 0
+                ? .ready(metrics) : .rejected(.invalidInput)
+        )
+    }
+
+    @discardableResult
+    public func renderPrepared(
+        _ placement: DanmakuLanePlacement,
+        preparationID: UInt64,
+        generation: UInt64
+    ) -> Bool {
+        render(placement)
+        return true
+    }
+
+    public func discardPreparation(preparationID: UInt64) {}
+
+    public func cancelPendingPreparations() {}
+
+    public func updateSurfaceSize(
+        width: Double,
+        height: Double,
+        backingScale: Double
+    ) {
+        updateSurfaceSize(width: width, height: height)
+    }
 }

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuTextureCache.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuTextureCache.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+final class DanmakuTextureLRUCache {
+    struct Limits: Sendable, Equatable {
+        // One item matches the rasterizer's 8 MiB bound. The 32 MiB total holds at
+        // least four maximum accepted items while remaining small
+        // compared with the 640-layer presentation ceiling.
+        static let production = Limits(
+            maximumItemCost: DanmakuTextureRasterizer.maximumTextureByteCost,
+            maximumTotalCost: 32 * 1_024 * 1_024
+        )
+
+        let maximumItemCost: Int
+        let maximumTotalCost: Int
+    }
+
+    private final class Node {
+        let key: DanmakuTextureCacheKey
+        let payload: DanmakuTexturePayload
+        weak var previous: Node?
+        var next: Node?
+
+        init(
+            key: DanmakuTextureCacheKey,
+            payload: DanmakuTexturePayload
+        ) {
+            self.key = key
+            self.payload = payload
+        }
+    }
+
+    let limits: Limits
+    private(set) var totalCost = 0
+    private(set) var hitCount = 0
+    private(set) var missCount = 0
+    private(set) var evictionCount = 0
+    private var entries: [DanmakuTextureCacheKey: Node] = [:]
+    private var mostRecentlyUsed: Node?
+    private var leastRecentlyUsed: Node?
+
+    init(limits: Limits = .production) {
+        precondition(limits.maximumItemCost > 0)
+        precondition(limits.maximumTotalCost >= limits.maximumItemCost)
+        self.limits = limits
+    }
+
+    var count: Int { entries.count }
+
+    func value(
+        for key: DanmakuTextureCacheKey
+    ) -> DanmakuTexturePayload? {
+        guard let node = entries[key] else {
+            missCount += 1
+            return nil
+        }
+        moveToFront(node)
+        hitCount += 1
+        return node.payload
+    }
+
+    @discardableResult
+    func insert(
+        _ payload: DanmakuTexturePayload,
+        for key: DanmakuTextureCacheKey
+    ) -> Bool {
+        guard payload.byteCost <= limits.maximumItemCost else { return false }
+        if let existing = entries[key] {
+            remove(existing)
+        }
+        while totalCost + payload.byteCost > limits.maximumTotalCost,
+            let oldest = leastRecentlyUsed
+        {
+            remove(oldest)
+            evictionCount += 1
+        }
+        guard totalCost + payload.byteCost <= limits.maximumTotalCost else {
+            return false
+        }
+        let node = Node(key: key, payload: payload)
+        entries[key] = node
+        insertAtFront(node)
+        totalCost += payload.byteCost
+        return true
+    }
+
+    func removeAll() {
+        entries.removeAll(keepingCapacity: false)
+        mostRecentlyUsed = nil
+        leastRecentlyUsed = nil
+        totalCost = 0
+    }
+
+    private func moveToFront(_ node: Node) {
+        guard mostRecentlyUsed !== node else { return }
+        unlink(node)
+        insertAtFront(node)
+    }
+
+    private func remove(_ node: Node) {
+        unlink(node)
+        entries[node.key] = nil
+        totalCost -= node.payload.byteCost
+    }
+
+    private func unlink(_ node: Node) {
+        let previous = node.previous
+        let next = node.next
+        previous?.next = next
+        next?.previous = previous
+        if mostRecentlyUsed === node {
+            mostRecentlyUsed = next
+        }
+        if leastRecentlyUsed === node {
+            leastRecentlyUsed = previous
+        }
+        node.previous = nil
+        node.next = nil
+    }
+
+    private func insertAtFront(_ node: Node) {
+        node.previous = nil
+        node.next = mostRecentlyUsed
+        mostRecentlyUsed?.previous = node
+        mostRecentlyUsed = node
+        if leastRecentlyUsed == nil {
+            leastRecentlyUsed = node
+        }
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuTexturePreparationOwner.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuTexturePreparationOwner.swift
@@ -1,0 +1,245 @@
+import BiliModels
+import Foundation
+
+@MainActor
+final class DanmakuTexturePreparationOwner {
+    typealias Rasterize =
+        @Sendable (DanmakuTextureCacheKey) -> DanmakuTexturePayload?
+
+    struct Configuration: Sendable, Equatable {
+        static let production = Configuration(
+            maximumConcurrentOperations: 2,
+            maximumOutstandingRequests:
+                DanmakuLaneConfiguration.hardMaximumActiveCount,
+            cacheLimits: .production
+        )
+
+        let maximumConcurrentOperations: Int
+        let maximumOutstandingRequests: Int
+        let cacheLimits: DanmakuTextureLRUCache.Limits
+    }
+
+    typealias Completion =
+        @MainActor @Sendable (
+            DanmakuPreparationResult
+        ) -> Void
+
+    private struct Request {
+        let generation: UInt64
+        let key: DanmakuTextureCacheKey
+        let completion: Completion
+    }
+
+    private struct Prepared {
+        let generation: UInt64
+        let key: DanmakuTextureCacheKey
+    }
+
+    private struct Inflight {
+        let operation: Operation
+        var requestIDs: [UInt64]
+    }
+
+    private(set) var rasterizationCount = 0
+    private var cache: DanmakuTextureLRUCache
+    private var requests: [UInt64: Request] = [:]
+    private var prepared: [UInt64: Prepared] = [:]
+    private var inflight: [DanmakuTextureCacheKey: Inflight] = [:]
+    private let configuration: Configuration
+    private let queue: OperationQueue
+    private let rasterize: Rasterize
+    private var memoryPressureSource: DispatchSourceMemoryPressure?
+
+    init(
+        configuration: Configuration = .production,
+        rasterize: @escaping Rasterize = {
+            DanmakuTextureRasterizer.rasterize(key: $0)
+        }
+    ) {
+        precondition(configuration.maximumConcurrentOperations > 0)
+        precondition(configuration.maximumOutstandingRequests > 0)
+        self.configuration = configuration
+        self.rasterize = rasterize
+        cache = DanmakuTextureLRUCache(limits: configuration.cacheLimits)
+        queue = OperationQueue()
+        queue.name = "com.shirokyan.BiliKit.danmaku-texture-preparation"
+        queue.qualityOfService = .userInitiated
+        queue.maxConcurrentOperationCount =
+            configuration.maximumConcurrentOperations
+        installMemoryPressureSource()
+    }
+
+    deinit {
+        memoryPressureSource?.setEventHandler {}
+        memoryPressureSource?.cancel()
+        queue.cancelAllOperations()
+    }
+
+    var outstandingRequestCount: Int { requests.count + prepared.count }
+    var cachedTextureCount: Int { cache.count }
+    var cachedByteCost: Int { cache.totalCost }
+    var cacheHitCount: Int { cache.hitCount }
+    var cacheMissCount: Int { cache.missCount }
+    var cacheEvictionCount: Int { cache.evictionCount }
+    var maximumConcurrentOperationCount: Int {
+        queue.maxConcurrentOperationCount
+    }
+
+    func prepare(
+        event: DanmakuEvent,
+        style: CoreAnimationDanmakuStyle,
+        backingScale: Double,
+        preparationID: UInt64,
+        generation: UInt64,
+        completion: @escaping Completion
+    ) {
+        guard requests[preparationID] == nil,
+            prepared[preparationID] == nil,
+            outstandingRequestCount
+                < configuration.maximumOutstandingRequests
+        else {
+            completion(.rejected(.capacity))
+            return
+        }
+        guard
+            let key = DanmakuTextureRasterizer.key(
+                event: event,
+                style: style,
+                backingScale: backingScale
+            )
+        else {
+            completion(.rejected(.invalidInput))
+            return
+        }
+        if let payload = cache.value(for: key) {
+            prepared[preparationID] = Prepared(
+                generation: generation,
+                key: key
+            )
+            completion(.ready(payload.metrics))
+            return
+        }
+
+        requests[preparationID] = Request(
+            generation: generation,
+            key: key,
+            completion: completion
+        )
+        if var existing = inflight[key] {
+            existing.requestIDs.append(preparationID)
+            inflight[key] = existing
+            return
+        }
+
+        let rasterize = rasterize
+        let operation = BlockOperation()
+        operation.addExecutionBlock { [weak operation] in
+            guard operation?.isCancelled == false else { return }
+            let payload = rasterize(key)
+            guard operation?.isCancelled == false else { return }
+            let handoff = DispatchSemaphore(value: 0)
+            Task { @MainActor [weak self] in
+                defer { handoff.signal() }
+                self?.finish(key: key, payload: payload)
+            }
+            // Keep this OperationQueue slot occupied until MainActor either accepts
+            // or discards the pixels. Otherwise queued Tasks can retain one full
+            // payload per request while the main thread is busy. MainActor teardown
+            // must remain cancellation-only and never wait for this queue.
+            handoff.wait()
+        }
+        inflight[key] = Inflight(
+            operation: operation,
+            requestIDs: [preparationID]
+        )
+        rasterizationCount += 1
+        queue.addOperation(operation)
+    }
+
+    func consume(
+        preparationID: UInt64,
+        generation: UInt64,
+        expectedKey: DanmakuTextureCacheKey
+    ) -> DanmakuTexturePayload? {
+        guard let value = prepared.removeValue(forKey: preparationID),
+            value.generation == generation,
+            value.key == expectedKey
+        else {
+            return nil
+        }
+        return cache.value(for: expectedKey)
+    }
+
+    func discard(preparationID: UInt64) {
+        requests.removeValue(forKey: preparationID)
+        prepared.removeValue(forKey: preparationID)
+    }
+
+    func cancelAllPreparations() {
+        requests.removeAll(keepingCapacity: false)
+        prepared.removeAll(keepingCapacity: false)
+        let operations = inflight.values.map(\.operation)
+        inflight.removeAll(keepingCapacity: false)
+        for operation in operations {
+            operation.cancel()
+        }
+    }
+
+    func handleMemoryPressureForTesting() {
+        handleMemoryPressure()
+    }
+
+    private func finish(
+        key: DanmakuTextureCacheKey,
+        payload: DanmakuTexturePayload?
+    ) {
+        guard let work = inflight.removeValue(forKey: key) else { return }
+        let acceptedPayload = payload.flatMap { value in
+            cache.insert(value, for: key) ? value : nil
+        }
+        for preparationID in work.requestIDs {
+            guard let request = requests.removeValue(forKey: preparationID)
+            else {
+                continue
+            }
+            guard let acceptedPayload else {
+                request.completion(.rejected(.oversized))
+                continue
+            }
+            prepared[preparationID] = Prepared(
+                generation: request.generation,
+                key: request.key
+            )
+            request.completion(.ready(acceptedPayload.metrics))
+        }
+    }
+
+    private func installMemoryPressureSource() {
+        let source = DispatchSource.makeMemoryPressureSource(
+            eventMask: [.warning, .critical],
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in
+            MainActor.assumeIsolated {
+                self?.handleMemoryPressure()
+            }
+        }
+        source.resume()
+        memoryPressureSource = source
+    }
+
+    private func handleMemoryPressure() {
+        let completions = requests.values.map(\.completion)
+        requests.removeAll(keepingCapacity: false)
+        prepared.removeAll(keepingCapacity: false)
+        let operations = inflight.values.map(\.operation)
+        inflight.removeAll(keepingCapacity: false)
+        cache.removeAll()
+        for operation in operations {
+            operation.cancel()
+        }
+        for completion in completions {
+            completion(.rejected(.capacity))
+        }
+    }
+}

--- a/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuTextureRasterizer.swift
+++ b/Packages/BiliKitCore/Sources/BiliDanmaku/Rendering/DanmakuTextureRasterizer.swift
@@ -1,0 +1,403 @@
+import Accelerate
+import AppKit
+import BiliModels
+import CoreText
+import Foundation
+
+struct DanmakuTextureCacheKey: Hashable, Sendable {
+    static let algorithmVersion = 1
+
+    let text: String
+    let fontSize: Double
+    let colorRGB: UInt32
+    let fontDescriptor: String
+    let fontWeight: CoreAnimationDanmakuFontWeight
+    let fontScale: Double
+    let backingScale: Double
+    let outlineWidthPoints: Double
+    let shadowRadiusPoints: Double
+    let algorithmVersion: Int
+}
+
+struct DanmakuTexturePayload: Sendable, Equatable {
+    let pixels: Data
+    let widthPixels: Int
+    let heightPixels: Int
+    let bytesPerRow: Int
+    let backingScale: Double
+
+    var byteCost: Int { bytesPerRow * heightPixels }
+
+    var metrics: DanmakuTextMetrics {
+        DanmakuTextMetrics(
+            width: Double(widthPixels) / backingScale,
+            height: Double(heightPixels) / backingScale
+        )
+    }
+}
+
+enum DanmakuTextureRasterizer {
+    // Core Text keeps color-glyph RGBA in the fill. Outline/shadow polarity is intentionally
+    // selected once from the event's declared RGB for the complete union mask; per-glyph adaptive
+    // decoration is not attempted, so mixed emoji/text never gets flattened to one fill color.
+    static let maximumTextUTF16Length = 512
+    static let maximumWidthPixels = 8_192
+    static let maximumHeightPixels = 512
+    static let maximumTextureByteCost = 8 * 1_024 * 1_024
+    static let maximumBackingScale = 4.0
+    static let outlineWidthPoints = 0.5
+    static let lightInkRelativeLuminanceThreshold = 0.179
+
+    static func key(
+        event: DanmakuEvent,
+        style: CoreAnimationDanmakuStyle,
+        backingScale: Double
+    ) -> DanmakuTextureCacheKey? {
+        guard !event.text.isEmpty,
+            event.text.utf16.count <= maximumTextUTF16Length,
+            event.fontSize.isFinite,
+            backingScale.isFinite,
+            backingScale >= 1,
+            backingScale <= maximumBackingScale
+        else {
+            return nil
+        }
+        let fontSize =
+            [18.0, 25.0, 36.0].contains(event.fontSize)
+            ? event.fontSize : 25
+        return DanmakuTextureCacheKey(
+            text: event.text,
+            fontSize: fontSize,
+            colorRGB: event.colorRGB & 0x00FF_FFFF,
+            fontDescriptor: "system-\(style.fontWeight.rawValue)",
+            fontWeight: style.fontWeight,
+            fontScale: style.fontScale,
+            backingScale: backingScale,
+            outlineWidthPoints: outlineWidthPoints,
+            shadowRadiusPoints: style.shadowBlurRadius,
+            algorithmVersion: DanmakuTextureCacheKey.algorithmVersion
+        )
+    }
+
+    static func rasterize(
+        key: DanmakuTextureCacheKey
+    ) -> DanmakuTexturePayload? {
+        let scale = CGFloat(key.backingScale)
+        let colorSpace =
+            CGColorSpace(name: CGColorSpace.sRGB)
+            ?? CGColorSpaceCreateDeviceRGB()
+        let font = NSFont.systemFont(
+            ofSize: CGFloat(key.fontSize * key.fontScale),
+            weight: fontWeight(key.fontWeight)
+        )
+        let components = rgbComponents(key.colorRGB)
+        let foreground = CGColor(
+            srgbRed: components.red,
+            green: components.green,
+            blue: components.blue,
+            alpha: 1
+        )
+        let attributed = NSAttributedString(
+            string: key.text,
+            attributes: [
+                NSAttributedString.Key(kCTFontAttributeName as String): font,
+                NSAttributedString.Key(kCTForegroundColorAttributeName as String):
+                    foreground,
+            ]
+        )
+        let line = CTLineCreateWithAttributedString(attributed)
+        var ascent: CGFloat = 0
+        var descent: CGFloat = 0
+        var leading: CGFloat = 0
+        let width = CGFloat(
+            CTLineGetTypographicBounds(line, &ascent, &descent, &leading)
+        )
+        let height = ascent + descent + leading
+        guard width.isFinite, height.isFinite, width > 0, height > 0 else {
+            return nil
+        }
+
+        let outlineRadiusPixels = key.outlineWidthPoints * key.backingScale
+        let shadowRadiusPixels =
+            key.shadowRadiusPoints > 0
+            ? max(
+                1,
+                Int((key.shadowRadiusPoints * key.backingScale).rounded())
+            ) : 0
+        let paddingPixels = max(
+            4,
+            Int(ceil(outlineRadiusPixels)) + shadowRadiusPixels + 2
+        )
+        let widthPixels = Int(ceil(width * scale)) + paddingPixels * 2
+        let heightPixels = Int(ceil(height * scale)) + paddingPixels * 2
+        let bytesPerRow = widthPixels * 4
+        guard widthPixels > 0,
+            heightPixels > 0,
+            widthPixels <= maximumWidthPixels,
+            heightPixels <= maximumHeightPixels,
+            bytesPerRow <= Int.max / heightPixels,
+            bytesPerRow * heightPixels <= maximumTextureByteCost
+        else {
+            return nil
+        }
+
+        var fill = [UInt8](repeating: 0, count: bytesPerRow * heightPixels)
+        let drewLine = fill.withUnsafeMutableBytes { buffer -> Bool in
+            guard
+                let context = CGContext(
+                    data: buffer.baseAddress,
+                    width: widthPixels,
+                    height: heightPixels,
+                    bitsPerComponent: 8,
+                    bytesPerRow: bytesPerRow,
+                    space: colorSpace,
+                    bitmapInfo: bitmapInfo.rawValue
+                )
+            else {
+                return false
+            }
+            context.scaleBy(x: scale, y: scale)
+            let padding = CGFloat(paddingPixels) / scale
+            context.textPosition = CGPoint(x: padding, y: padding + descent)
+            CTLineDraw(line, context)
+            return true
+        }
+        guard drewLine else { return nil }
+
+        let fillAlpha = alpha(from: fill)
+        let ringAlpha = outerRing(
+            alpha: fillAlpha,
+            width: widthPixels,
+            height: heightPixels,
+            radiusPixels: outlineRadiusPixels
+        )
+        let decorationIsLight =
+            relativeLuminance(components)
+            < lightInkRelativeLuminanceThreshold
+        let ring = monochromePixels(
+            alpha: ringAlpha,
+            isLight: decorationIsLight
+        )
+        let decorated = sourceOver(foreground: fill, background: ring)
+        guard shadowRadiusPixels > 0 else {
+            return DanmakuTexturePayload(
+                pixels: Data(decorated),
+                widthPixels: widthPixels,
+                heightPixels: heightPixels,
+                bytesPerRow: bytesPerRow,
+                backingScale: key.backingScale
+            )
+        }
+        let blurredAlpha = tentBlur(
+            alpha: alpha(from: decorated),
+            width: widthPixels,
+            height: heightPixels,
+            radius: shadowRadiusPixels
+        )
+        let shadow = monochromePixels(
+            alpha: blurredAlpha,
+            isLight: decorationIsLight
+        )
+        let baked = sourceOver(foreground: decorated, background: shadow)
+        return DanmakuTexturePayload(
+            pixels: Data(baked),
+            widthPixels: widthPixels,
+            heightPixels: heightPixels,
+            bytesPerRow: bytesPerRow,
+            backingScale: key.backingScale
+        )
+    }
+
+    static func outerRing(
+        alpha: [UInt8],
+        width: Int,
+        height: Int,
+        radiusPixels: Double
+    ) -> [UInt8] {
+        precondition(alpha.count == width * height)
+        guard !alpha.isEmpty, radiusPixels > 0 else {
+            return [UInt8](repeating: 0, count: alpha.count)
+        }
+        let radius = max(1, Int(ceil(radiusPixels)))
+        var source = alpha
+        var dilated = [UInt8](repeating: 0, count: alpha.count)
+        let kernelSize = vImagePixelCount(radius * 2 + 1)
+        let error = source.withUnsafeMutableBytes { sourceBuffer in
+            dilated.withUnsafeMutableBytes { destinationBuffer in
+                var sourceImage = vImage_Buffer(
+                    data: sourceBuffer.baseAddress,
+                    height: vImagePixelCount(height),
+                    width: vImagePixelCount(width),
+                    rowBytes: width
+                )
+                var destinationImage = vImage_Buffer(
+                    data: destinationBuffer.baseAddress,
+                    height: vImagePixelCount(height),
+                    width: vImagePixelCount(width),
+                    rowBytes: width
+                )
+                return vImageMax_Planar8(
+                    &sourceImage,
+                    &destinationImage,
+                    nil,
+                    0,
+                    0,
+                    kernelSize,
+                    kernelSize,
+                    vImage_Flags(kvImageEdgeExtend)
+                )
+            }
+        }
+        guard error == kvImageNoError else {
+            return [UInt8](repeating: 0, count: alpha.count)
+        }
+        let edgeCoverage = min(radiusPixels / Double(radius), 1)
+        return zip(dilated, alpha).map { expanded, original in
+            guard expanded > original else { return 0 }
+            return UInt8(
+                min(
+                    255,
+                    Int((Double(expanded - original) * edgeCoverage).rounded())
+                )
+            )
+        }
+    }
+
+    static func tentBlur(
+        alpha: [UInt8],
+        width: Int,
+        height: Int,
+        radius: Int
+    ) -> [UInt8] {
+        precondition(alpha.count == width * height)
+        guard !alpha.isEmpty, radius > 0 else { return alpha }
+        var source = alpha
+        var result = [UInt8](repeating: 0, count: alpha.count)
+        let kernelSize = UInt32(radius * 2 + 1)
+        let error = source.withUnsafeMutableBytes { sourceBuffer in
+            result.withUnsafeMutableBytes { destinationBuffer in
+                var sourceImage = vImage_Buffer(
+                    data: sourceBuffer.baseAddress,
+                    height: vImagePixelCount(height),
+                    width: vImagePixelCount(width),
+                    rowBytes: width
+                )
+                var destinationImage = vImage_Buffer(
+                    data: destinationBuffer.baseAddress,
+                    height: vImagePixelCount(height),
+                    width: vImagePixelCount(width),
+                    rowBytes: width
+                )
+                return vImageTentConvolve_Planar8(
+                    &sourceImage,
+                    &destinationImage,
+                    nil,
+                    0,
+                    0,
+                    kernelSize,
+                    kernelSize,
+                    0,
+                    vImage_Flags(kvImageEdgeExtend)
+                )
+            }
+        }
+        return error == kvImageNoError ? result : alpha
+    }
+
+    static func alpha(from pixels: [UInt8]) -> [UInt8] {
+        stride(from: 3, to: pixels.count, by: 4).map { pixels[$0] }
+    }
+
+    static func monochromePixels(
+        alpha: [UInt8],
+        isLight: Bool
+    ) -> [UInt8] {
+        var pixels = [UInt8](repeating: 0, count: alpha.count * 4)
+        for index in alpha.indices {
+            let value = alpha[index]
+            let offset = index * 4
+            let channel = isLight ? value : 0
+            pixels[offset] = channel
+            pixels[offset + 1] = channel
+            pixels[offset + 2] = channel
+            pixels[offset + 3] = value
+        }
+        return pixels
+    }
+
+    static func sourceOver(
+        foreground: [UInt8],
+        background: [UInt8]
+    ) -> [UInt8] {
+        precondition(foreground.count == background.count)
+        var result = background
+        for offset in stride(from: 0, to: result.count, by: 4) {
+            let foregroundAlpha = Int(foreground[offset + 3])
+            let inverseAlpha = 255 - foregroundAlpha
+            for channel in 0..<3 {
+                result[offset + channel] = UInt8(
+                    min(
+                        255,
+                        Int(foreground[offset + channel])
+                            + (Int(background[offset + channel])
+                                * inverseAlpha + 127) / 255
+                    )
+                )
+            }
+            result[offset + 3] = UInt8(
+                min(
+                    255,
+                    foregroundAlpha
+                        + (Int(background[offset + 3]) * inverseAlpha + 127)
+                        / 255
+                )
+            )
+        }
+        return result
+    }
+
+    static func decorationIsLight(colorRGB: UInt32) -> Bool {
+        relativeLuminance(rgbComponents(colorRGB))
+            < lightInkRelativeLuminanceThreshold
+    }
+
+    private static func rgbComponents(
+        _ colorRGB: UInt32
+    ) -> (red: CGFloat, green: CGFloat, blue: CGFloat) {
+        let rgb = colorRGB & 0x00FF_FFFF
+        return (
+            CGFloat((rgb >> 16) & 0xFF) / 255,
+            CGFloat((rgb >> 8) & 0xFF) / 255,
+            CGFloat(rgb & 0xFF) / 255
+        )
+    }
+
+    private static func relativeLuminance(
+        _ components: (red: CGFloat, green: CGFloat, blue: CGFloat)
+    ) -> CGFloat {
+        0.2126 * linearized(components.red)
+            + 0.7152 * linearized(components.green)
+            + 0.0722 * linearized(components.blue)
+    }
+
+    private static func linearized(_ component: CGFloat) -> CGFloat {
+        component <= 0.04045
+            ? component / 12.92
+            : pow((component + 0.055) / 1.055, 2.4)
+    }
+
+    private static func fontWeight(
+        _ weight: CoreAnimationDanmakuFontWeight
+    ) -> NSFont.Weight {
+        switch weight {
+        case .regular: .regular
+        case .medium: .medium
+        case .semibold: .semibold
+        case .bold: .bold
+        }
+    }
+
+    private static let bitmapInfo = CGBitmapInfo(
+        rawValue: CGImageAlphaInfo.premultipliedLast.rawValue
+    ).union(.byteOrder32Big)
+}

--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
@@ -7,6 +7,25 @@ import Testing
 
 @testable import BiliDanmaku
 
+private final class RasterizationStartProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let started = DispatchSemaphore(value: 0)
+    private var count = 0
+
+    func recordStart() {
+        lock.withLock { count += 1 }
+        started.signal()
+    }
+
+    func waitForStart(timeout: DispatchTime) -> DispatchTimeoutResult {
+        started.wait(timeout: timeout)
+    }
+
+    var startCount: Int {
+        lock.withLock { count }
+    }
+}
+
 @MainActor
 @Suite
 struct DanmakuPresentationControllerTests {
@@ -17,7 +36,7 @@ struct DanmakuPresentationControllerTests {
                 == CoreAnimationDanmakuStyle(
                     fontScale: 1,
                     fontWeight: .semibold,
-                    shadowBlurRadius: 2
+                    shadowBlurRadius: 1
                 )
         )
 
@@ -40,14 +59,14 @@ struct DanmakuPresentationControllerTests {
         )
         #expect(nonfinite.fontScale == 1)
         #expect(nonfinite.fontWeight == .regular)
-        #expect(nonfinite.shadowBlurRadius == 2)
+        #expect(nonfinite.shadowBlurRadius == 1)
 
         let laneConfiguration = DanmakuLaneConfiguration.production(
             surfaceWidth: 1_280,
             surfaceHeight: 720
         )
         #expect(laneConfiguration.laneHeight == 36)
-        #expect(laneConfiguration.minimumHorizontalGap == 40)
+        #expect(laneConfiguration.minimumHorizontalGap == 64)
         #expect(
             laneConfiguration.maximumActiveCount
                 == DanmakuLaneConfiguration.hardMaximumActiveCount
@@ -62,7 +81,7 @@ struct DanmakuPresentationControllerTests {
             DanmakuDensityAdmissionPolicy.init
         )
 
-        #expect(policies.map(\.minimumHorizontalGap) == [40, 20, 0])
+        #expect(policies.map(\.minimumHorizontalGap) == [64, 32, 0])
         #expect(policies.map(\.maximumOverlapDepth) == [1, 1, 3])
     }
 
@@ -471,6 +490,44 @@ struct DanmakuPresentationControllerTests {
     }
 
     @Test
+    func pendingPreparationQueueIsGloballyBoundedAcrossBatches() {
+        let backend = RecordingRenderingBackend()
+        backend.delaysPreparation = true
+        let controller = DanmakuPresentationController(
+            backend: backend,
+            configuration: configuration(maximumActiveCount: 640)
+        )
+        let identity = PlaybackItemIdentity(bvid: "BV1PendingBound", cid: 1)
+        let maximum = DanmakuLaneConfiguration.hardMaximumActiveCount
+
+        controller.apply(
+            update(
+                identity: identity,
+                position: 1,
+                generation: 1,
+                events: (0..<maximum).map {
+                    event(id: "first-\($0)", mode: .scrolling)
+                }
+            )
+        )
+        controller.apply(
+            update(
+                identity: identity,
+                position: 2,
+                generation: 1,
+                events: (0...maximum).map {
+                    event(id: "blocked-\($0)", mode: .scrolling)
+                }
+            )
+        )
+
+        #expect(backend.preparationIDs.count == maximum)
+        #expect(controller.statistics.droppedCapacity == maximum + 1)
+        controller.clearPresentation()
+        #expect(controller.statistics.active == 0)
+    }
+
+    @Test
     func pauseRateGenerationAndStopRemainSingleSequenceCommands() {
         let backend = RecordingRenderingBackend()
         let controller = DanmakuPresentationController(
@@ -632,28 +689,423 @@ struct DanmakuPresentationControllerTests {
     }
 
     @Test
-    func rendererResizeKeepsScrollingAnimationAndRelayoutsFixedModes() throws {
+    func unionOuterRingDoesNotEnterFillAndMapsHalfPointAtOneAndTwoX() {
+        let alpha: [UInt8] = [
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 255, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+        ]
+        let oneX = DanmakuTextureRasterizer.outerRing(
+            alpha: alpha,
+            width: 5,
+            height: 5,
+            radiusPixels: 0.5
+        )
+        let twoX = DanmakuTextureRasterizer.outerRing(
+            alpha: alpha,
+            width: 5,
+            height: 5,
+            radiusPixels: 1
+        )
+
+        #expect(oneX[2 * 5 + 2] == 0)
+        #expect(twoX[2 * 5 + 2] == 0)
+        #expect(oneX[2 * 5 + 1] == 128)
+        #expect(twoX[2 * 5 + 1] == 255)
+        #expect(oneX[1 * 5 + 1] == 128)
+        #expect(twoX[1 * 5 + 1] == 255)
+
+        let adjacent: [UInt8] = [
+            0, 0, 0, 0, 0,
+            0, 255, 255, 255, 0,
+            0, 0, 0, 0, 0,
+        ]
+        let union = DanmakuTextureRasterizer.outerRing(
+            alpha: adjacent,
+            width: 5,
+            height: 3,
+            radiusPixels: 1
+        )
+        #expect(union[1 * 5 + 1] == 0)
+        #expect(union[1 * 5 + 2] == 0)
+        #expect(union[1 * 5 + 3] == 0)
+    }
+
+    @Test
+    func onePointTentShadowIsZeroOffsetAndSymmetricAtOneAndTwoX() {
+        let source: [UInt8] = [
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 255, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+        ]
+        let oneX = DanmakuTextureRasterizer.tentBlur(
+            alpha: source,
+            width: 5,
+            height: 5,
+            radius: 1
+        )
+        let twoX = DanmakuTextureRasterizer.tentBlur(
+            alpha: source,
+            width: 5,
+            height: 5,
+            radius: 2
+        )
+
+        #expect(oneX[2 * 5 + 1] == oneX[2 * 5 + 3])
+        #expect(oneX[1 * 5 + 2] == oneX[3 * 5 + 2])
+        #expect(twoX[2 * 5] == twoX[2 * 5 + 4])
+        #expect(twoX[2] == twoX[4 * 5 + 2])
+        #expect(twoX[2 * 5 + 2] > twoX[2 * 5 + 1])
+        #expect(twoX[2 * 5 + 1] > twoX[2 * 5])
+    }
+
+    @Test
+    func cacheKeyIncludesEveryVisualInputAndAdaptiveInkThreshold() throws {
+        let baseEvent = event(
+            id: "key",
+            mode: .top,
+            colorRGB: 0xFFFFFF,
+            fontSize: 25
+        )
+        let base = try #require(
+            DanmakuTextureRasterizer.key(
+                event: baseEvent,
+                style: .production,
+                backingScale: 2
+            )
+        )
+        let changedText = try #require(
+            DanmakuTextureRasterizer.key(
+                event: DanmakuEvent(
+                    id: "key-2",
+                    timeSeconds: 1,
+                    mode: .top,
+                    text: "different",
+                    fontSize: 25,
+                    colorRGB: 0xFFFFFF,
+                    weight: 1
+                ),
+                style: .production,
+                backingScale: 2
+            )
+        )
+        let changedStyle = try #require(
+            DanmakuTextureRasterizer.key(
+                event: baseEvent,
+                style: CoreAnimationDanmakuStyle(
+                    fontScale: 1.5,
+                    fontWeight: .bold,
+                    shadowBlurRadius: 4
+                ),
+                backingScale: 2
+            )
+        )
+        let changedScale = try #require(
+            DanmakuTextureRasterizer.key(
+                event: baseEvent,
+                style: .production,
+                backingScale: 1
+            )
+        )
+        let changedColor = try #require(
+            DanmakuTextureRasterizer.key(
+                event: event(
+                    id: "key-color",
+                    mode: .top,
+                    colorRGB: 0x204060,
+                    fontSize: 25
+                ),
+                style: .production,
+                backingScale: 2
+            )
+        )
+        let changedFontSize = try #require(
+            DanmakuTextureRasterizer.key(
+                event: event(
+                    id: "key-size",
+                    mode: .top,
+                    colorRGB: 0xFFFFFF,
+                    fontSize: 36
+                ),
+                style: .production,
+                backingScale: 2
+            )
+        )
+
+        #expect(base != changedText)
+        #expect(base != changedStyle)
+        #expect(base != changedScale)
+        #expect(base != changedColor)
+        #expect(base != changedFontSize)
+        #expect(base.fontDescriptor == "system-semibold")
+        #expect(base.fontWeight == .semibold)
+        #expect(base.fontScale == 1)
+        #expect(base.outlineWidthPoints == 0.5)
+        #expect(base.shadowRadiusPoints == 1)
+        #expect(base.algorithmVersion == 1)
+        #expect(DanmakuTextureRasterizer.decorationIsLight(colorRGB: 0x757575))
+        #expect(!DanmakuTextureRasterizer.decorationIsLight(colorRGB: 0x767676))
+    }
+
+    @Test
+    func rasterizerHandlesSupportedSizesScriptsAndColorGlyphInputs() throws {
+        let samples = [
+            "中文弹幕",
+            "Latin 123",
+            "e\u{301}",
+            "👨‍👩‍👧‍👦 🌈",
+        ]
+        for scale in [1.0, 2.0] {
+            for size in [18.0, 25.0, 36.0] {
+                for (index, text) in samples.enumerated() {
+                    let fixture = DanmakuEvent(
+                        id: "raster-" + String(index),
+                        timeSeconds: 1,
+                        mode: .scrolling,
+                        text: text,
+                        fontSize: size,
+                        colorRGB: index.isMultiple(of: 2)
+                            ? 0xFFFFFF : 0x204060,
+                        weight: 1
+                    )
+                    let key = try #require(
+                        DanmakuTextureRasterizer.key(
+                            event: fixture,
+                            style: .production,
+                            backingScale: scale
+                        )
+                    )
+                    let payload = try #require(
+                        DanmakuTextureRasterizer.rasterize(key: key)
+                    )
+                    #expect(payload.widthPixels > 0)
+                    #expect(payload.heightPixels > 0)
+                    #expect(payload.byteCost == payload.pixels.count)
+                    #expect(
+                        stride(
+                            from: 3,
+                            to: payload.pixels.count,
+                            by: 4
+                        ).contains { payload.pixels[$0] > 0 }
+                    )
+                }
+            }
+        }
+
+        let emojiEvent = DanmakuEvent(
+            id: "color-emoji",
+            timeSeconds: 1,
+            mode: .scrolling,
+            text: "🌈",
+            fontSize: 36,
+            colorRGB: 0xFFFFFF,
+            weight: 1
+        )
+        let emojiKey = try #require(
+            DanmakuTextureRasterizer.key(
+                event: emojiEvent,
+                style: .production,
+                backingScale: 2
+            )
+        )
+        let emoji = try #require(
+            DanmakuTextureRasterizer.rasterize(key: emojiKey)
+        )
+        let hasColoredGlyphPixel = stride(
+            from: 0,
+            to: emoji.pixels.count,
+            by: 4
+        ).contains { offset in
+            let red = emoji.pixels[offset]
+            let green = emoji.pixels[offset + 1]
+            let blue = emoji.pixels[offset + 2]
+            return emoji.pixels[offset + 3] > 0
+                && (red != green || green != blue)
+        }
+        #expect(hasColoredGlyphPixel)
+    }
+
+    @Test
+    func byteBoundedCacheUsesLRUAndRejectsOversizedItems() throws {
+        let limits = DanmakuTextureLRUCache.Limits(
+            maximumItemCost: 64,
+            maximumTotalCost: 96
+        )
+        let cache = DanmakuTextureLRUCache(limits: limits)
+        let first = textureKey(text: "first")
+        let second = textureKey(text: "second")
+        let third = textureKey(text: "third")
+        let payload = texturePayload(byteCost: 48)
+
+        let insertedFirst = cache.insert(payload, for: first)
+        let insertedSecond = cache.insert(payload, for: second)
+        let firstHit = cache.value(for: first)
+        let insertedThird = cache.insert(payload, for: third)
+        let evictedSecond = cache.value(for: second)
+        let retainedFirst = cache.value(for: first)
+        let retainedThird = cache.value(for: third)
+        #expect(insertedFirst)
+        #expect(insertedSecond)
+        #expect(firstHit == payload)
+        #expect(insertedThird)
+        #expect(evictedSecond == nil)
+        #expect(retainedFirst == payload)
+        #expect(retainedThird == payload)
+        #expect(cache.totalCost == 96)
+        #expect(cache.evictionCount == 1)
+        let insertedOversized = cache.insert(
+            texturePayload(byteCost: 68),
+            for: second
+        )
+        #expect(!insertedOversized)
+        #expect(cache.totalCost == 96)
+        cache.removeAll()
+        #expect(cache.count == 0)
+        #expect(cache.totalCost == 0)
+    }
+
+    @Test
+    func preparedRendererUsesOneOrdinaryLayerAndRootOpacity() async throws {
+        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
+        renderer.updateSurfaceSize(width: 800, height: 240)
+        let fixture = event(
+            id: "one-layer",
+            mode: .scrolling,
+            colorRGB: 0xD0E0F0
+        )
+        let metrics = try await prepareAndRender(
+            renderer: renderer,
+            event: fixture,
+            preparationID: 1,
+            originY: 20
+        )
+        let layer = try #require(renderer.textLayer(forEventID: fixture.id))
+        let identity = try #require(
+            renderer.objectIdentity(forEventID: fixture.id)
+        )
+
+        #expect(metrics.width > 0)
+        #expect(metrics.height > 0)
+        #expect(!(layer is CATextLayer))
+        #expect(layer.contents != nil)
+        #expect(layer.sublayers == nil)
+        #expect(layer.shadowOpacity == 0)
+        #expect(renderer.rootLayer.sublayers?.count == 1)
+
+        let opacity = try #require(DanmakuOpacity(0.35))
+        renderer.setOpacity(opacity)
+        #expect(abs(Double(renderer.rootLayer.opacity) - 0.35) < 0.001)
+        #expect(layer.opacity == 1)
+        #expect(
+            renderer.objectIdentity(forEventID: fixture.id) == identity
+        )
+        #expect(renderer.activeTextureByteCost > 0)
+        #expect(
+            renderer.activeTextureByteCost
+                <= CoreAnimationDanmakuRenderer.maximumActiveTextureByteCost
+        )
+        renderer.remove(eventID: fixture.id)
+        #expect(renderer.activeTextureByteCost == 0)
+    }
+
+    @Test
+    func preparedRendererCachesByBytesAndClearsOnMemoryPressure() async throws {
+        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
+        renderer.updateSurfaceSize(width: 800, height: 240)
+        let first = event(id: "cache-first", mode: .top)
+        _ = try await prepareAndRender(
+            renderer: renderer,
+            event: first,
+            preparationID: 1,
+            originY: 0
+        )
+        renderer.remove(eventID: first.id)
+        let rasterizations = renderer.rasterizationCount
+        let repeated = DanmakuEvent(
+            id: "cache-second",
+            timeSeconds: first.timeSeconds,
+            mode: first.mode,
+            text: first.text,
+            fontSize: first.fontSize,
+            colorRGB: first.colorRGB,
+            weight: first.weight
+        )
+        _ = try await prepareAndRender(
+            renderer: renderer,
+            event: repeated,
+            preparationID: 2,
+            originY: 0
+        )
+        #expect(renderer.rasterizationCount == rasterizations)
+        #expect(renderer.cacheHitCount >= 1)
+        #expect(renderer.cachedTextureCount == 1)
+        #expect(renderer.cachedTextureByteCost > 0)
+
+        renderer.remove(eventID: repeated.id)
+        renderer.handleMemoryPressureForTesting()
+        #expect(renderer.cachedTextureCount == 0)
+        #expect(renderer.cachedTextureByteCost == 0)
+        _ = try await prepareAndRender(
+            renderer: renderer,
+            event: repeated,
+            preparationID: 3,
+            originY: 0
+        )
+        #expect(renderer.rasterizationCount == rasterizations + 1)
+
+        renderer.remove(eventID: repeated.id)
+        let prepared = await prepare(
+            renderer: renderer,
+            event: repeated,
+            preparationID: 4
+        )
+        guard case .ready(let metrics) = prepared else {
+            Issue.record("texture preparation was rejected")
+            return
+        }
+        #expect(renderer.outstandingPreparationCount == 1)
+        renderer.handleMemoryPressureForTesting()
+        #expect(renderer.outstandingPreparationCount == 0)
+        #expect(renderer.cachedTextureByteCost == 0)
+        #expect(
+            !renderer.renderPrepared(
+                placement(event: repeated, metrics: metrics, originY: 0),
+                preparationID: 4,
+                generation: 0
+            )
+        )
+    }
+
+    @Test
+    func rendererResizePreservesMotionAndRelayoutsFixedModes() async throws {
         let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
         renderer.updateSurfaceSize(width: 800, height: 300)
         let scrolling = event(id: "resize-scroll", mode: .scrolling)
         let top = event(id: "resize-top", mode: .top)
         let bottom = event(id: "resize-bottom", mode: .bottom)
 
-        for (fixture, originY) in [
-            (scrolling, 60.0),
-            (top, 0.0),
-            (bottom, 240.0),
-        ] {
-            let metrics = renderer.measure(fixture)
-            renderer.render(
-                placement(
-                    event: fixture,
-                    metrics: metrics,
-                    originY: originY
-                )
-            )
-        }
-
+        _ = try await prepareAndRender(
+            renderer: renderer,
+            event: scrolling,
+            preparationID: 1,
+            originY: 60
+        )
+        _ = try await prepareAndRender(
+            renderer: renderer,
+            event: top,
+            preparationID: 2,
+            originY: 0
+        )
+        let bottomMetrics = try await prepareAndRender(
+            renderer: renderer,
+            event: bottom,
+            preparationID: 3,
+            originY: 240
+        )
         let scrollingLayer = try #require(
             renderer.textLayer(forEventID: scrolling.id)
         )
@@ -664,499 +1116,54 @@ struct DanmakuPresentationControllerTests {
         let scrollingPosition = scrollingLayer.position
         let topY = topLayer.position.y
         let bottomY = bottomLayer.position.y
+        let animation = try #require(
+            scrollingLayer.animation(forKey: "danmaku") as? CABasicAnimation
+        )
+        let from = animation.fromValue as? NSNumber
+        let to = animation.toValue as? NSNumber
         let epoch = renderer.renderEpoch
-        let scrollingAnimation = try #require(
-            scrollingLayer.animation(forKey: "danmaku") as? CABasicAnimation
-        )
-        let scrollingFrom = try #require(
-            scrollingAnimation.fromValue as? NSNumber
-        )
-        let scrollingTo = try #require(
-            scrollingAnimation.toValue as? NSNumber
-        )
-        let scrollingDuration = scrollingAnimation.duration
-        let rootTiming = (
-            beginTime: renderer.rootLayer.beginTime,
-            timeOffset: renderer.rootLayer.timeOffset,
-            speed: renderer.rootLayer.speed
-        )
 
         renderer.updateSurfaceSize(width: 1_200, height: 500)
 
+        #expect(bottomMetrics.height > 0)
         #expect(renderer.renderEpoch == epoch)
         #expect(renderer.activeLayerCount == 3)
         #expect(scrollingLayer.position == scrollingPosition)
-        let resizedAnimation = try #require(
+        let resized = try #require(
             scrollingLayer.animation(forKey: "danmaku") as? CABasicAnimation
         )
-        #expect((resizedAnimation.fromValue as? NSNumber) == scrollingFrom)
-        #expect((resizedAnimation.toValue as? NSNumber) == scrollingTo)
-        #expect(resizedAnimation.duration == scrollingDuration)
-        #expect(renderer.rootLayer.beginTime == rootTiming.beginTime)
-        #expect(renderer.rootLayer.timeOffset == rootTiming.timeOffset)
-        #expect(renderer.rootLayer.speed == rootTiming.speed)
-        #expect(topLayer.position == CGPoint(x: 600, y: topY))
-        #expect(bottomLayer.position == CGPoint(x: 600, y: bottomY + 200))
-
-        renderer.updateSurfaceSize(width: 0, height: 0)
-        renderer.updateSurfaceSize(width: 1_200, height: 500)
-
-        #expect(renderer.renderEpoch == epoch)
-        #expect(renderer.activeLayerCount == 3)
-        #expect(scrollingLayer.position == scrollingPosition)
+        #expect((resized.fromValue as? NSNumber) == from)
+        #expect((resized.toValue as? NSNumber) == to)
         #expect(topLayer.position == CGPoint(x: 600, y: topY))
         #expect(bottomLayer.position == CGPoint(x: 600, y: bottomY + 200))
     }
 
     @Test
-    func receivedLegacyLargeBottomStaysAnchoredAcrossResize() throws {
-        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
-        renderer.updateSurfaceSize(width: 800, height: 300)
-        let fixture = event(
-            id: "large-bottom-resize",
-            mode: .bottom,
-            fontSize: 36
-        )
-        let metrics = renderer.measure(fixture)
-        renderer.render(
-            placement(
-                event: fixture,
-                metrics: metrics,
-                originY: 300 - metrics.height
-            )
-        )
-        let layer = try #require(
-            renderer.textLayer(forEventID: fixture.id)
-        )
-
-        #expect(layer.frame.maxY == 300)
-        renderer.updateSurfaceSize(width: 1_200, height: 500)
-        #expect(layer.frame.maxY == 500)
-        #expect(layer.position.x == 600)
-    }
-
-    @Test
-    func coreAnimationStyleUsesHeavyInkWithoutCompositorShadow() throws {
-        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
-        renderer.updateSurfaceSize(width: 800, height: 200)
-        let fixture = event(id: "style", mode: .scrolling)
-        let metrics = renderer.measure(fixture)
-        renderer.render(
-            placement(
-                event: fixture,
-                metrics: metrics,
-                originY: 20
-            )
-        )
-
-        let layer = try #require(renderer.textLayer(forEventID: fixture.id))
-        let attributed = try #require(layer.string as? NSAttributedString)
-        let shadow = try #require(
-            attributed.attribute(
-                .shadow,
-                at: 0,
-                effectiveRange: nil
-            ) as? NSShadow
-        )
-
-        #expect(layer.shadowOpacity == 0)
-        #expect(shadow.shadowBlurRadius == 2)
-        #expect(shadow.shadowOffset == .zero)
-        #expect(renderer.activeLayerCount == 1)
-    }
-
-    @Test
-    func coreAnimationStyleMapsScaleWeightAndShadowIntoMeasurementAndLayer() throws {
-        let productionRenderer = CoreAnimationDanmakuRenderer(
-            style: .production,
-            contentsScale: 2
-        )
-        let customStyle = CoreAnimationDanmakuStyle(
-            fontScale: 1.5,
-            fontWeight: .bold,
-            shadowBlurRadius: 4
-        )
-        let customRenderer = CoreAnimationDanmakuRenderer(
-            style: customStyle,
-            contentsScale: 2
-        )
-        let fixture = event(id: "custom-style", mode: .top, fontSize: 25)
-        let productionMetrics = productionRenderer.measure(fixture)
-        let customMetrics = customRenderer.measure(fixture)
-
-        #expect(customRenderer.style == customStyle)
-        #expect(customMetrics.width > productionMetrics.width)
-        #expect(customMetrics.height > productionMetrics.height)
-
-        customRenderer.updateSurfaceSize(width: 800, height: 240)
-        customRenderer.render(
-            placement(
-                event: fixture,
-                metrics: customMetrics,
-                originY: 20
-            )
-        )
-        let layer = try #require(customRenderer.textLayer(forEventID: fixture.id))
-        let attributed = try #require(layer.string as? NSAttributedString)
-        let font = try #require(
-            attributed.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
-        )
-        let shadow = try #require(
-            attributed.attribute(.shadow, at: 0, effectiveRange: nil) as? NSShadow
-        )
-
-        #expect(Double(font.pointSize) == 37.5)
-        #expect(font.fontDescriptor.symbolicTraits.contains(.bold))
-        #expect(shadow.shadowBlurRadius == 4)
-        #expect(layer.shadowOpacity == 0)
-    }
-
-    @Test
-    func coreAnimationUsesReceivedFontSizeForMeasurementAndLayer() throws {
-        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
-        renderer.updateSurfaceSize(width: 800, height: 240)
-        let fixtures = [18.0, 25.0, 36.0].map { fontSize in
-            DanmakuEvent(
-                id: "font-\(fontSize)",
-                timeSeconds: 1,
-                mode: .top,
-                text: "同一条字号测试弹幕",
-                fontSize: fontSize,
-                colorRGB: 0xFFFFFF,
-                weight: 1
-            )
-        }
-        let metrics = fixtures.map(renderer.measure)
-
-        #expect(metrics[0].width < metrics[1].width)
-        #expect(metrics[1].width < metrics[2].width)
-        #expect(metrics[0].height < metrics[1].height)
-        #expect(metrics[1].height < metrics[2].height)
-
-        for (index, fixture) in fixtures.enumerated() {
-            renderer.render(
-                placement(
-                    event: fixture,
-                    metrics: metrics[index],
-                    originY: Double(index) * 64
-                )
-            )
-            let layer = try #require(
-                renderer.textLayer(forEventID: fixture.id)
-            )
-            let attributed = try #require(
-                layer.string as? NSAttributedString
-            )
-            let font = try #require(
-                attributed.attribute(.font, at: 0, effectiveRange: nil)
-                    as? NSFont
-            )
-            #expect(Double(font.pointSize) == fixture.fontSize)
-            #expect(Double(layer.bounds.width) == metrics[index].width)
-            #expect(Double(layer.bounds.height) == metrics[index].height)
-        }
-    }
-
-    @Test
-    func presentationControllerAdmitsReceivedSizesWithoutVerticalOverlap()
-        throws
-    {
-        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
-        let controller = DanmakuPresentationController(
-            backend: renderer,
-            configuration: DanmakuLaneConfiguration(
-                surfaceWidth: 800,
-                surfaceHeight: 240,
-                laneHeight: 36,
-                minimumHorizontalGap: 12,
-                maximumActiveCount: 20,
-                displayAreaFraction: 1
-            )
-        )
-        let identity = PlaybackItemIdentity(
-            bvid: "BV1FontSizeFixture",
-            cid: 1
-        )
-
-        controller.apply(
-            update(
-                identity: identity,
-                position: 1,
-                generation: 1,
-                events: [
-                    ("controller-font-18.0", 18.0),
-                    ("controller-font-25.0", 25.0),
-                    ("controller-font-36.0", 36.0),
-                    ("controller-after-large", 18.0),
-                ].map { id, fontSize in
-                    event(
-                        id: id,
-                        mode: .top,
-                        fontSize: fontSize
-                    )
-                }
-            )
-        )
-
-        #expect(controller.statistics.admitted == 4)
-        #expect(controller.statistics.active == 4)
-        #expect(controller.statistics.droppedNoLane == 0)
-        #expect(renderer.activeLayerCount == 4)
-
-        let smallLayer = try #require(
-            renderer.textLayer(forEventID: "controller-font-18.0")
-        )
-        let standardLayer = try #require(
-            renderer.textLayer(forEventID: "controller-font-25.0")
-        )
-        let legacyLargeLayer = try #require(
-            renderer.textLayer(forEventID: "controller-font-36.0")
-        )
-        let afterLargeLayer = try #require(
-            renderer.textLayer(forEventID: "controller-after-large")
-        )
-        #expect(legacyLargeLayer.bounds.height > 36)
-        #expect(smallLayer.frame.maxY <= standardLayer.frame.minY)
-        #expect(standardLayer.frame.maxY <= legacyLargeLayer.frame.minY)
-        #expect(legacyLargeLayer.frame.maxY <= afterLargeLayer.frame.minY)
-    }
-
-    @Test(arguments: [Double.nan, .infinity, -.infinity])
-    func nonfiniteReceivedFontSizeFailsClosed(fontSize: Double) {
-        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
-        renderer.updateSurfaceSize(width: 800, height: 200)
-        let fixture = DanmakuEvent(
-            id: "invalid-font-size",
-            timeSeconds: 1,
-            mode: .scrolling,
-            text: "不会进入图层的测试弹幕",
-            fontSize: fontSize,
-            colorRGB: 0xFFFFFF,
-            weight: 1
-        )
-        let metrics = renderer.measure(fixture)
-
-        #expect(metrics == DanmakuTextMetrics(width: 0, height: 0))
-        renderer.render(
-            placement(event: fixture, metrics: metrics, originY: 0)
-        )
-        #expect(renderer.activeLayerCount == 0)
-    }
-
-    @Test(arguments: [12.0, 24.0, 45.0, 64.0])
-    func unknownFiniteFontSizeFallsBackToStandard(
-        fontSize: Double
-    )
-        throws
-    {
-        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
-        renderer.updateSurfaceSize(width: 800, height: 200)
-        let fixture = event(
-            id: "font-fallback-\(fontSize)",
-            mode: .top,
-            fontSize: fontSize
-        )
-        let metrics = renderer.measure(fixture)
-
-        #expect(metrics.width > 0)
-        #expect(metrics.height > 0)
-        renderer.render(
-            placement(event: fixture, metrics: metrics, originY: 0)
-        )
-        let layer = try #require(
-            renderer.textLayer(forEventID: fixture.id)
-        )
-        let attributed = try #require(layer.string as? NSAttributedString)
-        let font = try #require(
-            attributed.attribute(.font, at: 0, effectiveRange: nil)
-                as? NSFont
-        )
-        #expect(Double(font.pointSize) == 25)
-    }
-
-    @Test
-    func coreAnimationUsesEventRGBAndAppliesOpacityWithoutReplacingLayers() throws {
-        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
-        renderer.updateSurfaceSize(width: 800, height: 200)
-        let colorful = event(
-            id: "colorful",
-            mode: .scrolling,
-            colorRGB: 0xAB_D0_E0_F0
-        )
-        let dark = event(id: "dark", mode: .top, colorRGB: 0x000000)
-
-        for (fixture, originY) in [(colorful, 20.0), (dark, 60.0)] {
-            let metrics = renderer.measure(fixture)
-            renderer.render(
-                placement(
-                    event: fixture,
-                    metrics: metrics,
-                    originY: originY
-                )
-            )
-        }
-
-        let colorfulLayer = try #require(
-            renderer.textLayer(forEventID: colorful.id)
-        )
-        let colorfulIdentity = try #require(
-            renderer.objectIdentity(forEventID: colorful.id)
-        )
-        let colorfulText = try #require(
-            colorfulLayer.string as? NSAttributedString
-        )
-        let foreground = try #require(
-            colorfulText.attribute(
-                .foregroundColor,
-                at: 0,
-                effectiveRange: nil
-            ) as? NSColor
-        )
-        let sRGB = try #require(foreground.usingColorSpace(.sRGB))
-        let colorfulShadow = try #require(
-            colorfulText.attribute(.shadow, at: 0, effectiveRange: nil)
-                as? NSShadow
-        )
-        let colorfulShadowColor = try #require(
-            colorfulShadow.shadowColor?.usingColorSpace(.sRGB)
-        )
-
-        #expect(abs(sRGB.redComponent - 0xD0 / 255) < 0.001)
-        #expect(abs(sRGB.greenComponent - 0xE0 / 255) < 0.001)
-        #expect(abs(sRGB.blueComponent - 0xF0 / 255) < 0.001)
-        #expect(colorfulShadowColor.redComponent == 0)
-
-        let darkLayer = try #require(renderer.textLayer(forEventID: dark.id))
-        let darkText = try #require(darkLayer.string as? NSAttributedString)
-        let darkShadow = try #require(
-            darkText.attribute(.shadow, at: 0, effectiveRange: nil) as? NSShadow
-        )
-        let darkShadowColor = try #require(
-            darkShadow.shadowColor?.usingColorSpace(.sRGB)
-        )
-        #expect(darkShadowColor.redComponent == 1)
-
-        let opacity = try #require(DanmakuOpacity(0.45))
-        renderer.setOpacity(opacity)
-
-        #expect(abs(Double(renderer.rootLayer.opacity) - opacity.value) < 0.001)
-        #expect(renderer.activeLayerCount == 2)
-        #expect(
-            renderer.objectIdentity(forEventID: colorful.id)
-                == colorfulIdentity
-        )
-        #expect(renderer.textLayer(forEventID: colorful.id) === colorfulLayer)
-    }
-
-    @Test
-    func adaptiveHeavyInkUsesFixedRelativeLuminanceThreshold() throws {
-        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
-        renderer.updateSurfaceSize(width: 800, height: 200)
-        let belowThreshold = event(
-            id: "ink-below-threshold",
-            mode: .scrolling,
-            colorRGB: 0x757575
-        )
-        let aboveThreshold = event(
-            id: "ink-above-threshold",
-            mode: .top,
-            colorRGB: 0x767676
-        )
-
-        for (fixture, originY) in [
-            (belowThreshold, 20.0),
-            (aboveThreshold, 60.0),
-        ] {
-            renderer.render(
-                placement(
-                    event: fixture,
-                    metrics: renderer.measure(fixture),
-                    originY: originY
-                )
-            )
-        }
-
-        func attributes(for eventID: String) throws -> NSAttributedString {
-            let layer = try #require(renderer.textLayer(forEventID: eventID))
-            return try #require(layer.string as? NSAttributedString)
-        }
-
-        func shadowRedComponent(for eventID: String) throws -> CGFloat {
-            let text = try attributes(for: eventID)
-            let shadow = try #require(
-                text.attribute(.shadow, at: 0, effectiveRange: nil) as? NSShadow
-            )
-            let color = try #require(
-                shadow.shadowColor?.usingColorSpace(.sRGB)
-            )
-            #expect(
-                text.attribute(.strokeColor, at: 0, effectiveRange: nil) == nil
-            )
-            #expect(
-                text.attribute(.strokeWidth, at: 0, effectiveRange: nil) == nil
-            )
-            return color.redComponent
-        }
-
-        #expect(try shadowRedComponent(for: belowThreshold.id) == 1)
-        #expect(try shadowRedComponent(for: aboveThreshold.id) == 0)
-    }
-
-    @Test
-    func coreAnimationTextDoesNotForceContentLanguage() throws {
-        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
-        renderer.updateSurfaceSize(width: 800, height: 200)
-        let fixture = DanmakuEvent(
-            id: "simplified-chinese-language",
-            timeSeconds: 1,
-            mode: .scrolling,
-            text: "弹幕字体/视频推荐/门骨直令",
-            fontSize: 24,
-            colorRGB: 0xFFFFFF,
-            weight: 1
-        )
-        let metrics = renderer.measure(fixture)
-        renderer.render(
-            placement(
-                event: fixture,
-                metrics: metrics,
-                originY: 20
-            )
-        )
-
-        let layer = try #require(renderer.textLayer(forEventID: fixture.id))
-        let attributed = try #require(layer.string as? NSAttributedString)
-        let language =
-            attributed.attribute(
-                NSAttributedString.Key(kCTLanguageAttributeName as String),
-                at: 0,
-                effectiveRange: nil
-            ) as? String
-
-        #expect(language == nil)
-    }
-
-    @Test
-    func staleCompletionCannotRemoveReplacementWithSameEventID() throws {
+    func staleAnimationCompletionCannotRemoveReplacement() async throws {
         let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
         let delegate = RecordingRendererDelegate()
         renderer.delegate = delegate
         renderer.updateSurfaceSize(width: 800, height: 200)
         let fixture = event(id: "reused", mode: .top)
-        let metrics = renderer.measure(fixture)
-        let fixturePlacement = placement(
+        _ = try await prepareAndRender(
+            renderer: renderer,
             event: fixture,
-            metrics: metrics,
+            preparationID: 1,
             originY: 10
         )
-        renderer.render(fixturePlacement)
         let oldIdentity = try #require(
             renderer.objectIdentity(forEventID: fixture.id)
         )
         let oldEpoch = renderer.renderEpoch
 
         renderer.clearAll()
-        renderer.render(fixturePlacement)
+        _ = try await prepareAndRender(
+            renderer: renderer,
+            event: fixture,
+            preparationID: 2,
+            generation: 1,
+            originY: 10
+        )
         let newIdentity = try #require(
             renderer.objectIdentity(forEventID: fixture.id)
         )
@@ -1180,43 +1187,217 @@ struct DanmakuPresentationControllerTests {
     }
 
     @Test
-    func concreteRendererCoversThreeModesRateAndLifecycleEpochs() throws {
+    func controllerWaitsForTextureAndPreservesPreparationOrder() {
+        let backend = RecordingRenderingBackend()
+        backend.delaysPreparation = true
+        let controller = DanmakuPresentationController(
+            backend: backend,
+            configuration: configuration(maximumActiveCount: 4)
+        )
+        let identity = PlaybackItemIdentity(bvid: "BV1Prepared", cid: 1)
+        controller.apply(
+            update(
+                identity: identity,
+                position: 1,
+                generation: 1,
+                events: [
+                    event(id: "first", mode: .top),
+                    event(id: "second", mode: .top),
+                ]
+            )
+        )
+        let firstID = backend.preparationIDs[0]
+        let secondID = backend.preparationIDs[1]
+
+        #expect(controller.statistics.active == 0)
+        #expect(backend.renderedEventIDs.isEmpty)
+        backend.completePreparation(secondID)
+        #expect(backend.renderedEventIDs.isEmpty)
+        backend.completePreparation(firstID)
+        #expect(backend.renderedEventIDs == ["first", "second"])
+        #expect(controller.statistics.active == 2)
+    }
+
+    @Test
+    func identityReplacementRejectsLatePreparation() {
+        let backend = RecordingRenderingBackend()
+        backend.delaysPreparation = true
+        let controller = DanmakuPresentationController(
+            backend: backend,
+            configuration: configuration(maximumActiveCount: 4)
+        )
+        let oldIdentity = PlaybackItemIdentity(bvid: "BV1OldIdentity", cid: 1)
+        let newIdentity = PlaybackItemIdentity(bvid: "BV1NewIdentity", cid: 2)
+
+        controller.apply(
+            update(
+                identity: oldIdentity,
+                position: 1,
+                generation: 1,
+                events: [event(id: "old-identity", mode: .top)]
+            )
+        )
+        let oldPreparationID = backend.preparationIDs.last!
+        controller.apply(
+            update(
+                identity: newIdentity,
+                position: 1,
+                generation: 1,
+                events: [event(id: "new-identity", mode: .top)]
+            )
+        )
+        let newPreparationID = backend.preparationIDs.last!
+
+        backend.completePreparation(oldPreparationID)
+        #expect(backend.renderedEventIDs.isEmpty)
+        backend.completePreparation(newPreparationID)
+        #expect(backend.renderedEventIDs == ["new-identity"])
+        #expect(controller.statistics.active == 1)
+    }
+
+    @Test
+    func generationStopAndBackingScaleInvalidateLatePreparation() {
+        let backend = RecordingRenderingBackend()
+        backend.delaysPreparation = true
+        let controller = DanmakuPresentationController(
+            backend: backend,
+            configuration: configuration(maximumActiveCount: 4)
+        )
+        let owner = UUID()
+        controller.attachSurface(ownerID: owner)
+        controller.updateSurface(
+            width: 800,
+            height: 300,
+            backingScale: 2,
+            ownerID: owner
+        )
+        let identity = PlaybackItemIdentity(bvid: "BV1Late", cid: 1)
+        controller.apply(
+            update(
+                identity: identity,
+                position: 1,
+                generation: 1,
+                events: [event(id: "old-generation", mode: .top)]
+            )
+        )
+        let oldGenerationID = backend.preparationIDs.last!
+        controller.apply(
+            update(
+                identity: identity,
+                position: 2,
+                generation: 2
+            )
+        )
+        backend.completePreparation(oldGenerationID)
+        #expect(backend.renderedEventIDs.isEmpty)
+
+        controller.apply(
+            update(
+                identity: identity,
+                position: 3,
+                generation: 2,
+                events: [event(id: "old-scale", mode: .top)]
+            )
+        )
+        let oldScaleID = backend.preparationIDs.last!
+        controller.updateSurface(
+            width: 800,
+            height: 300,
+            backingScale: 1,
+            ownerID: owner
+        )
+        backend.completePreparation(oldScaleID)
+        #expect(backend.renderedEventIDs.isEmpty)
+
+        controller.apply(
+            update(
+                identity: identity,
+                position: 3.5,
+                generation: 2,
+                events: [event(id: "cleared", mode: .top)]
+            )
+        )
+        let clearedID = backend.preparationIDs.last!
+        controller.clearPresentation()
+        backend.completePreparation(clearedID)
+        #expect(backend.renderedEventIDs.isEmpty)
+
+        controller.apply(
+            update(
+                identity: identity,
+                position: 4,
+                generation: 2,
+                events: [event(id: "stopped", mode: .top)]
+            )
+        )
+        let stoppedID = backend.preparationIDs.last!
+        controller.stopPresentation()
+        backend.completePreparation(stoppedID)
+        #expect(backend.renderedEventIDs.isEmpty)
+        #expect(controller.statistics.active == 0)
+        #expect(backend.cancelPreparationCount >= 3)
+    }
+
+    @Test
+    func sameScaleResizeKeepsPendingPreparationAndUsesNewSurface() {
+        let backend = RecordingRenderingBackend()
+        backend.delaysPreparation = true
+        let controller = DanmakuPresentationController(
+            backend: backend,
+            configuration: configuration(maximumActiveCount: 4)
+        )
+        let owner = UUID()
+        controller.attachSurface(ownerID: owner)
+        let identity = PlaybackItemIdentity(bvid: "BV1ResizePending", cid: 1)
+        controller.apply(
+            update(
+                identity: identity,
+                position: 1,
+                generation: 1,
+                events: [event(id: "pending-resize", mode: .top)]
+            )
+        )
+        let preparationID = backend.preparationIDs.last!
+        let cancelCount = backend.cancelPreparationCount
+        controller.updateSurface(
+            width: 1_200,
+            height: 500,
+            backingScale: 2,
+            ownerID: owner
+        )
+        #expect(backend.cancelPreparationCount == cancelCount)
+
+        backend.completePreparation(preparationID)
+        #expect(backend.renderedEventIDs == ["pending-resize"])
+        #expect(
+            backend.renderedPlacements.last?.surfaceWidthAtAdmission == 1_200
+        )
+    }
+
+    @Test
+    func rendererThreeModesRateAndLifecycleRemainBounded() async throws {
         let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
         renderer.updateSurfaceSize(width: 800, height: 300)
-        let scrolling = event(id: "scroll", mode: .scrolling)
-        let top = event(id: "top", mode: .top)
-        let bottom = event(id: "bottom", mode: .bottom)
-
-        for (fixture, originY) in [
-            (scrolling, 60.0),
-            (top, 0.0),
-            (bottom, 240.0),
-        ] {
-            let metrics = renderer.measure(fixture)
-            renderer.render(
-                placement(
-                    event: fixture,
-                    metrics: metrics,
-                    originY: originY
-                )
+        let fixtures = [
+            event(id: "scroll", mode: .scrolling),
+            event(id: "top", mode: .top),
+            event(id: "bottom", mode: .bottom),
+        ]
+        for (index, fixture) in fixtures.enumerated() {
+            _ = try await prepareAndRender(
+                renderer: renderer,
+                event: fixture,
+                preparationID: UInt64(index + 1),
+                originY: Double(index) * 80
             )
         }
 
-        let scrollingAnimation = try #require(
-            renderer.textLayer(forEventID: scrolling.id)?
-                .animation(forKey: "danmaku") as? CABasicAnimation
+        #expect(
+            renderer.textLayer(forEventID: "scroll")?
+                .animation(forKey: "danmaku") is CABasicAnimation
         )
-        let topAnimation = try #require(
-            renderer.textLayer(forEventID: top.id)?
-                .animation(forKey: "danmaku") as? CABasicAnimation
-        )
-        let bottomAnimation = try #require(
-            renderer.textLayer(forEventID: bottom.id)?
-                .animation(forKey: "danmaku") as? CABasicAnimation
-        )
-        #expect(scrollingAnimation.keyPath == "position.x")
-        #expect(topAnimation.keyPath == "opacity")
-        #expect(bottomAnimation.keyPath == "opacity")
+        #expect(renderer.activeLayerCount == 3)
+        #expect(renderer.maximumConcurrentPreparationCount == 2)
 
         renderer.setPlaybackRate(0)
         #expect(renderer.rootLayer.speed == 0)
@@ -1225,111 +1406,280 @@ struct DanmakuPresentationControllerTests {
         renderer.setPlaybackRate(2)
         #expect(renderer.rootLayer.speed == 2)
 
-        let controller = DanmakuPresentationController(
-            backend: renderer,
-            configuration: configuration(maximumActiveCount: 640)
-        )
-        let surfaceOwner = UUID()
-        controller.attachSurface(ownerID: surfaceOwner)
-        let beforeDetach = renderer.renderEpoch
-        controller.detachSurface(ownerID: surfaceOwner)
-        #expect(renderer.renderEpoch == beforeDetach + 1)
-        #expect(renderer.activeLayerCount == 0)
-        #expect(renderer.rootLayer.sublayers?.isEmpty != false)
-
-        controller.attachSurface(ownerID: surfaceOwner)
         let beforeStop = renderer.renderEpoch
-        controller.stopPresentation()
-        controller.stopPresentation()
-        #expect(renderer.renderEpoch == beforeStop + 2)
+        renderer.stop()
+        #expect(renderer.renderEpoch == beforeStop + 1)
         #expect(renderer.activeLayerCount == 0)
+        #expect(renderer.outstandingPreparationCount == 0)
         #expect(renderer.rootLayer.speed == 0)
     }
 
     @Test
-    func oversizedTextFailsClosedBeforeLayerCreation() {
+    func preparationOwnerRejectsWorkBeyondItsHardOutstandingLimit() {
+        let renderer = CoreAnimationDanmakuRenderer(
+            style: .production,
+            contentsScale: 2,
+            preparationConfiguration: .init(
+                maximumConcurrentOperations: 1,
+                maximumOutstandingRequests: 1,
+                cacheLimits: .production
+            )
+        )
+        renderer.updateSurfaceSize(width: 800, height: 300)
+        var secondResult: DanmakuPreparationResult?
+        renderer.prepare(
+            event(id: "bounded-first", mode: .scrolling),
+            preparationID: 1,
+            generation: 0,
+            backingScale: 2
+        ) { _ in }
+        renderer.prepare(
+            event(id: "bounded-second", mode: .scrolling),
+            preparationID: 2,
+            generation: 0,
+            backingScale: 2
+        ) { result in
+            secondResult = result
+        }
+
+        #expect(secondResult == .rejected(.capacity))
+        #expect(renderer.outstandingPreparationCount == 1)
+        #expect(renderer.maximumConcurrentPreparationCount == 1)
+        renderer.stop()
+        #expect(renderer.outstandingPreparationCount == 0)
+    }
+
+    @Test
+    func completedPayloadHandoffKeepsOperationSlotOccupied() {
+        let probe = RasterizationStartProbe()
+        let owner = DanmakuTexturePreparationOwner(
+            configuration: .init(
+                maximumConcurrentOperations: 1,
+                maximumOutstandingRequests: 3,
+                cacheLimits: .production
+            ),
+            rasterize: { _ in
+                probe.recordStart()
+                return DanmakuTexturePayload(
+                    pixels: Data(repeating: 1, count: 4),
+                    widthPixels: 1,
+                    heightPixels: 1,
+                    bytesPerRow: 4,
+                    backingScale: 1
+                )
+            }
+        )
+        for index in 0..<3 {
+            owner.prepare(
+                event: event(id: "handoff-\(index)", mode: .scrolling),
+                style: .production,
+                backingScale: 2,
+                preparationID: UInt64(index + 1),
+                generation: 0
+            ) { _ in }
+        }
+
+        #expect(probe.waitForStart(timeout: .now() + 1) == .success)
+        #expect(
+            probe.waitForStart(timeout: .now() + .milliseconds(100))
+                == .timedOut
+        )
+        #expect(probe.startCount == 1)
+        owner.cancelAllPreparations()
+    }
+
+    @Test
+    func rendererRejectsTextureBeyondActiveByteBudget() async {
+        let renderer = CoreAnimationDanmakuRenderer(
+            style: .production,
+            contentsScale: 2,
+            preparationConfiguration: .production,
+            activeTextureByteLimit: 1
+        )
+        renderer.updateSurfaceSize(width: 800, height: 300)
+        let fixture = event(id: "active-byte-limit", mode: .top)
+        let prepared = await prepare(
+            renderer: renderer,
+            event: fixture,
+            preparationID: 1
+        )
+        guard case .ready(let metrics) = prepared else {
+            Issue.record("texture preparation was rejected")
+            return
+        }
+
+        #expect(
+            !renderer.renderPrepared(
+                placement(event: fixture, metrics: metrics, originY: 0),
+                preparationID: 1,
+                generation: 0
+            )
+        )
+        #expect(renderer.activeLayerCount == 0)
+        #expect(renderer.activeTextureByteCost == 0)
+        #expect(renderer.outstandingPreparationCount == 0)
+    }
+
+    @Test
+    func failedLayerInstallImmediatelyReleasesAdmittedLane() {
+        let backend = RecordingRenderingBackend()
+        backend.renderPreparedResult = false
+        let controller = DanmakuPresentationController(
+            backend: backend,
+            configuration: configuration(maximumActiveCount: 1)
+        )
+        let identity = PlaybackItemIdentity(bvid: "BV1Install", cid: 1)
+        controller.apply(
+            update(
+                identity: identity,
+                position: 1,
+                generation: 1,
+                events: [event(id: "failed", mode: .top)]
+            )
+        )
+        #expect(controller.statistics.active == 0)
+        #expect(controller.statistics.droppedCapacity == 1)
+
+        backend.renderPreparedResult = true
+        controller.apply(
+            update(
+                identity: identity,
+                position: 2,
+                generation: 1,
+                events: [event(id: "replacement", mode: .top)]
+            )
+        )
+        #expect(backend.renderedEventIDs == ["replacement"])
+        #expect(controller.statistics.active == 1)
+    }
+
+    @Test
+    func stoppedPreparationOwnerAndRendererAreReleased() async throws {
+        weak var weakRenderer: CoreAnimationDanmakuRenderer?
+        do {
+            let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
+            weakRenderer = renderer
+            renderer.updateSurfaceSize(width: 800, height: 300)
+            _ = try await prepareAndRender(
+                renderer: renderer,
+                event: event(id: "release", mode: .scrolling),
+                preparationID: 1,
+                originY: 20
+            )
+            renderer.stop()
+        }
+        #expect(weakRenderer == nil)
+    }
+
+    @Test
+    func invalidAndOversizedTextFailClosedBeforeLaneAdmission() async {
         let renderer = CoreAnimationDanmakuRenderer(contentsScale: 2)
         renderer.updateSurfaceSize(width: 800, height: 300)
+        let invalid = DanmakuEvent(
+            id: "invalid",
+            timeSeconds: 1,
+            mode: .scrolling,
+            text: "invalid",
+            fontSize: .nan,
+            colorRGB: 0xFFFFFF,
+            weight: 1
+        )
         let oversized = DanmakuEvent(
             id: "oversized",
             timeSeconds: 1,
             mode: .scrolling,
-            text: String(repeating: "W", count: 4_096),
-            fontSize: 24,
+            text: String(repeating: "W", count: 512),
+            fontSize: 36,
             colorRGB: 0xFFFFFF,
             weight: 1
         )
 
-        let metrics = renderer.measure(oversized)
-
-        #expect(metrics == DanmakuTextMetrics(width: 0, height: 0))
-        #expect(renderer.activeLayerCount == 0)
-    }
-
-    @Test
-    func backendHardCapRejectsObjectSixHundredFortyOne() {
-        let renderer = CoreAnimationDanmakuRenderer(contentsScale: 1)
-        renderer.updateSurfaceSize(width: 800, height: 300)
-        let metrics = DanmakuTextMetrics(width: 40, height: 24)
-
-        for index in 0...DanmakuLaneConfiguration.hardMaximumActiveCount {
-            let fixture = DanmakuEvent(
-                id: "direct-\(index)",
-                timeSeconds: 1,
-                mode: .top,
-                text: "A",
-                fontSize: 24,
-                colorRGB: 0xFFFFFF,
-                weight: 1
-            )
-            renderer.render(
-                placement(
-                    event: fixture,
-                    metrics: metrics,
-                    originY: 0
-                )
-            )
-        }
-
         #expect(
-            renderer.activeLayerCount
-                == DanmakuLaneConfiguration.hardMaximumActiveCount
+            await prepare(
+                renderer: renderer,
+                event: invalid,
+                preparationID: 1
+            ) == .rejected(.invalidInput)
         )
-        renderer.stop()
+        #expect(
+            await prepare(
+                renderer: renderer,
+                event: oversized,
+                preparationID: 2
+            ) == .rejected(.oversized)
+        )
         #expect(renderer.activeLayerCount == 0)
+        #expect(renderer.outstandingPreparationCount == 0)
     }
 
-    @Test
-    func stoppedOwnerAndRendererAreReleased() {
-        weak var weakRenderer: CoreAnimationDanmakuRenderer?
-        weak var weakController: DanmakuPresentationController?
-
-        do {
-            let renderer = CoreAnimationDanmakuRenderer(contentsScale: 1)
-            let controller = DanmakuPresentationController(
-                backend: renderer,
-                configuration: configuration(maximumActiveCount: 4)
-            )
-            weakRenderer = renderer
-            weakController = controller
-            let fixture = event(id: "active", mode: .scrolling)
-            let metrics = renderer.measure(fixture)
-            renderer.render(
-                placement(
-                    event: fixture,
-                    metrics: metrics,
-                    originY: 60
-                )
-            )
-            #expect(renderer.activeLayerCount == 1)
-            controller.stopPresentation()
-            #expect(renderer.activeLayerCount == 0)
+    private func prepareAndRender(
+        renderer: CoreAnimationDanmakuRenderer,
+        event: DanmakuEvent,
+        preparationID: UInt64,
+        generation: UInt64 = 0,
+        originY: Double
+    ) async throws -> DanmakuTextMetrics {
+        let result = await prepare(
+            renderer: renderer,
+            event: event,
+            preparationID: preparationID,
+            generation: generation
+        )
+        guard case .ready(let metrics) = result else {
+            Issue.record("texture preparation was rejected")
+            return DanmakuTextMetrics(width: 0, height: 0)
         }
-
-        #expect(weakController == nil)
-        #expect(weakRenderer == nil)
+        let didRender = renderer.renderPrepared(
+            placement(event: event, metrics: metrics, originY: originY),
+            preparationID: preparationID,
+            generation: generation
+        )
+        #expect(didRender)
+        return metrics
     }
 
+    private func prepare(
+        renderer: CoreAnimationDanmakuRenderer,
+        event: DanmakuEvent,
+        preparationID: UInt64,
+        generation: UInt64 = 0
+    ) async -> DanmakuPreparationResult {
+        await withCheckedContinuation { continuation in
+            renderer.prepare(
+                event,
+                preparationID: preparationID,
+                generation: generation,
+                backingScale: 2
+            ) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    private func textureKey(text: String) -> DanmakuTextureCacheKey {
+        DanmakuTextureCacheKey(
+            text: text,
+            fontSize: 25,
+            colorRGB: 0xFFFFFF,
+            fontDescriptor: "system-semibold",
+            fontWeight: .semibold,
+            fontScale: 1,
+            backingScale: 2,
+            outlineWidthPoints: 0.5,
+            shadowRadiusPoints: 1,
+            algorithmVersion: 1
+        )
+    }
+
+    private func texturePayload(byteCost: Int) -> DanmakuTexturePayload {
+        DanmakuTexturePayload(
+            pixels: Data(repeating: 1, count: byteCost),
+            widthPixels: byteCost / 4,
+            heightPixels: 1,
+            bytesPerRow: byteCost,
+            backingScale: 1
+        )
+    }
     private func configuration(
         maximumActiveCount: Int,
         surfaceHeight: Double = 300
@@ -1428,6 +1778,12 @@ private final class RecordingRenderingBackend: DanmakuRenderingBackend {
     private(set) var stopCount = 0
     private(set) var measureCount = 0
     private(set) var surfaceSizes: [DanmakuTextMetrics] = []
+    var delaysPreparation = false
+    var renderPreparedResult = true
+    private(set) var preparationIDs: [UInt64] = []
+    private(set) var cancelPreparationCount = 0
+    private var preparationCompletions:
+        [UInt64: @MainActor @Sendable (DanmakuPreparationResult) -> Void] = [:]
 
     func measure(_ event: DanmakuEvent) -> DanmakuTextMetrics {
         measureCount += 1
@@ -1439,6 +1795,48 @@ private final class RecordingRenderingBackend: DanmakuRenderingBackend {
         operations.append(.render(eventID))
         renderedEventIDs.append(eventID)
         renderedPlacements.append(placement)
+    }
+
+    func prepare(
+        _ event: DanmakuEvent,
+        preparationID: UInt64,
+        generation: UInt64,
+        backingScale: Double,
+        completion:
+            @escaping @MainActor @Sendable (
+                DanmakuPreparationResult
+            ) -> Void
+    ) {
+        preparationIDs.append(preparationID)
+        if delaysPreparation {
+            preparationCompletions[preparationID] = completion
+        } else {
+            completion(.ready(measure(event)))
+        }
+    }
+
+    @discardableResult
+    func renderPrepared(
+        _ placement: DanmakuLanePlacement,
+        preparationID: UInt64,
+        generation: UInt64
+    ) -> Bool {
+        guard renderPreparedResult else { return false }
+        render(placement)
+        return true
+    }
+
+    func completePreparation(
+        _ preparationID: UInt64,
+        result: DanmakuPreparationResult = .ready(
+            DanmakuTextMetrics(width: 120, height: 24)
+        )
+    ) {
+        preparationCompletions[preparationID]?(result)
+    }
+
+    func cancelPendingPreparations() {
+        cancelPreparationCount += 1
     }
 
     func remove(eventID: String) {

--- a/Tools/DanmakuLab/Sources/DanmakuLabCore/LabRunOwner.swift
+++ b/Tools/DanmakuLab/Sources/DanmakuLabCore/LabRunOwner.swift
@@ -119,6 +119,7 @@ public final class LabRunOwner {
             controller.updateSurface(
                 width: width,
                 height: height,
+                backingScale: backingScale,
                 ownerID: ownerID
             )
         else {
@@ -169,6 +170,7 @@ public final class LabRunOwner {
             controller.updateSurface(
                 width: width,
                 height: height,
+                backingScale: backingScale,
                 ownerID: ownerID
             )
         else {
@@ -236,6 +238,7 @@ public final class LabRunOwner {
             controller.updateSurface(
                 width: surfaceSize.width,
                 height: surfaceSize.height,
+                backingScale: surfaceBackingScale,
                 ownerID: surfaceOwnerID
             )
         else {

--- a/Tools/DanmakuLab/Tests/DanmakuLabCoreTests/DanmakuLabCoreTests.swift
+++ b/Tools/DanmakuLab/Tests/DanmakuLabCoreTests/DanmakuLabCoreTests.swift
@@ -1051,9 +1051,103 @@ struct DanmakuLabCoreTests {
         #expect(owner.statistics == LabStatistics())
     }
 
+    @Test("run owner forwards backing scale through attach, resize, and performance reset")
+    @MainActor
+    func runOwnerForwardsBackingScale() {
+        let candidateID = LabRendererID(rawValue: "scale-candidate")
+        var createdBackend: TestDanmakuRenderingBackend?
+        let candidate = LabRendererDescriptor.candidate(
+            id: candidateID,
+            displayName: "Scale Candidate"
+        ) { _ in
+            let backend = TestDanmakuRenderingBackend()
+            createdBackend = backend
+            return LabRendererInstance(
+                backend: backend,
+                surfaceLayer: backend.surfaceLayer
+            )
+        }
+        let manifest = LabRunManifest(
+            scenario: .standard,
+            seed: 44,
+            eventRate: 24,
+            burstSize: 120,
+            filter: LabEventFilter(),
+            speedLevel: .three,
+            opacity: 0.9,
+            displayArea: .full,
+            density: .normal,
+            rendererID: candidateID,
+            startsPlaying: false
+        )
+        let preset = LabPerformancePreset(
+            id: LabPerformancePresetID(rawValue: "scale-forwarding"),
+            version: 1,
+            displayName: "Scale forwarding",
+            scenario: .standard,
+            seed: 44,
+            eventRate: 24,
+            burstSize: 120,
+            canvasSize: CGSize(width: 640, height: 360),
+            requiredBackingScale: 1,
+            warmupSeconds: 0.1,
+            measurementSeconds: 0.1,
+            repetitions: 1,
+            logicalTicksPerSecond: 60
+        )
+        let owner = LabRunOwner(
+            manifest: manifest,
+            rendererDescriptor: candidate
+        )
+        guard let backend = createdBackend else {
+            Issue.record("candidate backend was not created")
+            return
+        }
+        let ownerID = UUID()
+
+        #expect(
+            owner.attachSurface(
+                width: 640,
+                height: 360,
+                backingScale: 1,
+                ownerID: ownerID
+            )
+        )
+        #expect(backend.surfaceBackingScales.last == 1)
+        #expect(
+            owner.updateSurface(
+                width: 640,
+                height: 360,
+                backingScale: 2,
+                ownerID: ownerID
+            )
+        )
+        #expect(backend.surfaceBackingScales.last == 2)
+        #expect(
+            owner.updateSurface(
+                width: 640,
+                height: 360,
+                backingScale: 1,
+                ownerID: ownerID
+            )
+        )
+        #expect(backend.surfaceBackingScales.last == 1)
+        let scaleUpdateCount = backend.surfaceBackingScales.count
+
+        #expect(
+            owner.beginPerformanceMeasurement(
+                preset: preset,
+                attemptID: UUID()
+            )
+        )
+        #expect(backend.surfaceBackingScales.count == scaleUpdateCount + 2)
+        #expect(backend.surfaceBackingScales.last == 1)
+        owner.shutdown()
+    }
+
     @Test("production renderer handles play, pause, resize, discontinuity, and stop")
     @MainActor
-    func productionRendererLifecycleSmoke() {
+    func productionRendererLifecycleSmoke() async {
         let renderer = CoreAnimationDanmakuRenderer(contentsScale: 1)
         let controller = DanmakuPresentationController(
             backend: renderer,
@@ -1084,7 +1178,10 @@ struct DanmakuLabCoreTests {
                 )
             )
         )
-        #expect(renderer.activeLayerCount > 0)
+        let renderedFirstLayer = await waitUntil {
+            renderer.activeLayerCount > 0
+        }
+        #expect(renderedFirstLayer)
         #expect(
             renderer.activeLayerCount
                 <= DanmakuLaneConfiguration.hardMaximumActiveCount
@@ -1121,6 +1218,20 @@ struct DanmakuLabCoreTests {
         #expect(renderer.activeLayerCount == 0)
         #expect(renderer.rootLayer.speed == 0)
         #expect(controller.detachSurface(ownerID: ownerID))
+    }
+
+    @MainActor
+    private func waitUntil(
+        timeout: Duration = .seconds(5),
+        condition: () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !condition() {
+            guard clock.now < deadline else { return false }
+            await Task.yield()
+        }
+        return true
     }
 
     private func events(for scenario: LabScenario, count: Int) -> [DanmakuEvent] {
@@ -1192,6 +1303,7 @@ private final class TestDanmakuRenderingBackend: DanmakuRenderingBackend {
     weak var delegate: (any DanmakuRenderingBackendDelegate)?
     let surfaceLayer = CALayer()
     private(set) var stopCount = 0
+    private(set) var surfaceBackingScales: [Double] = []
 
     func measure(_ event: DanmakuEvent) -> DanmakuTextMetrics {
         DanmakuTextMetrics(width: 100, height: 36)
@@ -1218,6 +1330,15 @@ private final class TestDanmakuRenderingBackend: DanmakuRenderingBackend {
             width: width,
             height: height
         )
+    }
+
+    func updateSurfaceSize(
+        width: Double,
+        height: Double,
+        backingScale: Double
+    ) {
+        surfaceBackingScales.append(backingScale)
+        updateSurfaceSize(width: width, height: height)
     }
 
     func stop() {


### PR DESCRIPTION
## 变化

- 将生产弹幕文字改为后台 Core Text / vImage 预烘焙 RGBA 纹理，使用普通 `CALayer` 展示；描边为 0.5 pt union outline，阴影为 1 pt 零偏移烘焙阴影，并保留彩色 emoji。
- 将纹理准备接入有序异步准入，按播放 identity、generation 与 backing scale 隔离迟到结果；宿主与 DanmakuLab 均透传实际 backing scale。
- 增加完整资源边界：最多 2 个并发栅格任务、640 个全局待处理请求、单项 8 MiB / 总计 32 MiB LRU 缓存、64 MiB 活动纹理预算，以及内存压力清理。
- 保持后台结果到 MainActor 的交接有界，避免主线程繁忙时排队闭包累计大量像素数据。
- 将普通/增量密度的横向间距调整为 64 / 32 pt，重叠模式保持 0 pt。
- 将 DanmakuLab 与 App 的旧同步生命周期断言改为等待真实异步状态，并补充缓存、容量、取消、缩放与迟到结果测试。

## 原因

生产 renderer 已从同步文字 layer 转为异步预烘焙纹理。旧断言与旧资源模型无法覆盖新的完成时序，也不能证明高负载下的内存上界；本次同时收紧生命周期、缓存、活动纹理和交接队列。

## 用户影响

- 弹幕在高密度场景下具有更大的横向呼吸感。
- 描边与阴影以预烘焙纹理呈现，透明度仍由根 layer 控制。
- 缓存逐出、内存压力或容量达到上限时会 fail-closed 丢弃对应弹幕，不会无限积压。

用户已在 Apple Development 签名的 Debug App 中确认同一视觉参数；之后的复审修复仅涉及资源边界、backing scale 透传与异步测试同步。

## 验证

- 三路并行高风险复审通过；复审中发现的全局待处理队列、像素多重驻留、Lab backing scale 和 MainActor 交接峰值问题均已关闭。
- `sh Scripts/run-quality-gates.sh app`：静态检查通过，Swift Package 667 项测试通过，App build-for-testing 与全部 BiliKitMacTests 通过。
- `swift test --package-path Tools/DanmakuLab`：27 项测试通过。
- Apple Development Debug 构建已通过严格签名校验并由用户完成视觉确认。

## 未覆盖边界

- 尚未用 Instruments 形成正式 FPS、CPU、RSS 或 GPU 性能裁决，也未完成 1x / 2x / 4x 的长时间压力测量。
- 纹理当前固定使用 sRGB；未验证 HDR 或广色域输出。
- 签名证据为 Apple Development Debug，不代表 Developer ID、notarization 或 Gatekeeper 发布验证。
- 本次没有网络、认证、凭据或其他页面 UI 改动，也未进行真实服务请求。
