### PR TITLE
fix(release): 按 App target 读取发布版本

### DIFF
--- a/Scripts/release/release.py
+++ b/Scripts/release/release.py
@@ -68,14 +68,18 @@ def source():
 
 
 def version():
-    project = (ROOT / 'BiliKitMac.xcodeproj/project.pbxproj').read_text()
-    versions = re.findall(r'MARKETING_VERSION = ([0-9.]+);', project)
-    builds = re.findall(r'CURRENT_PROJECT_VERSION = ([0-9]+);', project)
+    project = json.loads(run('plutil', '-convert', 'json', '-o', '-', ROOT / 'BiliKitMac.xcodeproj/project.pbxproj'))
+    objects = project['objects']
+    targets = [value for value in objects.values() if value.get('isa') == 'PBXNativeTarget' and value.get('name') == 'BiliKitMac']
+    require(len(targets) == 1, '需要唯一 BiliKitMac App target')
+    configurations = objects[targets[0]['buildConfigurationList']]['buildConfigurations']
+    settings = [objects[key]['buildSettings'] for key in configurations]
+    versions = [value['MARKETING_VERSION'] for value in settings]
+    builds = [str(value['CURRENT_PROJECT_VERSION']) for value in settings]
     require(len(versions) == 2 and len(set(versions)) == 1, 'App 版本配置不一致')
-    app_builds = [v for v in builds if v != '1']
-    require(len(app_builds) == 2 and len(set(app_builds)) == 1, 'App build 配置不一致')
+    require(len(set(builds)) == 1 and re.fullmatch(r'[1-9][0-9]*', builds[0]), 'App build 配置不一致')
     require(re.fullmatch(r'\d+\.\d+\.\d+', versions[0]), '需要三段版本')
-    return versions[0], int(app_builds[0])
+    return versions[0], int(builds[0])
 
 
 def ci(commit):

--- a/Scripts/release/test_release.py
+++ b/Scripts/release/test_release.py
@@ -1,5 +1,6 @@
 """Release safety contracts; no Keychain, signing, network or external mutation."""
 import importlib.util
+import json
 import sys
 sys.dont_write_bytecode = True
 from pathlib import Path
@@ -13,6 +14,22 @@ spec.loader.exec_module(release)
 
 
 class ReleaseSafetyTests(unittest.TestCase):
+    def test_version_ignores_test_target_version(self):
+        project = {'objects': {
+            'app': {'isa': 'PBXNativeTarget', 'name': 'BiliKitMac', 'buildConfigurationList': 'appList'},
+            'tests': {'isa': 'PBXNativeTarget', 'name': 'BiliKitMacTests', 'buildConfigurationList': 'testList'},
+            'appList': {'buildConfigurations': ['debug', 'release']},
+            'testList': {'buildConfigurations': ['test']},
+            'debug': {'buildSettings': {'MARKETING_VERSION': '2.0.0', 'CURRENT_PROJECT_VERSION': '9'}},
+            'release': {'buildSettings': {'MARKETING_VERSION': '2.0.0', 'CURRENT_PROJECT_VERSION': '9'}},
+            'test': {'buildSettings': {'MARKETING_VERSION': '1.0', 'CURRENT_PROJECT_VERSION': '1'}},
+        }}
+        with patch.object(release, 'run', return_value=json.dumps(project)):
+            self.assertEqual(release.version(), ('2.0.0', 9))
+        project['objects']['release']['buildSettings']['CURRENT_PROJECT_VERSION'] = '10'
+        with patch.object(release, 'run', return_value=json.dumps(project)), self.assertRaises(ValueError):
+            release.version()
+
     def test_acceptance_must_bind_exact_candidate(self):
         state = {'commit': 'a' * 40, 'assets': {'app.dmg': {'sha256': 'b' * 64}}}
         evidence = dict(commit=state['commit'], dmg_sha256='b' * 64, decision='go', reviewer='maintainer',


### PR DESCRIPTION
实际发布预检错误地把测试 target 的 marketing version 1.0 计入 App 版本，导致合法的 1.0.0 (4) 被拒绝。改为解析工程对象并沿 BiliKitMac App target 的 buildConfigurationList 读取 Debug/Release 配置，仍拒绝两套配置不一致。

新增回归测试覆盖测试 target 使用不同版本以及 App Debug/Release build 冲突；5 项发布安全测试通过，实际工程读取结果为 1.0.0 (4)，diff 检查通过。预检在归档前停止，尚未生成或签名候选包；合并后重新冻结提交。
