### PR TITLE
feat(updates): 接入 Sparkle 自动更新与 Cloudflare 签名源

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Preserve the upstream license verbatim, including its existing trailing space.
+BiliKitMac/Resources/Licenses/Sparkle-LICENSE.txt whitespace=-blank-at-eol

--- a/BiliKitMac.xcodeproj/project.pbxproj
+++ b/BiliKitMac.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		A1000000000000000000000A /* BiliApplication in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000015 /* BiliApplication */; };
 		A1000000000000000000000B /* BiliLibraryFeature in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000019 /* BiliLibraryFeature */; };
 		A1000000000000000000000C /* BiliDanmaku in Frameworks */ = {isa = PBXBuildFile; productRef = A1000000000000000000001A /* BiliDanmaku */; };
+		A20000000000000000000001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A20000000000000000000002 /* Sparkle */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -83,6 +84,7 @@
 				A10000000000000000000004 /* BiliAPI in Frameworks */,
 				A10000000000000000000003 /* BiliPlayback in Frameworks */,
 				A1000000000000000000000C /* BiliDanmaku in Frameworks */,
+				A20000000000000000000001 /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -155,6 +157,7 @@
 				A10000000000000000000013 /* BiliPlayback */,
 				A10000000000000000000014 /* BiliAPI */,
 				A1000000000000000000001A /* BiliDanmaku */,
+				A20000000000000000000002 /* Sparkle */,
 			);
 			productName = BiliKitMac;
 			productReference = 8DFA9001300F375500DF3E1D /* BiliKit.app */;
@@ -217,6 +220,7 @@
 			mainGroup = 8DFA8FF8300F375500DF3E1D;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				A20000000000000000000003 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				A10000000000000000000020 /* XCLocalSwiftPackageReference "Packages/BiliKitCore" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -403,12 +407,13 @@
 				CODE_SIGN_ENTITLEMENTS = BiliKitMac/BiliKitMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 2B3LZ256AG;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Configuration/BiliKit-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = BiliKit;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 shiinayane.";
@@ -441,12 +446,13 @@
 				CODE_SIGN_ENTITLEMENTS = BiliKitMac/BiliKitMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 2B3LZ256AG;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Configuration/BiliKit-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = BiliKit;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 shiinayane.";
@@ -551,6 +557,17 @@
 		};
 /* End XCLocalSwiftPackageReference section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		A20000000000000000000003 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = exactVersion;
+				version = 2.9.6;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		A10000000000000000000013 /* BiliPlayback */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -591,6 +608,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A10000000000000000000020 /* XCLocalSwiftPackageReference "Packages/BiliKitCore" */;
 			productName = BiliDanmaku;
+		};
+		A20000000000000000000002 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A20000000000000000000003 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/BiliKitMac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BiliKitMac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "741093db004b9ec401082832706d6105af735393392e2cc120b83860db08f6bb",
+  "originHash" : "72f6daca01a494229c351b49c28cf5c81e51fa71a66cdb34d4a33e0b108fbf0b",
   "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
+      }
+    },
     {
       "identity" : "swift-protobuf",
       "kind" : "remoteSourceControl",

--- a/BiliKitMac/App/AppUpdateCommands.swift
+++ b/BiliKitMac/App/AppUpdateCommands.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct AppUpdateCommands: Commands {
+    @ObservedObject var updater: AppUpdater
+
+    var body: some Commands {
+        CommandGroup(after: .appInfo) {
+            if !updater.isConfigured {
+                Button("检查更新（尚未配置）") {}
+                    .disabled(true)
+            } else if updater.failedToStart {
+                Button("检查更新（暂不可用）") {}
+                    .disabled(true)
+            } else {
+                Button("检查更新…", action: updater.checkForUpdates)
+                    .disabled(!updater.canCheckForUpdates)
+                Toggle(
+                    "自动检查更新",
+                    isOn: Binding(
+                        get: { updater.automaticallyChecksForUpdates },
+                        set: { updater.setAutomaticallyChecksForUpdates($0) }
+                    )
+                )
+                Toggle(
+                    "自动下载并安装更新",
+                    isOn: Binding(
+                        get: { updater.automaticallyDownloadsUpdates },
+                        set: { updater.setAutomaticallyDownloadsUpdates($0) }
+                    )
+                )
+                .disabled(!updater.automaticallyChecksForUpdates)
+            }
+        }
+    }
+}

--- a/BiliKitMac/App/BiliKitMacApp.swift
+++ b/BiliKitMac/App/BiliKitMacApp.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 @main
 struct BiliKitMacApp: App {
+    @StateObject private var updater = AppUpdater()
     @State private var accountSessionCoordinator: AccountSessionCoordinator
     @State private var systemNowPlayingController = SystemNowPlayingController()
     @State private var appSettingsModel: AppSettingsModel
@@ -35,6 +36,9 @@ struct BiliKitMacApp: App {
             )
         }
         .defaultSize(width: 1_320, height: 820)
+        .commands {
+            AppUpdateCommands(updater: updater)
+        }
 
         Settings {
             PlaybackSourceSettingsView(model: appSettingsModel)

--- a/BiliKitMac/BiliKitMac.entitlements
+++ b/BiliKitMac/BiliKitMac.entitlements
@@ -6,6 +6,11 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
+	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>

--- a/BiliKitMac/Localizable.xcstrings
+++ b/BiliKitMac/Localizable.xcstrings
@@ -5184,7 +5184,147 @@
     "最近一周": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Past week" } }, "ja": { "stringUnit": { "state": "translated", "value": "過去1週間" } }, "zh-Hans": { "stringUnit": { "state": "translated", "value": "最近一周" } }, "zh-Hant": { "stringUnit": { "state": "translated", "value": "最近一週" } } } },
     "最近半年": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Past six months" } }, "ja": { "stringUnit": { "state": "translated", "value": "過去6か月" } }, "zh-Hans": { "stringUnit": { "state": "translated", "value": "最近半年" } }, "zh-Hant": { "stringUnit": { "state": "translated", "value": "最近半年" } } } },
     "自定义日期": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Custom range" } }, "ja": { "stringUnit": { "state": "translated", "value": "期間を指定" } }, "zh-Hans": { "stringUnit": { "state": "translated", "value": "自定义日期" } }, "zh-Hant": { "stringUnit": { "state": "translated", "value": "自訂日期" } } } },
-    "试看已结束，此视频为充电专属，BiliKit 暂不提供充电操作。": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "The preview has ended. This is a supporter-only video, and BiliKit does not currently offer supporter payments." } }, "ja": { "stringUnit": { "state": "translated", "value": "プレビューは終了しました。この動画は充電メンバー限定です。BiliKitは現在、充電操作に対応していません。" } }, "zh-Hans": { "stringUnit": { "state": "translated", "value": "试看已结束，此视频为充电专属，BiliKit 暂不提供充电操作。" } }, "zh-Hant": { "stringUnit": { "state": "translated", "value": "試看已結束，此影片為充電專屬，BiliKit 目前不提供充電操作。" } } } }
+    "试看已结束，此视频为充电专属，BiliKit 暂不提供充电操作。": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "The preview has ended. This is a supporter-only video, and BiliKit does not currently offer supporter payments." } }, "ja": { "stringUnit": { "state": "translated", "value": "プレビューは終了しました。この動画は充電メンバー限定です。BiliKitは現在、充電操作に対応していません。" } }, "zh-Hans": { "stringUnit": { "state": "translated", "value": "试看已结束，此视频为充电专属，BiliKit 暂不提供充电操作。" } }, "zh-Hant": { "stringUnit": { "state": "translated", "value": "試看已結束，此影片為充電專屬，BiliKit 目前不提供充電操作。" } } } },
+    "检查更新（尚未配置）": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates (Not Configured)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートを確認（未設定）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新（尚未配置）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢查更新（尚未設定）"
+          }
+        }
+      }
+    },
+    "检查更新（暂不可用）": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates (Unavailable)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートを確認（利用不可）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新（暂不可用）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢查更新（暫時無法使用）"
+          }
+        }
+      }
+    },
+    "检查更新…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートを確認…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢查更新⋯"
+          }
+        }
+      }
+    },
+    "自动检查更新": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically Check for Updates"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートを自動的に確認"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动检查更新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動檢查更新"
+          }
+        }
+      }
+    },
+    "自动下载并安装更新": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically Download and Install Updates"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートを自動的にダウンロードしてインストール"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动下载并安装更新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動下載並安裝更新"
+          }
+        }
+      }
+    }
   },
   "version": "1.2"
 }

--- a/BiliKitMac/Platform/AppUpdater.swift
+++ b/BiliKitMac/Platform/AppUpdater.swift
@@ -1,0 +1,74 @@
+import Combine
+import Foundation
+import Sparkle
+
+/// Owns Sparkle for the application process, independently of accounts and windows.
+@MainActor
+final class AppUpdater: ObservableObject {
+    @Published private(set) var canCheckForUpdates = false
+    @Published private(set) var automaticallyChecksForUpdates = false
+    @Published private(set) var automaticallyDownloadsUpdates = false
+    private(set) var isConfigured = false
+    private(set) var failedToStart = false
+
+    private var controller: SPUStandardUpdaterController?
+
+    init(info: [String: Any] = Bundle.main.infoDictionary ?? [:]) {
+        guard Self.hasValidConfiguration(info) else { return }
+        isConfigured = true
+        // Hosted tests must never start Sparkle's scheduler or touch update preferences.
+        guard NSClassFromString("XCTestCase") == nil else { return }
+        let controller = SPUStandardUpdaterController(
+            startingUpdater: false,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        self.controller = controller
+        do {
+            try controller.updater.start()
+            controller.updater.publisher(for: \.canCheckForUpdates)
+                .assign(to: &$canCheckForUpdates)
+            controller.updater.publisher(for: \.automaticallyChecksForUpdates)
+                .assign(to: &$automaticallyChecksForUpdates)
+            controller.updater.publisher(for: \.automaticallyDownloadsUpdates)
+                .assign(to: &$automaticallyDownloadsUpdates)
+        } catch {
+            // Configuration errors do not interrupt app launch or expose diagnostic URLs.
+            failedToStart = true
+        }
+    }
+
+    func checkForUpdates() {
+        guard canCheckForUpdates else { return }
+        controller?.checkForUpdates(nil)
+    }
+
+    func setAutomaticallyChecksForUpdates(_ enabled: Bool) {
+        controller?.updater.automaticallyChecksForUpdates = enabled
+    }
+
+    func setAutomaticallyDownloadsUpdates(_ enabled: Bool) {
+        controller?.updater.automaticallyDownloadsUpdates = enabled
+    }
+
+    static func hasValidConfiguration(_ info: [String: Any]) -> Bool {
+        guard info["BiliKitUpdaterEnabled"] as? Bool == true,
+            let feed = info["SUFeedURL"] as? String,
+            let url = URLComponents(string: feed),
+            url.scheme == "https",
+            let host = url.host, !host.isEmpty,
+            url.user == nil, url.password == nil,
+            url.query == nil, url.fragment == nil,
+            url.port == nil || url.port == 443,
+            url.path == "/appcast.xml",
+            let key = info["SUPublicEDKey"] as? String,
+            let decoded = Data(base64Encoded: key), decoded.count == 32,
+            info["SUEnableInstallerLauncherService"] as? Bool == true,
+            info["SUEnableDownloaderService"] as? Bool == false,
+            info["SUVerifyUpdateBeforeExtraction"] as? Bool == true,
+            info["SURequireSignedFeed"] as? Bool == true,
+            info["SUSignedFeedFailureExpirationInterval"] as? Int == 0
+        else { return false }
+        return true
+    }
+}

--- a/BiliKitMac/Resources/Licenses/Sparkle-LICENSE.txt
+++ b/BiliKitMac/Resources/Licenses/Sparkle-LICENSE.txt
@@ -1,0 +1,134 @@
+Copyright (c) 2006-2013 Andy Matuschak.
+Copyright (c) 2009-2013 Elgato Systems GmbH.
+Copyright (c) 2011-2014 Kornel Lesiński.
+Copyright (c) 2015-2017 Mayur Pawashe.
+Copyright (c) 2014 C.W. Betts.
+Copyright (c) 2014 Petroules Corporation.
+Copyright (c) 2014 Big Nerd Ranch.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+=================
+EXTERNAL LICENSES
+=================
+
+bspatch.c and bsdiff.c, from bsdiff 4.3 <http://www.daemonology.net/bsdiff/>:
+
+Copyright 2003-2005 Colin Percival
+All rights reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted providing that the following conditions 
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+--
+
+sais.c and sais.h, from sais-lite (2010/08/07) <https://sites.google.com/site/yuta256/sais>:
+
+The sais-lite copyright is as follows:
+
+Copyright (c) 2008-2010 Yuta Mori All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+--
+
+Portable C implementation of Ed25519, from https://github.com/orlp/ed25519
+
+Copyright (c) 2015 Orson Peters <orsonpeters@gmail.com>
+
+This software is provided 'as-is', without any express or implied warranty. In no event will the
+authors be held liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose, including commercial
+applications, and to alter it and redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the
+   original software. If you use this software in a product, an acknowledgment in the product
+   documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+   being the original software.
+
+3. This notice may not be removed or altered from any source distribution.
+
+--
+
+SUSignatureVerifier.m:
+
+Copyright (c) 2011 Mark Hamlin.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted providing that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/BiliKitMacTests/AppUpdaterTests.swift
+++ b/BiliKitMacTests/AppUpdaterTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+
+@testable import BiliKit
+
+@MainActor
+struct AppUpdaterTests {
+    private var configuredInfo: [String: Any] {
+        [
+            "BiliKitUpdaterEnabled": true,
+            "SUFeedURL": "https://updates.example.org/appcast.xml",
+            "SUPublicEDKey": Data(repeating: 1, count: 32).base64EncodedString(),
+            "SUEnableInstallerLauncherService": true,
+            "SUEnableDownloaderService": false,
+            "SUVerifyUpdateBeforeExtraction": true,
+            "SURequireSignedFeed": true,
+            "SUSignedFeedFailureExpirationInterval": 0,
+        ]
+    }
+
+    @Test
+    func incompleteConfigurationLeavesUpdaterUnavailable() {
+        let updater = AppUpdater(info: [:])
+        #expect(!updater.isConfigured)
+        #expect(!updater.canCheckForUpdates)
+        #expect(!updater.failedToStart)
+        updater.checkForUpdates()
+        var info = configuredInfo
+        info["BiliKitUpdaterEnabled"] = false
+        #expect(!AppUpdater.hasValidConfiguration(info))
+        info = configuredInfo
+        info["SUPublicEDKey"] = ""
+        #expect(!AppUpdater.hasValidConfiguration(info))
+        info["SUPublicEDKey"] = Data(repeating: 1, count: 31).base64EncodedString()
+        #expect(!AppUpdater.hasValidConfiguration(info))
+    }
+
+    @Test
+    func feedMustBeCredentialFreeHTTPSAndSigningMustBeEnabled() {
+        #expect(AppUpdater.hasValidConfiguration(configuredInfo))
+        for feed in [
+            "http://updates.example.org/appcast.xml",
+            "https://user@updates.example.org/appcast.xml",
+            "https://updates.example.org/appcast.xml?key=placeholder",
+            "https://updates.example.org/appcast.xml#fragment",
+            "https://updates.example.org:8080/appcast.xml",
+            "https://updates.example.org/",
+        ] {
+            var info = configuredInfo
+            info["SUFeedURL"] = feed
+            #expect(!AppUpdater.hasValidConfiguration(info))
+        }
+        for key in [
+            "SUEnableInstallerLauncherService", "SUVerifyUpdateBeforeExtraction",
+            "SURequireSignedFeed",
+        ] {
+            var info = configuredInfo
+            info[key] = false
+            #expect(!AppUpdater.hasValidConfiguration(info))
+        }
+        var info = configuredInfo
+        info["SUSignedFeedFailureExpirationInterval"] = 1
+        #expect(!AppUpdater.hasValidConfiguration(info))
+        info = configuredInfo
+        info["SUEnableDownloaderService"] = true
+        #expect(!AppUpdater.hasValidConfiguration(info))
+    }
+}

--- a/Configuration/BiliKit-Info.plist
+++ b/Configuration/BiliKit-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BiliKitUpdaterEnabled</key>
+	<true/>
+	<key>SUFeedURL</key>
+	<string>https://updates.shiinayane.com/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>HdIQTHoipGYzoK7LB+WioPkiQhqY/I6C1PZuZL1imEs=</string>
+	<key>SUEnableInstallerLauncherService</key>
+	<true/>
+	<key>SUEnableDownloaderService</key>
+	<false/>
+	<key>SUVerifyUpdateBeforeExtraction</key>
+	<true/>
+	<key>SURequireSignedFeed</key>
+	<true/>
+	<key>SUEnableSystemProfiling</key>
+	<false/>
+	<key>SUSignedFeedFailureExpirationInterval</key>
+	<integer>0</integer>
+</dict>
+</plist>

--- a/Scripts/check-architecture.sh
+++ b/Scripts/check-architecture.sh
@@ -64,4 +64,9 @@ if grep -R -n -E --include='*.swift' '^import SwiftProtobuf$' \
     exit 1
 fi
 
+check_forbidden_imports \
+    "Packages/BiliKitCore" \
+    '^import Sparkle$' \
+    "Sparkle 只能存在于 App target"
+
 echo "架构依赖边界检查通过"

--- a/Scripts/check-project-contract.sh
+++ b/Scripts/check-project-contract.sh
@@ -51,7 +51,7 @@ top_level_key_count=$(
     /usr/bin/plutil -p "$entitlements" \
         | awk '/^  "/ { total += 1 } END { print total + 0 }'
 )
-[ "$top_level_key_count" -eq 3 ] \
+[ "$top_level_key_count" -eq 4 ] \
     || fail "entitlements 出现未审计的额外能力"
 
 expect_count 2 'CODE_SIGN_ENTITLEMENTS = BiliKitMac/BiliKitMac.entitlements;' "$project" "App 配置必须使用同一 entitlement"
@@ -59,7 +59,8 @@ expect_count 6 'DEVELOPMENT_TEAM = 2B3LZ256AG;' "$project" "Project 与 target �
 expect_count 2 'PRODUCT_BUNDLE_IDENTIFIER = com.shiinayane.BiliKit;' "$project" "App Bundle Identifier 不一致"
 expect_count 2 'PRODUCT_NAME = BiliKit;' "$project" "App 产品名不一致"
 expect_count 2 'MARKETING_VERSION = 1.0.0;' "$project" "V1 marketing version 必须使用三段版本号"
-expect_count 4 'CURRENT_PROJECT_VERSION = 1;' "$project" "V1 初始工程 build number 不一致"
+expect_count 2 'CURRENT_PROJECT_VERSION = 3;' "$project" "Sparkle 候选 App build 必须递增为 3"
+expect_count 2 'CURRENT_PROJECT_VERSION = 1;' "$project" "测试 target build number 不一致"
 expect_count 2 'INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";' "$project" "App 类别元数据不一致"
 expect_count 2 'INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 shiinayane.";' "$project" "App 版权元数据不一致"
 expect_count 2 'ENABLE_APP_SANDBOX = YES;' "$project" "App Sandbox 必须启用"
@@ -88,3 +89,14 @@ sh -n Scripts/run-quality-gates.sh || fail "质量 Gate 脚本语法无效"
 sh -n Scripts/run-targeted-tests.sh || fail "定向测试脚本语法无效"
 
 echo "工程、安全能力与最低系统版本静态契约检查通过"
+
+[ "$(/usr/libexec/PlistBuddy -c 'Print :com.apple.security.temporary-exception.mach-lookup.global-name:0' "$entitlements")" = '$(PRODUCT_BUNDLE_IDENTIFIER)-spks' ] || fail "Sparkle status mach lookup 不一致"
+[ "$(/usr/libexec/PlistBuddy -c 'Print :com.apple.security.temporary-exception.mach-lookup.global-name:1' "$entitlements")" = '$(PRODUCT_BUNDLE_IDENTIFIER)-spki' ] || fail "Sparkle installer mach lookup 不一致"
+if /usr/libexec/PlistBuddy -c 'Print :com.apple.security.temporary-exception.mach-lookup.global-name:2' "$entitlements" >/dev/null 2>&1; then
+    fail "Sparkle mach lookup 只能授权两个精确服务"
+fi
+
+expect_count 2 'Configuration/BiliKit-Info.plist' "$project" "App 必须合并受审计的 Sparkle 配置"
+expect_count 1 'version = 2.9.6;' "$project" "Sparkle 必须精确锁版"
+expect_count 1 'kind = exactVersion;' "$project" "Sparkle 禁止浮动版本约束"
+/usr/bin/plutil -lint Configuration/BiliKit-Info.plist >/dev/null || fail "Sparkle Info.plist 无效"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # 第三方声明
 
-项目当前不打包第三方视觉资产，并使用以下源码 Package：
+项目当前不打包第三方视觉资产，并使用以下第三方依赖：
 
 ## SwiftProtobuf
 
@@ -14,3 +14,13 @@
 
 本地 `references/` 中的第三方研究 checkout 仅作为参考。其代码、注释、fixture、图标及其他
 受版权保护的资产均不属于 BiliKit，也不得进入产品、测试 fixture 或发布物。
+
+## Sparkle
+
+- 版本：精确固定为 2.9.6（revision `ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a`）
+- 来源：https://github.com/sparkle-project/Sparkle/tree/2.9.6
+- 用途：仅 App target 的标准自动更新 UI、下载、验签及 Installer XPC 安装。
+- 许可证：MIT；分发包同时包含 bsdiff、sais-lite、Ed25519 与 SUSignatureVerifier 的附属许可。
+- 版权、全部许可条件与免责声明原文随 App 资源打包：
+  [`Sparkle-LICENSE.txt`](BiliKitMac/Resources/Licenses/Sparkle-LICENSE.txt)。发布时保留该文件与 framework 自带资源。
+- SwiftPM 二进制 checksum：`8d5fb41d960b43f4a68aa14126bf62b098544ec8d191cdcc73eb14e63a8e7606`。

--- a/Updates/cloudflare/.gitignore
+++ b/Updates/cloudflare/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.wrangler/
+.dev.vars*
+.env*
+public/appcast.xml
+__pycache__/

--- a/Updates/cloudflare/README.md
+++ b/Updates/cloudflare/README.md
@@ -1,0 +1,88 @@
+# BiliKit HTTPS 更新源
+
+独立的 Cloudflare Workers Static Assets 目录。2026-09-05 已获用户授权并部署：
+Worker `bilikit-updates`，URL `https://updates.shiinayane.com/appcast.xml`。
+build 2 和 build 3 测试安装包已作为独立 GitHub prerelease 公开；线上双版本 feed/DMG 原始字节、哈希及公钥验签通过，
+HTTPS、缓存头和 404 行为通过。用户已确认 build 2→3 升级成功、版本正确且登录状态保留；失败矩阵仍待验证。
+
+只原样分发签名 feed，不包含 Worker 请求处理代码、DMG、私钥、用户凭据或 B 站代理。
+`workers_dev` 和 preview URLs 关闭，未知路径返回 404，不使用 SPA fallback。
+
+## 本地准备
+
+需要 Node.js 22+、npm、Python 3，以及发布 Mac 的 Xcode/Sparkle 2.9.6 工具。
+Wrangler 精确固定为 4.129.0，使用锁文件安装：
+
+```sh
+cd Updates/cloudflare
+npm ci
+npm test
+```
+
+1. 发布者在发布机运行官方 `generate_keys`，只让它在 login Keychain 生成/保存密钥。
+   完成加密备份和隔离恢复；不要把私钥粘贴到终端参数、聊天、仓库、CI 或 Cloudflare。
+2. 将工具打印的**公钥**填入本目录 `release.json` 的 `publicEDKey` 以及仓库
+   `Configuration/BiliKit-Info.plist` 的 `SUPublicEDKey`。确认最终域名后，再将后者
+   `BiliKitUpdaterEnabled` 改为 true。域名变更同时调整这两份配置、Wrangler route 与 `feed.py` 的 feed 契约。
+3. 在新 commit/build 上重新 Archive、Developer ID export、App/DMG 签名、公证和 staple。
+   不修改冻结的 1.0.0 (1) 候选。两个安装测试版本都必须带更新器；首次可用版本为 build 2，
+   下一测试版本至少为 build 3。每次更新同步工程 build 契约。
+4. 把一个新版本的最终完整 DMG 放入独立 release staging 目录。不要混放其他 tag 的归档。
+   用固定包中的官方工具生成并签名 appcast，例如（变量均为本机路径或公开 tag）：
+
+```sh
+"$SPARKLE_BIN/generate_appcast" \
+  --maximum-deltas 0 \
+  --download-url-prefix "https://github.com/shiinayane/BiliKit-Mac/releases/download/$RELEASE_TAG/" \
+  --embed-release-notes \
+  "$RELEASE_STAGING"
+```
+
+`SPARKLE_BIN` 是 Xcode SwiftPM artifact 中 `artifacts/sparkle/Sparkle/bin`。
+工具通过 Keychain 签名；`SURequireSignedFeed=true` 使官方工具同时签名 feed。
+第一次只发布完整包、不生成 delta，不使用远程 release notes。如需说明，使用同名内嵌 HTML
+片段，不包含远程资源。已有多版本 feed 的维护必须保留每个旧 asset URL，不能统一改到新 tag。
+
+5. 公钥与 feed 在 App 中一致后，做**纯本地**暂存和验签：
+
+```sh
+python3 feed.py stage --feed "$RELEASE_STAGING/appcast.xml" \
+  --app "$EXPORTED_APP" --archives "$RELEASE_STAGING"
+npm run dry-run
+```
+
+`stage` 验证 App 的签名/Gatekeeper/staple、公开配置、feed 签名和每个本地 DMG 的长度与
+Ed25519 签名，仅原样原子复制 appcast。Node 验签仅消费公钥；不调用会读取 Keychain 私钥的
+`sign_update --verify`。它不替代 Archive manifest 对 App、DMG 内容、Team、架构与 hash 的交叉复核。
+`validate`/`deploy` 再次检查 feed 签名与 public 文件白名单；它们不保留或上传 DMG。
+
+## 后续实际部署
+
+正式发布先完成安装失败矩阵。测试发布亦须确认固定 GitHub Release 资产已获准公开，且匿名下载可达、hash/字节数
+与 appcast 一致。草稿资产不是正式下载源。确认 Cloudflare 账户、域名所有权和费用后，由发布者
+使用 `wrangler login`；多账户时在本机选择/设置正确 account ID。不要提供 token 给聊天或仓库。
+
+```sh
+npm run deploy
+```
+
+这是唯一的一键外部部署步骤；会上传 `public` 并通过 Custom Domain route 创建/更新
+`updates.shiinayane.com` 的路由与 DNS。不可在未批准时运行。本次测试发布已获得授权，完成登录、部署和 Custom Domain 创建；
+后续发布按当次授权执行。不要覆盖旧安装资产。
+
+部署后匿名检查 HTTPS、`Content-Type`、缓存头、404 行为与 feed 原始字节/hash，并用公钥重验。
+appcast 浏览器缓存上限 300 秒，`no-transform` 防止内容转写；不要给 XML 开启修改响应正文的规则。
+Cloudflare 静态资产请求当前免费且不计动态 Worker 请求，单文件上限 25 MiB；本流程主动把 feed
+限制为 1 MiB，安装包继续在 GitHub。账户计划、域名费用和未来价格需要部署当日重新核对。
+
+停用时先移除更新项并重新签名部署（保留 HTTPS feed 可用）；不要覆盖旧资产或降低 build。
+需要彻底删除 Worker/域名时单独授权，已安装客户端将得到更新错误。失去 EdDSA 私钥时，
+由于关闭了签名失败超时降级，可能需要从可信发布页手动安装新签名公证版本恢复。
+
+官方资料：
+[Static Assets](https://developers.cloudflare.com/workers/static-assets/)、
+[配置](https://developers.cloudflare.com/workers/wrangler/configuration/)、
+[响应头](https://developers.cloudflare.com/workers/static-assets/headers/)、
+[费用](https://developers.cloudflare.com/workers/static-assets/billing-and-limitations/)、
+[上限](https://developers.cloudflare.com/workers/platform/limits/)、
+[Sparkle 发布](https://sparkle-project.org/documentation/)。

--- a/Updates/cloudflare/feed.py
+++ b/Updates/cloudflare/feed.py
@@ -71,6 +71,9 @@ def validate_feed(data, config, archives=None):
         enclosures = item.findall("enclosure")
         require(len(enclosures) == 1, "每个更新项需要一个完整安装包")
         enclosure = enclosures[0]
+        # Sparkle prefers the legacy enclosure attribute over the item element.
+        require(enclosure.get(f"{{{SPARKLE}}}version", version) == version,
+                "enclosure 与 item 的 build 必须完全一致")
         url = urlsplit(enclosure.attrib["url"])
         require(url.scheme == "https" and url.netloc == "github.com" and not url.query and not url.fragment,
                 "安装包必须来自无凭据的 GitHub HTTPS 地址")

--- a/Updates/cloudflare/feed.py
+++ b/Updates/cloudflare/feed.py
@@ -1,0 +1,141 @@
+"""Stage/validate public Sparkle metadata; never generate or read signing keys."""
+import argparse
+import base64
+import json
+import plistlib
+import re
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+ROOT = Path(__file__).resolve().parent
+SPARKLE = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+NS = {"s": SPARKLE}
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def decode(value, length):
+    data = base64.b64decode(value, validate=True)
+    require(len(data) == length, "签名或公钥长度不正确")
+    return data
+
+
+def verify(public_key, signature, data):
+    decode(public_key, 32)
+    decode(signature, 64)
+    result = subprocess.run(
+        ["node", str(ROOT / "verify.mjs")],
+        input=json.dumps({"publicKey": public_key, "signature": signature,
+                          "content": base64.b64encode(data).decode()}),
+        text=True, capture_output=True,
+    )
+    require(result.returncode == 0, "Ed25519 公钥验签失败")
+
+
+def validate_feed(data, config, archives=None):
+    require(len(data) <= 1024 * 1024, "appcast 超过 1 MiB 本地上限")
+    decode(config["publicEDKey"], 32)
+    require(config["feedURL"] == "https://updates.shiinayane.com/appcast.xml",
+            "feed 与候选 Cloudflare 路由不一致；变更域名需同步 App 与部署配置")
+    # Exact output envelope from Sparkle 2.9.6 common_cli/Signing.swift.
+    marker = b"<!-- sparkle-signatures:\n"
+    require(data.count(marker) == 1, "必须包含唯一的 Sparkle feed 签名")
+    content, block = data.split(marker)
+    match = re.fullmatch(rb"edSignature: ([A-Za-z0-9+/]{86}==)\nlength: ([0-9]+)\n-->\n", block)
+    require(match is not None, "feed 签名封装不是固定版本官方工具的输出")
+    require(int(match[2]) == len(content), "feed 签名长度不匹配")
+    verify(config["publicEDKey"], match[1].decode(), content)
+    require(b"<!DOCTYPE" not in content and b"<!ENTITY" not in content, "不接受 XML DTD/entity")
+    root = ET.fromstring(content)
+    require(root.tag == "rss" and root.attrib.get("version") == "2.0", "需要 RSS 2.0")
+    require(len(root.findall("channel")) == 1, "需要单一 channel")
+    items = root.findall("channel/item")
+    # First release uses full immutable GitHub assets and no remote release notes.
+    require(not root.findall(".//s:deltas", NS), "当前发布流程只允许完整包")
+    require(not root.findall(".//s:releaseNotesLink", NS), "请使用内嵌发布说明")
+    require(not root.findall(".//s:fullReleaseNotesLink", NS), "请使用内嵌发布说明")
+    versions = set()
+    for item in items:
+        version = item.findtext("s:version", namespaces=NS)
+        require(version is not None and re.fullmatch(r"[1-9][0-9]*", version), "需要正整数 build")
+        require(int(version) >= 2 and version not in versions, "build 必须唯一且至少为 2")
+        versions.add(version)
+        require(item.findtext("s:minimumSystemVersion", namespaces=NS) == "15.0", "最低系统必须为 15.0")
+        enclosures = item.findall("enclosure")
+        require(len(enclosures) == 1, "每个更新项需要一个完整安装包")
+        enclosure = enclosures[0]
+        url = urlsplit(enclosure.attrib["url"])
+        require(url.scheme == "https" and url.netloc == "github.com" and not url.query and not url.fragment,
+                "安装包必须来自无凭据的 GitHub HTTPS 地址")
+        parts = url.path.split("/")
+        require(len(parts) == 7 and parts[1:5] == ["shiinayane", "BiliKit-Mac", "releases", "download"],
+                "安装包必须属于批准的仓库 release asset")
+        require(parts[5] and not parts[5].startswith("untagged-") and parts[5] != "latest", "不接受草稿或可变 tag")
+        filename = unquote(parts[6])
+        require(re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*\.dmg", filename), "只允许简单文件名的 DMG")
+        signature = enclosure.attrib[f"{{{SPARKLE}}}edSignature"]
+        decode(signature, 64)
+        length = int(enclosure.attrib["length"])
+        require(length > 0, "安装包长度无效")
+        if archives is not None:
+            archive = archives / filename
+            require(archive.is_file() and not archive.is_symlink(), "缺少本地完整安装包")
+            require(archive.stat().st_size == length, "安装包长度不匹配")
+            verify(config["publicEDKey"], signature, archive.read_bytes())
+    return len(items)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("validate")
+    stage = commands.add_parser("stage")
+    stage.add_argument("--feed", type=Path, required=True)
+    stage.add_argument("--app", type=Path, required=True, help="新导出的 Developer ID App")
+    stage.add_argument("--archives", type=Path, required=True)
+    args = parser.parse_args()
+    config = json.loads((ROOT / "release.json").read_text())
+    public = ROOT / "public"
+    require(not public.is_symlink(), "public 不得为符号链接")
+    for path in public.iterdir():
+        require(path.name in {"_headers", "appcast.xml"} and path.is_file() and not path.is_symlink(),
+                "public 只允许 _headers 和 appcast.xml，不允许目录、凭据或安装包")
+    if args.command == "stage":
+        info = plistlib.loads((args.app / "Contents/Info.plist").read_bytes())
+        require(info.get("CFBundleIdentifier") == "com.shiinayane.BiliKit", "App 身份不一致")
+        require(info.get("BiliKitUpdaterEnabled") is True, "App 更新器未启用")
+        require(info.get("SURequireSignedFeed") is True and info.get("SUVerifyUpdateBeforeExtraction") is True,
+                "App 必须强制 feed 与归档验签")
+        require(info.get("SUSignedFeedFailureExpirationInterval") == 0, "feed 签名失败不得超时降级")
+        require(info.get("SUFeedURL") == config["feedURL"], "App 与部署 feed 不一致")
+        require(info.get("SUPublicEDKey") == config["publicEDKey"], "App 与部署公钥不一致")
+        for command in [
+            ["codesign", "--verify", "--deep", "--strict", str(args.app)],
+            ["spctl", "--assess", "--type", "execute", str(args.app)],
+            ["xcrun", "stapler", "validate", str(args.app)],
+        ]:
+            subprocess.run(command, check=True, stdout=subprocess.DEVNULL)
+        data = args.feed.read_bytes()
+        count = validate_feed(data, config, args.archives)
+        with tempfile.NamedTemporaryFile(dir=public, delete=False) as target:
+            target.write(data)
+            temporary = Path(target.name)
+        temporary.replace(public / "appcast.xml")
+        print(f"已原样暂存 {count} 个已验签更新项；未上传或部署。")
+    else:
+        count = validate_feed((public / "appcast.xml").read_bytes(), config)
+        print(f"{count} 个更新项：feed 公钥验签与静态上传边界通过。")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (ValueError, KeyError, OSError, ET.ParseError, subprocess.CalledProcessError):
+        sys.exit("更新源验证失败：配置、签名或输入不符合要求；未部署。")

--- a/Updates/cloudflare/package-lock.json
+++ b/Updates/cloudflare/package-lock.json
@@ -1,0 +1,1542 @@
+{
+  "name": "bilikit-update-feed",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bilikit-update-feed",
+      "version": "1.0.0",
+      "devDependencies": {
+        "wrangler": "4.129.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260903.1.tgz",
+      "integrity": "sha512-FG+4mGxAXhKiL/1temH42alevIkumtYXNidhTa//3yULpzux6APw5UNVocI/vCQ1yG1YOEZRfbVy8lyuipM9MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260903.1.tgz",
+      "integrity": "sha512-o241VefnjG8eG+kGap5CjgV4zOT5UaAmS3OR1VZCpNj7vkXGxvp9KftKvtQgcCsIqJKaKx+7Xd7xq0L1DjkfPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260903.1.tgz",
+      "integrity": "sha512-/VEvvtQ/XKf6HlBbg6FbvpwcpfYUcx6Fv6RkASY8DyEmUyuJ8rc7Qxil83ClRFoBzz/GY0BV94UZ6F+wers/hg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260903.1.tgz",
+      "integrity": "sha512-OWhihGC6KoTXF4u2C1AonfpgXeM4/7p/1IXuALqXESmFUpLLP5gZhRzjSk/gWW+mrCZDfSrvnjifl+lRqselbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260903.1.tgz",
+      "integrity": "sha512-soPMF9/aMHlHKK7M0vq5HrRRicPbnZO1F6ZZ7JWN8EltxWJU5L7CEq7CxjO878DzyPx7gYvqBFy3SVgdZKZjMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260903.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260903.0-alpha.tgz",
+      "integrity": "sha512-VCZIFxOqFXeibRBJWwTlppqbv2lkeO10IX3QBRGK9j1QiMAfH/OSsCvbjp1MslBMhVZmy2VTRlVaVnsKnbDp6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260903.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260903.1.tgz",
+      "integrity": "sha512-xJzt2RnCy7ulOULmZy/4JLbEPg1uisp9lVoOUsEz+UVhDsTmrSQ0rBXZMGcXuhr2HCGKs89bg8nnbbzvBSX1Ig==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260903.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260903.1",
+        "@cloudflare/workerd-linux-64": "1.20260903.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260903.1",
+        "@cloudflare/workerd-windows-64": "1.20260903.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.129.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.129.0.tgz",
+      "integrity": "sha512-PGPvs9UPoFrwxT0VogpESSZGvZIctAuTK3wGsLLPHtHsSgS85kNdvtpa2d14UzG8gwLWD64XUGFPGG9tOXG9VQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260903.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260903.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260903.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/Updates/cloudflare/package.json
+++ b/Updates/cloudflare/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bilikit-update-feed",
+  "private": true,
+  "version": "1.0.0",
+  "engines": { "node": ">=22" },
+  "scripts": {
+    "test": "python3 -m unittest discover -s tests",
+    "validate": "python3 feed.py validate",
+    "preview": "npm run validate && wrangler dev --local",
+    "dry-run": "npm run validate && wrangler deploy --dry-run",
+    "deploy": "npm run validate && wrangler deploy"
+  },
+  "devDependencies": { "wrangler": "4.129.0" }
+}

--- a/Updates/cloudflare/public/_headers
+++ b/Updates/cloudflare/public/_headers
@@ -1,0 +1,5 @@
+/appcast.xml
+  Content-Type: application/rss+xml; charset=utf-8
+  Cache-Control: public, max-age=300, no-transform
+  X-Content-Type-Options: nosniff
+  Content-Security-Policy: default-src 'none'

--- a/Updates/cloudflare/release.json
+++ b/Updates/cloudflare/release.json
@@ -1,0 +1,4 @@
+{
+  "feedURL": "https://updates.shiinayane.com/appcast.xml",
+  "publicEDKey": "HdIQTHoipGYzoK7LB+WioPkiQhqY/I6C1PZuZL1imEs="
+}

--- a/Updates/cloudflare/tests/test_feed.py
+++ b/Updates/cloudflare/tests/test_feed.py
@@ -1,0 +1,78 @@
+import base64
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from feed import validate_feed
+
+
+class FeedTests(unittest.TestCase):
+    def signed_feed(self, url=None, empty=False):
+        # Test keys live only in this subprocess's memory. No production key or Keychain access.
+        source = r'''
+const {generateKeyPairSync, sign} = require('node:crypto');
+const {publicKey, privateKey} = generateKeyPairSync('ed25519');
+const archive = Buffer.from('test archive bytes');
+const url = process.argv[1];
+let xml = Buffer.from(`<?xml version="1.0"?><rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel><item><sparkle:version>2</sparkle:version><sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion><enclosure url="${url}" length="${archive.length}" sparkle:edSignature="${sign(null, archive, privateKey).toString('base64')}" /></item></channel></rss>\n`);
+if (process.argv[2] === 'empty') xml = Buffer.from('<?xml version="1.0"?><rss version="2.0"><channel /></rss>\n');
+const envelope = `<!-- sparkle-signatures:\nedSignature: ${sign(null, xml, privateKey).toString('base64')}\nlength: ${xml.length}\n-->\n`;
+process.stdout.write(JSON.stringify({
+  key: publicKey.export({format:'der',type:'spki'}).subarray(-32).toString('base64'),
+  feed: Buffer.concat([xml, Buffer.from(envelope)]).toString('base64')
+}));
+'''
+        result = subprocess.run([
+            "node", "-e", source,
+            url or "https://github.com/shiinayane/BiliKit-Mac/releases/download/v1.0.0-build.2/BiliKit-2.dmg",
+            "empty" if empty else "full",
+        ], check=True, capture_output=True, text=True)
+        fixture = json.loads(result.stdout)
+        return base64.b64decode(fixture["feed"]), {
+            "publicEDKey": fixture["key"],
+            "feedURL": "https://updates.shiinayane.com/appcast.xml",
+        }
+
+    def test_valid_feed_and_archive_signatures(self):
+        data, config = self.signed_feed()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)
+            (path / "BiliKit-2.dmg").write_bytes(b"test archive bytes")
+            self.assertEqual(validate_feed(data, config, path), 1)
+            (path / "BiliKit-2.dmg").write_bytes(b"fake archive bytes")
+            with self.assertRaises(ValueError):
+                validate_feed(data, config, path)
+
+    def test_feed_tampering_is_rejected(self):
+        data, config = self.signed_feed()
+        with self.assertRaises(ValueError):
+            validate_feed(data.replace(b"<sparkle:version>2", b"<sparkle:version>3"), config)
+
+    def test_unsigned_feed_and_trailing_content_are_rejected(self):
+        data, config = self.signed_feed()
+        for invalid in [data.split(b"<!-- sparkle-signatures:")[0], data + b"extra"]:
+            with self.assertRaises(ValueError):
+                validate_feed(invalid, config)
+
+    def test_wrong_public_key_is_rejected(self):
+        data, _ = self.signed_feed()
+        _, other_config = self.signed_feed()
+        with self.assertRaises(ValueError):
+            validate_feed(data, other_config)
+
+    def test_signed_feed_cannot_publish_disallowed_asset(self):
+        for url in [
+            "https://github.com/shiinayane/BiliKit-Mac/releases/download/untagged-123/BiliKit-2.dmg",
+            "https://github.com/other/BiliKit-Mac/releases/download/v2/BiliKit-2.dmg",
+            "https://updates.shiinayane.com/BiliKit-2.dmg",
+            "http://github.com/shiinayane/BiliKit-Mac/releases/download/v2/BiliKit-2.dmg",
+        ]:
+            data, config = self.signed_feed(url)
+            with self.assertRaises(ValueError):
+                validate_feed(data, config)
+
+    def test_signed_empty_feed_can_pause_offering_updates(self):
+        data, config = self.signed_feed(empty=True)
+        self.assertEqual(validate_feed(data, config), 0)

--- a/Updates/cloudflare/tests/test_feed.py
+++ b/Updates/cloudflare/tests/test_feed.py
@@ -9,14 +9,16 @@ from feed import validate_feed
 
 
 class FeedTests(unittest.TestCase):
-    def signed_feed(self, url=None, empty=False):
+    def signed_feed(self, url=None, empty=False, enclosure_version=None):
         # Test keys live only in this subprocess's memory. No production key or Keychain access.
         source = r'''
 const {generateKeyPairSync, sign} = require('node:crypto');
 const {publicKey, privateKey} = generateKeyPairSync('ed25519');
 const archive = Buffer.from('test archive bytes');
 const url = process.argv[1];
-let xml = Buffer.from(`<?xml version="1.0"?><rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel><item><sparkle:version>2</sparkle:version><sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion><enclosure url="${url}" length="${archive.length}" sparkle:edSignature="${sign(null, archive, privateKey).toString('base64')}" /></item></channel></rss>\n`);
+const enclosureVersion = JSON.parse(process.argv[3]);
+const versionAttribute = enclosureVersion === null ? '' : ` sparkle:version="${enclosureVersion}"`;
+let xml = Buffer.from(`<?xml version="1.0"?><rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel><item><sparkle:version>2</sparkle:version><sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion><enclosure${versionAttribute} url="${url}" length="${archive.length}" sparkle:edSignature="${sign(null, archive, privateKey).toString('base64')}" /></item></channel></rss>\n`);
 if (process.argv[2] === 'empty') xml = Buffer.from('<?xml version="1.0"?><rss version="2.0"><channel /></rss>\n');
 const envelope = `<!-- sparkle-signatures:\nedSignature: ${sign(null, xml, privateKey).toString('base64')}\nlength: ${xml.length}\n-->\n`;
 process.stdout.write(JSON.stringify({
@@ -28,6 +30,7 @@ process.stdout.write(JSON.stringify({
             "node", "-e", source,
             url or "https://github.com/shiinayane/BiliKit-Mac/releases/download/v1.0.0-build.2/BiliKit-2.dmg",
             "empty" if empty else "full",
+            json.dumps(enclosure_version),
         ], check=True, capture_output=True, text=True)
         fixture = json.loads(result.stdout)
         return base64.b64decode(fixture["feed"]), {
@@ -44,6 +47,17 @@ process.stdout.write(JSON.stringify({
             (path / "BiliKit-2.dmg").write_bytes(b"fake archive bytes")
             with self.assertRaises(ValueError):
                 validate_feed(data, config, path)
+
+    def test_signed_conflicting_enclosure_version_is_rejected(self):
+        for version in ["1", "3", "02", ""]:
+            with self.subTest(enclosure_version=version):
+                data, config = self.signed_feed(enclosure_version=version)
+                with self.assertRaisesRegex(ValueError, "enclosure.*build"):
+                    validate_feed(data, config)
+
+    def test_signed_matching_enclosure_version_is_accepted(self):
+        data, config = self.signed_feed(enclosure_version="2")
+        self.assertEqual(validate_feed(data, config), 1)
 
     def test_feed_tampering_is_rejected(self):
         data, config = self.signed_feed()

--- a/Updates/cloudflare/verify.mjs
+++ b/Updates/cloudflare/verify.mjs
@@ -1,0 +1,14 @@
+// Public-key-only verification. This process never accesses a Keychain or private key.
+import { createPublicKey, verify } from 'node:crypto';
+let input = '';
+for await (const chunk of process.stdin) input += chunk;
+const { publicKey, signature, content } = JSON.parse(input);
+const key = createPublicKey({
+  key: Buffer.concat([
+    Buffer.from('302a300506032b6570032100', 'hex'),
+    Buffer.from(publicKey, 'base64'),
+  ]),
+  format: 'der',
+  type: 'spki',
+});
+process.exit(verify(null, Buffer.from(content, 'base64'), key, Buffer.from(signature, 'base64')) ? 0 : 1);

--- a/Updates/cloudflare/wrangler.jsonc
+++ b/Updates/cloudflare/wrangler.jsonc
@@ -1,0 +1,16 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "bilikit-updates",
+  "compatibility_date": "2026-09-05",
+  "workers_dev": false,
+  "preview_urls": false,
+  "routes": [
+    { "pattern": "updates.shiinayane.com", "custom_domain": true }
+  ],
+  "assets": {
+    "directory": "./public",
+    "html_handling": "none",
+    "not_found_handling": "none"
+  },
+  "observability": { "enabled": false }
+}

--- a/docs/release/CHECKLIST.md
+++ b/docs/release/CHECKLIST.md
@@ -47,19 +47,31 @@
 - [ ] 发布资产不可变；不覆盖同名文件，坏版本只用更高 build 前向修复。
 - [ ] 发布 workflow（若有）使用完整 action SHA、最小权限且不提前持有发布秘密。
 
-## E. Sparkle（只有 B–D 基线通过后）
+## E. Sparkle（已授权实现；正式发布仍须完成适用 B–D Gate）
+
+2026-09-05：原 build 1 保持冻结；用户已完成 build 2→3 升级，确认版本 1.0.0 (3) 与登录状态保留。
+本机正常路径通过不替代不同用户、真实 Intel/macOS 15、Translocation 或异常恢复验证。
+详细证据与来源限制见 [接入与验收记录](SPARKLE-INTEGRATION-2026-09-05.md)。
 
 - [ ] 实施当日重新核对 Sparkle 稳定版、安全公告、最低系统与 license 并精确锁定。
-- [ ] Sparkle 只进入 App target，进程级 updater owner 唯一。
-- [ ] 只启用 Installer XPC 和必需沙箱例外，不启用无需求的 Downloader XPC。
-- [ ] framework、XPC、Autoupdate 与 Updater 的双架构、签名、runtime 和 entitlement 通过。
+- [x] Sparkle 只进入 App target，进程级 updater owner 唯一。
+- [x] 只启用 Installer XPC 和必需沙箱例外，不启用无需求的 Downloader XPC。
+- [x] framework、XPC、Autoupdate 与 Updater 的双架构、签名、runtime 和 entitlement 通过。
 - [ ] EdDSA key 的 Keychain 保存、离线备份与恢复通过；私钥不进入仓库／CI／Cloudflare。
-- [ ] `SUPublicEDKey`、HTTPS feed 与签名要求正确，appcast 由官方工具生成。
-- [ ] 两个真实 Developer ID 版本完成完整包 v1→v2、损坏／错误签名／旧 build／错误架构失败矩阵。
+- [x] `SUPublicEDKey`、HTTPS feed 与签名要求正确，appcast 由官方工具生成。
+- [x] 用户确认两个真实 Developer ID 版本完成完整包 build 2→3 升级，版本正确且登录状态保留。
+- [ ] 损坏／错误签名／旧 build／错误架构失败矩阵通过。
 - [ ] 离线、超时、404/500、中断、磁盘不足、权限拒绝和重启清理不破坏现有 App。
 - [ ] 新依赖的 Privacy Manifest、第三方 notice、日志和诊断边界复核通过。
 
-## F. 可选 Cloudflare 停止条件
+## F. Cloudflare 更新源（2026-09-05 已授权测试部署）
 
-- [ ] 静态 appcast 存在已证明的域名稳定性或故障隔离缺口；没有则停止，不建 Worker。
-- [ ] 若立项，重新完成官方资料、成本、滥用、缓存、DNS、停用和零凭据设计审查。
+- [x] 用户授权独立 Wrangler 目录准备，域名 `shiinayane.com` 已托管。
+- [x] 最终 Worker、账户、子域名、公开资产与公钥已确认。
+- [x] 本地官方工具生成签名 feed，DMG 与 feed 公钥验证、dry-run 通过。
+- [x] 两个带更新器的签名公证版本正常升级通过（用户报告）。
+- [ ] 更新失败矩阵通过。
+- [x] 部署前重新确认成本、缓存、DNS、停用与零凭据边界，并取得实际部署授权。
+- [x] 部署后匿名 HTTPS、原始字节/hash、缓存头和 404 通过；强制验签配置下真实升级成功（用户报告）。
+
+正常升级与登录保留已由用户确认；组合项中的失败矩阵仍未完成，不据此勾选完整正式发布验收。

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -1,6 +1,6 @@
 # V1 Developer ID 发布准备
 
-状态：当前执行入口；explicit App ID 工单待 Apple Developer Support 处理
+状态：当前执行入口；无更新器基线已完成签名公证，Sparkle build 2→3 已完成本机正常升级与登录保留验收（用户报告），正式发布剩余 Gate 仍待完成。
 
 ## 已冻结事实
 
@@ -12,22 +12,22 @@
   network server、单一 Keychain access group；
 - 载体：只读 DMG；当前不需要 Developer ID Installer certificate；
 - 当前发布 Mac 已有有效 `Developer ID Application: YANKAI WANG (2B3LZ256AG)` identity；
-- `BiliKit-Notary` Keychain profile 已通过 Apple validation，公证历史为空；
-- 首个基线成品不含 Sparkle，不部署 Cloudflare Worker。
+- `BiliKit-Notary` 已用于无更新器基线与 Sparkle 测试 App 的公证提交；凭据可用性每次实际执行时核对；
+- 冻结的首个基线成品 `1.0.0 (1)` 不含 Sparkle。2026-09-05 已授权独立 worktree 接入
+  更新器并准备 Cloudflare 静态更新源；实现授权不豁免剩余安装 Gate 或授权公开部署。
 
 证书指纹、submission ID、机器路径和最终哈希只进入每次发布候选的
 [`MANIFEST.md`](./MANIFEST.md) 副本；私钥、`.p12` 密码、App 专用密码和 API key 永不进入仓库。
 
-## 当前阻塞
+## 身份证据与历史问题
 
-正式 Team 只有 wildcard App ID。手工注册 explicit App ID `com.shiinayane.BiliKit` 返回
-`not available`，App Store Connect 没有 App；Apple Developer Support 工单正在调查旧 Personal
-Team 或残留登记。在 Apple 明确归属前：
+早期 explicit App ID 注册曾返回 `not available`，因此当时停止正式归档与发布。
+2026-09-05 的基线导出成品已获得 Developer ID 公证；本次重新读取其 profile，确认 Team
+`2B3LZ256AG`、App ID `2B3LZ256AG.com.shiinayane.BiliKit` 及有效期。
+这以实际签名成品为依据，不表示 Apple 工单状态已另行查询。
 
-- 不修改稳定 Bundle ID；
-- 不把 wildcard development profile 当作正式身份；
-- 不生成最终 Release archive、公开 DMG、release 或 appcast；
-- 可以维护文档、备份现有证书、运行无签名 Release compile 和准备真实 Intel 环境。
+新候选继续逐项核对最终 entitlement、profile、Keychain group 与嵌套签名。
+未经提交的源码快照只能用于明确标注的内部测试，不能替代下述正式发布的 clean commit 冻结。
 
 ## 严格发布顺序
 
@@ -120,8 +120,9 @@ Rosetta、Intel CI、arm64 CI、build、截图和旧验证记录都不能替代�
 
 ## 更新器与 Cloudflare 边界
 
-无更新器的 Developer ID 基线成功后，更新器候选为 Sparkle 2，当时重新核对官方最新稳定版本、
-安全公告、最低系统与 license。若实施：
+2026-09-05 的更新器精确锁定 Sparkle 2.9.6，App build 已递增为 3；
+原 build 1 与已公证 DMG 保持冻结。更新器已启用，HTTPS feed 已授权上线，
+用户已确认 build 2→3 升级及登录保留；失败矩阵与跨系统安装验收仍待完成。实现遵循：
 
 - Sparkle 只进入 App target，由进程级唯一 owner 持有，不进入 `BiliApplication` 或 Feature；
 - 使用标准 UI、Installer XPC、Developer ID code signing 与 EdDSA，不自研下载替换器；
@@ -129,8 +130,9 @@ Rosetta、Intel CI、arm64 CI、build、截图和旧验证记录都不能替代�
 - 先用两个真实 Developer ID 测试版本完成完整包 v1→v2 和失败矩阵；V1 不以 delta 代替；
 - 更新失败不得影响现有 App 启动、认证、播放、设置或 Keychain。
 
-Cloudflare Worker 默认不部署。只有静态 HTTPS appcast 出现已证明的域名稳定性或故障隔离需求时才
-重新立项；届时重新读取官方 pricing/limits。它只能原样分发已签名 appcast，零用户凭据、零 EdDSA
-私钥、零大文件代理、零 B 站 API／媒体代理。
+用户已授权准备并部署独立 [Wrangler 更新源目录](../../Updates/cloudflare/README.md)，地址为
+`updates.shiinayane.com`。只原样分发已签名 appcast，零用户凭据、零 EdDSA 私钥、零大文件代理、
+零 B 站 API／媒体代理。build 2/3 为已授权公开的测试 prerelease；正式发布仍遵循当次授权与发布 Gate。
+配置、失钥恢复与失败边界见 [更新安全模型](../security/app-updates.md)。
 
 逐项执行以 [`CHECKLIST.md`](./CHECKLIST.md) 为准。

--- a/docs/release/SPARKLE-INTEGRATION-2026-09-05.md
+++ b/docs/release/SPARKLE-INTEGRATION-2026-09-05.md
@@ -1,0 +1,72 @@
+# Sparkle / Cloudflare 接入与验收记录
+
+日期：2026-09-05（Asia/Tokyo）。范围：Sparkle 2.9.6、完整 DMG 更新及静态 HTTPS appcast。
+
+## 当前结果
+
+用户已通过 build 2 的更新器升级到 `1.0.0 (3)`，并确认原登录状态保留。
+这是本机正常升级路径的用户验收结果；不是异常恢复、跨用户或跨系统的完整验收。
+
+- [build 2 测试发布](https://github.com/shiinayane/BiliKit-Mac/releases/tag/v1.0.0-sparkle-test.2)
+- [build 3 测试发布](https://github.com/shiinayane/BiliKit-Mac/releases/tag/v1.0.0-sparkle-test.3)
+- [线上更新源](https://updates.shiinayane.com/appcast.xml)，Worker `bilikit-updates`。
+
+测试二进制来自基于 `b177f05b3f8fda7788a580cfb4f5d22e0481bed7` 的未提交源码快照。
+两个测试 tag 指向该基线；GitHub 自动生成源码归档不包含 Sparkle 改动，此限制已写入公开发布说明。
+后续源码提交不改变既有二进制来源。正式候选必须从冻结 commit 使用更高 build 重新构建。
+
+## 实现与安全边界
+
+- Sparkle 仅链接 App target，精确固定 2.9.6；App 进程唯一 `AppUpdater` 持有标准 controller。
+- 菜单提供检查更新、自动检查、自动下载并安装设置；偏好、调度、下载、安装和重启交由 Sparkle。
+- 更新器已启用；公钥与 HTTPS feed 在 App 配置和部署配置中一致。
+- 强制 feed 签名与解包前归档验签，签名失败不允许超时降级；不采集 Sparkle system profile。
+- 仅启用 Installer XPC 的两个精确 mach lookup；Downloader XPC 随框架打包但不启用，不增加 runtime exception。
+- Cloudflare 只分发已签名 appcast；安装包使用 GitHub 独立版本资产，不覆盖旧包，无 B 站或媒体代理。
+- 公钥可公开；发布私钥只由官方工具访问 Keychain，未进入聊天、仓库、日志或 Cloudflare。
+
+## 验证证据
+
+| 项目 | 已取得的证据 | 限制 |
+| --- | --- | --- |
+| 完整 App Gate（build 2） | 666 Package tests / 69 suites，184 App tests passed | 1 signed Keychain smoke skipped；不替代真实安装 |
+| build 3 构建 | 仅递增 build 2→3；static Gate、新 Universal Archive 与导出通过 | 不把 build 2 测试计作 build 3 新测试 |
+| 更新源校验 | 6 项测试覆盖 feed/归档验签、篡改、错误公钥、无签名/尾随内容、非批准资产、签名空 feed | 本地拒绝测试不替代 Sparkle 客户端失败矩阵 |
+| App/DMG 签名与公证 | 两个版本均完成 Developer ID、完整公证日志无问题项、staple；最终包 Gatekeeper 通过 | 仅本次成品 |
+| 产物身份 | 六个 Mach-O 双架构、runtime、timestamp、entitlement/profile；DMG 包内 App 哈希及链接一致 | 不证明真实 Intel 运行 |
+| 线上分发 | GitHub 匿名下载字节/hash 一致并重验签名、公证；Cloudflare HTTPS、原始字节、签名、缓存头、404 通过 | 未开启 GitHub 仓库级 immutable；后续不可覆盖资产 |
+| 正常更新 | 用户先确认 build 2 安装及更新器入口，再报告“已更新，现在显示1.0.0(3)” | 用户报告；未采集屏幕或运行时日志 |
+| 登录状态 | 用户明确确认升级后登录状态保留 | 未读取凭据；不等同于完整 Keychain 恢复、登出与重装测试 |
+
+原无更新器 build 1 及其发布资产保持冻结；build 1 不能自行发起 Sparkle 更新。
+详细机器证据和源码快照保存在 gitignored `docs/_local/release/sparkle-test-1.0.0-{2,3}-2026-09-05/`，
+不随源码提交。最终安装包校验和也随各测试 Release 发布。
+
+## 本次提交前复核
+
+2026-09-05 对最终暂存实现运行一次完整 `sh Scripts/run-quality-gates.sh app`：static、
+666 Package tests / 69 suites、App build-for-testing 与 184 App tests 全部通过；
+1 项 signed Keychain smoke 因无签名 host 跳过。保留既有 sidebar 测试未使用返回值 warning。
+更新源 6 项测试、当前双版本 feed 公钥验证及暂存秘密/差异检查通过。
+
+逐文件核对 App 构建输入与已验收 build 3 快照完全一致。本轮收尾只更新验收文档，以及
+为上游许可证原文的既有行尾空格添加单文件 Git 检查例外。未改写已发布 App/DMG 或在线 feed。
+DanmakuLab 的 Xcode 锁文件旁支改动保留在提交之外；临时测试产物按 Gate 清理。
+
+## 签名密钥恢复
+
+已核对备份所在磁盘映像处于加密状态，备份文件存在且非空。官方 `generate_keys -f` 将备份
+导入 UUID 命名的独立 Keychain 测试条目；丢弃导入输出，只读取公钥并核对与 App 一致。
+随后删除临时条目并确认不存在，正式密钥未修改，备份卷已推出。
+
+这证明当前 Mac 的隔离条目恢复可行，不证明异机恢复、离线副本或密码的独立保管。
+签名密钥丢失时，当前拒绝降级策略可能需要人工安装恢复。
+
+## 尚未完成
+
+- 从冻结源码 commit 构建正式候选，使源码、tag、版本与二进制来源对应。
+- Sparkle 客户端损坏包、错误签名、旧 build、错误架构、断网、超时、404/500、下载中断、磁盘不足与权限拒绝测试。
+- 真实 Intel/macOS 15、不同 macOS 用户、DMG 内启动/Translocation、离线票据、重装和签名 Keychain smoke。
+- Developer ID 私钥备份恢复、发布与恢复责任人，以及面向用户的人工恢复说明等发布清单剩余项。
+
+步骤见 [更新源 README](../../Updates/cloudflare/README.md)，信任边界见 [更新安全模型](../security/app-updates.md)。

--- a/docs/release/SPARKLE-INTEGRATION-2026-09-05.md
+++ b/docs/release/SPARKLE-INTEGRATION-2026-09-05.md
@@ -70,3 +70,11 @@ DanmakuLab 的 Xcode 锁文件旁支改动保留在提交之外；临时测试�
 - Developer ID 私钥备份恢复、发布与恢复责任人，以及面向用户的人工恢复说明等发布清单剩余项。
 
 步骤见 [更新源 README](../../Updates/cloudflare/README.md)，信任边界见 [更新安全模型](../security/app-updates.md)。
+
+## 推送前 agent 审核修复
+
+独立审核发现部署校验只读取 item build，而 Sparkle 优先读取 enclosure 版本属性。
+现要求该可选属性与已验证的 item build 完全一致；冲突、空值与前导零差异均拒绝。
+合法临时签名的回归测试在旧实现失败，修复后 8 项更新源测试、现有双版本 feed 验签及 static Gate 通过。
+原审核 agent 只读复核确认该 P2 关闭，未发现修复引入的新问题。
+改动仅涉及本地发布校验与测试；App、已发布 DMG 和签名 appcast 均未变化，无需重新公证或部署。

--- a/docs/security/app-updates.md
+++ b/docs/security/app-updates.md
@@ -1,0 +1,47 @@
+# App 自动更新信任边界
+
+日期：2026-09-05。范围：Sparkle 2.9.6、完整 DMG 更新及静态 HTTPS appcast。
+此文允许实现与本地验证；不表示更新安装、公开发布或 Cloudflare 部署已经验收。
+
+## 资产与 owner
+
+- App 进程唯一 `AppUpdater` 由 SwiftUI App 的 `StateObject` 持有，跨窗口共享；
+  Sparkle 拥有更新网络、取消、安装 helper 和重启生命周期，不自建下载替换器。
+- 更新器没有 BiliAuth、账户 coordinator、API authorizer 或播放器引用，不访问 B 站 Keychain。
+  认证 transport 使用独立 ephemeral session，不向共享 Cookie storage 写入凭据；
+  更新网络不能得到 B 站授权头，也不将更新失败送入认证恢复链路。
+- 默认更新检查由 Sparkle 第二次启动时询问；自动下载与安装默认关闭，用户可通过菜单更改。
+  不收集 Sparkle system profile，不添加账号标识、查询参数或自定义请求头。
+- Sparkle 自己管理更新偏好和非秘密更新时间。Cloudflare/GitHub 仍可观察 IP、请求时间、
+  标准 User-Agent；关闭 Worker observability 不等同于服务商不记录网络元数据。
+
+## 攻击与控制
+
+| 风险 | 控制 | 证据边界 |
+| --- | --- | --- |
+| feed 或下载源被篡改 | HTTPS、Ed25519 feed 签名、解包前归档验证、Developer ID、公证 | 本地测试证明 feed/归档篡改被部署校验拒绝；Sparkle 真安装仍需签名版本验证 |
+| feed 验签长时间失败后降级 | `SUSignedFeedFailureExpirationInterval=0`，始终拒绝未签名 feed | 失钥后可能必须人工下载可信的签名公证新版恢复，不承诺自动恢复 |
+| 未配置公钥、域名未上线 | `BiliKitUpdaterEnabled=false`；完整校验通过才创建 Sparkle controller | 未配置时菜单显示尚未配置；2026-09-05 已填公钥并为内部测试启用，该 URL 已授权上线且匿名验签通过，用户已确认正常升级及登录保留，失败矩阵仍待验收 |
+| Sandbox 安装权限扩大 | 只启用 Installer XPC；新增精确 bundle `-spks`/`-spki` mach lookup | Downloader XPC 随官方包保留但不启用；不增加文件权限或 runtime exception |
+| 更新源泄露秘密 | Cloudflare 只上传 `public/_headers` 和已签名 `appcast.xml`；拒绝目录和 symlink | 公钥可公开；私钥仅发布机 Keychain 与加密备份，不上云、不进脚本参数/日志 |
+| 草稿或可变资产被当更新 | 只允许固定仓库 `/releases/download/<tag>/<file>.dmg`，拒绝草稿 tag、latest 与 query | 本地校验不能证明 tag/资产已公开、不可变或网络可达，发布者必须匿名下载核对 hash |
+| 降级或坏版本 | 正整数递增 build；资产不可覆盖；完整包前向修复 | 发布脚本不替代 Sparkle 旧 build/错误架构/签名的真实拒绝测试 |
+| 更新失败损坏使用中的 App | 交由 Sparkle 标准安装与错误 UI；失败不调用账户/播放清理 | 离线、断流、磁盘不足、权限拒绝等仍需完整失败矩阵 |
+
+## 依赖与隐私复核
+
+官方稳定版 2.9.6 最低 macOS 10.13，满足本 App macOS 15；包含 2026-08-17 的
+安装路径符号链接与 root 清理安全修复。已查看官方 advisories 列表与该版 release notes，
+不能将“精确锁版”解释成永远没有漏洞；每次发布重新核对。
+
+固定包未提供独立 `PrivacyInfo.xcprivacy`；App 现有声明包含本 App 偏好使用的 UserDefaults
+理由。当前禁用 Sparkle profiling，未引入分析 SDK。最终 Archive 的隐私报告、嵌套签名、
+两种架构和实际网络元数据仍需复核，不能由源码或无签名测试替代。
+
+官方依据：
+[Sparkle 2.9.6](https://github.com/sparkle-project/Sparkle/releases/tag/2.9.6)、
+[安全公告](https://github.com/sparkle-project/Sparkle/security/advisories)、
+[SwiftUI owner](https://sparkle-project.org/documentation/programmatic-setup/)、
+[Sandbox 与签名](https://sparkle-project.org/documentation/sandboxing/)、
+[签名与发布](https://sparkle-project.org/documentation/)、
+[配置与失钥恢复取舍](https://sparkle-project.org/documentation/customization/)。


### PR DESCRIPTION
## 变化

接入 Sparkle 2.9.6 标准更新器，App 菜单提供检查更新、自动检查和自动下载并安装设置。更新器由 App 进程唯一 owner 持有，强制 feed 与安装包签名验证，仅增加 Installer XPC 必需的两项精确沙箱权限。

新增独立 Cloudflare 静态更新源目录、精确 Wrangler 锁文件及公钥验签工具。发布前校验拒绝非批准资产、签名错误和版本字段冲突；不上传安装包、私钥或用户凭据。补齐许可、多语言菜单、测试及实际升级验收记录。

## 原因

为 Developer ID 分发建立标准自动更新流程，并让部署前校验与 Sparkle 的版本解析保持一致。独立 agent 审核发现 Sparkle 优先读取 enclosure 版本属性，而原校验只读取 item build；后续修复要求两者完全一致，原审核 agent 已复核关闭该 P2。

## 用户影响

用户可从已安装的 build 2 检查更新并升级至 1.0.0 (3)。用户已确认升级成功、版本正确且原登录状态保留。原无更新器 build 1 无法自行发起 Sparkle 更新。

测试安装包已作为独立 prerelease 发布，更新源 https://updates.shiinayane.com/appcast.xml 已上线。现有 App/DMG 和线上签名 feed 未因校验修复而改写。

## 验证

- [x] 唯一最高适用 Gate：实现提交前运行 `sh Scripts/run-quality-gates.sh app`，666 Package tests / 69 suites、184 App tests 通过；1 signed Keychain smoke 因无签名 host 跳过。保留既有 sidebar 测试未使用返回值 warning。
- [x] 后续仅发布校验修复：`sh Scripts/run-quality-gates.sh static` 通过；8 项更新源测试通过，新增冲突版本回归用例在旧实现失败、修复后通过；现有双版本 feed 公钥验签通过。
- [x] 必要真实检查：build 2/3 App 与 DMG 完成 Developer ID 签名、公证、票据装订、Gatekeeper、双架构及包内一致性核验；线上匿名下载字节/hash/签名、HTTPS/缓存/404 通过；用户确认 build 2→3 升级与登录保留。
- [x] 独立 agent 审核及修复复核完成，未发现其余阻塞问题。

## 未覆盖边界

- 错误签名/损坏包等 Sparkle 客户端失败矩阵、异常恢复、真实 Intel/macOS 15、跨用户、Translocation 和完整签名 Keychain 运行验证仍未完成。本机正常升级不替代这些证据。
- 测试二进制来自基于 b177f05 的未提交源码快照；测试 tag 指向旧基线，GitHub 自动源码归档不含 Sparkle 改动，已在发布说明明确披露。后续正式候选需从冻结 commit 用更高 build 重新构建，不移动测试 tag 或覆盖旧资产。
- 本机成品与详细证据保持 gitignored；本 PR 不含安装包、密钥或 DanmakuLab 的未提交旁支锁文件改动。
