### PR TITLE
test(danmaku): 移除依赖固定等待的回交测试

### DIFF
--- a/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
+++ b/Packages/BiliKitCore/Tests/BiliDanmakuTests/DanmakuPresentationControllerTests.swift
@@ -7,25 +7,6 @@ import Testing
 
 @testable import BiliDanmaku
 
-private final class RasterizationStartProbe: @unchecked Sendable {
-    private let lock = NSLock()
-    private let started = DispatchSemaphore(value: 0)
-    private var count = 0
-
-    func recordStart() {
-        lock.withLock { count += 1 }
-        started.signal()
-    }
-
-    func waitForStart(timeout: DispatchTime) -> DispatchTimeoutResult {
-        started.wait(timeout: timeout)
-    }
-
-    var startCount: Int {
-        lock.withLock { count }
-    }
-}
-
 @MainActor
 @Suite
 struct DanmakuPresentationControllerTests {
@@ -1447,45 +1428,6 @@ struct DanmakuPresentationControllerTests {
         #expect(renderer.maximumConcurrentPreparationCount == 1)
         renderer.stop()
         #expect(renderer.outstandingPreparationCount == 0)
-    }
-
-    @Test
-    func completedPayloadHandoffKeepsOperationSlotOccupied() {
-        let probe = RasterizationStartProbe()
-        let owner = DanmakuTexturePreparationOwner(
-            configuration: .init(
-                maximumConcurrentOperations: 1,
-                maximumOutstandingRequests: 3,
-                cacheLimits: .production
-            ),
-            rasterize: { _ in
-                probe.recordStart()
-                return DanmakuTexturePayload(
-                    pixels: Data(repeating: 1, count: 4),
-                    widthPixels: 1,
-                    heightPixels: 1,
-                    bytesPerRow: 4,
-                    backingScale: 1
-                )
-            }
-        )
-        for index in 0..<3 {
-            owner.prepare(
-                event: event(id: "handoff-\(index)", mode: .scrolling),
-                style: .production,
-                backingScale: 2,
-                preparationID: UInt64(index + 1),
-                generation: 0
-            ) { _ in }
-        }
-
-        #expect(probe.waitForStart(timeout: .now() + 1) == .success)
-        #expect(
-            probe.waitForStart(timeout: .now() + .milliseconds(100))
-                == .timedOut
-        )
-        #expect(probe.startCount == 1)
-        owner.cancelAllPreparations()
     }
 
     @Test


### PR DESCRIPTION
macOS 15 Intel 的 main CI 在 `completedPayloadHandoffKeepsOperationSlotOccupied` 中失败：后台栅格任务未在 1 秒内启动，随后启动次数仍为 0。PR #103 和其合并提交的 CI 均通过；失败提交只删除 Codex 配置，产品与测试代码未变。失败记录：https://github.com/shiinayane/BiliKit-Mac/actions/runs/33933521166/job/101216838834

该测试在 MainActor 上同步等待 semaphore，并用 100 ms 超时判断第二个任务没有启动；启动信号也不能证明像素已经完成并进入回交阶段。按仓库删除依赖任意等待测试的规则，移除该测试及仅供它使用的 RasterizationStartProbe，共一个文件、58 行。生产行为不变，保留容量上限、取消、缓存和生命周期测试。

验证：`sh Scripts/run-quality-gates.sh package` 通过，包含静态检查及 666 项测试、69 个 suite；`git diff --check` 通过。运行环境为 Apple Silicon / Xcode 26.6，macOS 15 Intel / Xcode 26.3 仍需本 PR CI 验证。构建临时产物由 Gate 清理。

覆盖边界：此次移除后不再直接测试“回交期间占用 operation 名额”这一内部行为；没有以延长超时或新增 probe 替代，也不将本地通过视为 Intel、真实播放或性能验证。
